### PR TITLE
chore(release): wire api compat and public api analyzer infrastructure

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.dotnet.apicompat.tool": {
+      "version": "9.0.100",
+      "commands": [
+        "apicompat"
+      ]
+    }
+  }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
+    <EnablePackageValidation Condition="'$(IsPackable)' != 'false'">true</EnablePackageValidation>
+    <EnableStrictModeForBaselineValidation Condition="'$(IsPackable)' != 'false'">true</EnableStrictModeForBaselineValidation>
+    <NoWarn>$(NoWarn);RS0016;RS0017;RS0024;RS0025;RS0026;RS0027;RS0036;RS0037;RS0041</NoWarn>
+
     <!-- NuGet package metadata -->
     <Authors>Abongile Boja</Authors>
     <PackageProjectUrl>https://github.com/AbongileBoja/QuerySpec</PackageProjectUrl>
@@ -41,6 +45,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' != 'false'">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.24454.1" PrivateAssets="all" />
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
 </Project>

--- a/src/QuerySpec.Core/PublicAPI.Shipped.txt
+++ b/src/QuerySpec.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/QuerySpec.Core/PublicAPI.Unshipped.txt
+++ b/src/QuerySpec.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/QuerySpec.DependencyInjection/PublicAPI.Shipped.txt
+++ b/src/QuerySpec.DependencyInjection/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/QuerySpec.DependencyInjection/PublicAPI.Unshipped.txt
+++ b/src/QuerySpec.DependencyInjection/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/QuerySpec.EFCore/PublicAPI.Shipped.txt
+++ b/src/QuerySpec.EFCore/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/QuerySpec.EFCore/PublicAPI.Unshipped.txt
+++ b/src/QuerySpec.EFCore/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

Wires up the SemVer-enforcement infrastructure called out in #1.

- `.config/dotnet-tools.json` adds `Microsoft.DotNet.ApiCompat.Tool` so `dotnet apicompat package <new>.nupkg --baseline-package <prev>.nupkg` is available locally and in CI.
- `Directory.Build.props` enables `EnablePackageValidation` and `EnableStrictModeForBaselineValidation` for shipped projects only (gated on `IsPackable != false`).
- `Microsoft.CodeAnalysis.PublicApiAnalyzers` is referenced for the three shipped packages with `PrivateAssets=all`.
- `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` are checked in (empty, with `#nullable enable` directive) for `QuerySpec.Core`, `QuerySpec.EFCore`, and `QuerySpec.DependencyInjection`.

## Why no `PackageValidationBaselineVersion` yet

Versions 1.0.0 through 1.0.8 were signed with the old strong-name keypair that was rotated in commit b68305f. Pointing the baseline at 1.0.8 would surface a strong-name token mismatch on every build. The baseline gets set against v2.0.0 once the rotation release ships, so all subsequent versions are validated against the post-rotation public surface.

## Why the PublicApiAnalyzer rules are NoWarn'd

The empty `PublicAPI.Shipped.txt` files would otherwise flag every existing public member as missing from the baseline. The follow-up work — populating Shipped.txt against the v2.0.0 surface and removing the suppressions — will enable strict tracking from v2.0.0 forward.

## Verified

- `dotnet build QuerySpec.sln -c Release`: 0 errors
- `dotnet test QuerySpec.sln -c Release`: 774/774 pass on net8/9/10
- `dotnet pack src/QuerySpec.Core` produces `.nupkg` + `.snupkg` cleanly with PackageValidation enabled

## Follow-up

A separate issue should track populating `PublicAPI.Shipped.txt` per shipped project against the v2.0.0 surface and removing the NoWarn suppressions.

Fixes #1