### PR TITLE
ci(ci): pin actions to commit SHAs and lock workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,14 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions: read-all
+
 jobs:
   build:
     name: Build & test (.NET ${{ matrix.dotnet-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -17,10 +21,10 @@ jobs:
         dotnet-version: ['8.0.x', '9.0.x', '10.0.x']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Setup .NET 8, 9, 10
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: |
           8.0.x
@@ -44,7 +48,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: test-results-${{ matrix.dotnet-version }}
         path: ./TestResults
@@ -88,7 +92,7 @@ jobs:
 
     - name: Upload coverage report
       if: matrix.dotnet-version == '10.0.x'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: coverage-report
         path: ./CoverageReport
@@ -100,7 +104,7 @@ jobs:
 
     - name: Upload NuGet artifacts
       if: matrix.dotnet-version == '10.0.x'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: nuget-packages
         path: ./artifacts
@@ -109,9 +113,11 @@ jobs:
   format:
     name: dotnet format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: '10.0.x'
     - name: Restore
@@ -127,13 +133,13 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: '10.0.x'
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3
       with:
         languages: csharp
         queries: security-and-quality
@@ -142,27 +148,32 @@ jobs:
       run: dotnet build QuerySpec.sln --configuration Release -p:TreatWarningsAsErrors=false
 
     - name: Run CodeQL analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3
       with:
         category: "/language:csharp"
 
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Review dependencies
-      uses: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4
       with:
         fail-on-severity: high
 
   vulnerability-scan:
     name: NuGet vulnerability scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: '10.0.x'
     - name: Restore
@@ -180,12 +191,14 @@ jobs:
   commitlint:
     name: Commit message lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         fi
 
     - name: Checkout (full history for reachability check)
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0
 
@@ -61,12 +61,12 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: |
           8.0.x
@@ -141,7 +141,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: release-test-results
         path: ./TestResults
@@ -190,7 +190,7 @@ jobs:
         echo "Package metadata OK: 3 nupkg + 3 snupkg at version ${{ steps.version.outputs.version }}."
 
     - name: Upload packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
         name: nuget-packages
         path: ./artifacts
@@ -216,13 +216,13 @@ jobs:
       packages: write
     steps:
     - name: Download packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       with:
         name: nuget-packages
         path: ./artifacts
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: '10.0.x'
 
@@ -257,7 +257,7 @@ jobs:
         done
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
       with:
         tag_name: ${{ github.ref_name }}
         name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Pins every `uses:` in `ci.yml` and `release.yml` to a commit SHA (with the version tag captured as a trailing comment), and adds workflow-level + per-job `permissions:` blocks to `ci.yml`.

## Why pin to SHAs

Floating tags (`@v4`) let the action publisher swap implementation under us silently. SHA pins make any change to the action a reviewable diff. This is the same pattern the OpenSSF / SLSA recommendations call for and matches what Microsoft's own first-party repos use.

## Permissions

`ci.yml` now defaults to `read-all` at workflow level. Each job opts up explicitly:

| Job | Permissions |
|---|---|
| build, format, vulnerability-scan, commitlint | `contents: read` |
| codeql | `actions: read, contents: read, security-events: write` |
| dependency-review | `contents: read, pull-requests: read` |

`release.yml` already had `permissions: read-all` from earlier work; only the action SHAs needed pinning here.

## Resolved SHAs

```
actions/checkout@v4               34e114876b0b11c390a56381ad16ebd13914f8d5
actions/setup-dotnet@v4           67a3573c9a986a3f9c594539f4ab511d57bb3ce9
actions/setup-node@v4             49933ea5288caeca8642d1e84afbd3f7d6820020
actions/upload-artifact@v4        ea165f8d65b6e75b540449e92b4886f43607fa02
actions/download-artifact@v4      d3f86a106a0bac45b974a628896c90dbdf5c8093
github/codeql-action@v3           ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
actions/dependency-review-action@v4 2031cfc080254a8a887f58cffee85186f0e49e48
softprops/action-gh-release@v2    3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
```

Verify any of these with `gh api repos/<owner>/<repo>/commits/v<N> --jq .sha`.

Fixes #15