### PR TITLE
chore(deps): align core tests on the latest xunit 2.9.x

### DIFF
--- a/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
+++ b/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Brings `QuerySpec.Core.Tests` to the same test-stack versions already used by `QuerySpec.EFCore.Tests`, eliminating the version skew between the two projects.

| Package | Before | After |
|---|---|---|
| `Microsoft.NET.Test.Sdk` | 17.11.0 | 17.14.1 |
| `xunit` | 2.9.0 | 2.9.3 |
| `xunit.runner.visualstudio` | 2.8.0 | 3.1.4 |

`QuerySpec.EFCore.Tests` was already at these versions; this aligns the two projects.

## Why 2.9.x and not v3

A v3 migration is real work — different package (`xunit.v3`), some API differences for fixtures/lifetimes, separated assertion library. It warrants its own PR with a green test run as the acceptance criterion. Filed as #22.

## Verified

- `dotnet test`: 774/774 pass on net8.0, net9.0, net10.0 (no test code changed)

Fixes #17