### PR TITLE
feat(security)!: keyed hash masking with per-tenant separation

### DIFF
--- a/src/QuerySpec.Core/Security/DataMaskingEngine.cs
+++ b/src/QuerySpec.Core/Security/DataMaskingEngine.cs
@@ -10,6 +10,21 @@ namespace QuerySpec.Core.Security;
 /// PII (Personally Identifiable Information) data masking engine.
 /// Supports multiple masking strategies for different data types.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="MaskingStrategy.HashMask"/> requires a per-instance keyed hash secret to be
+/// supplied to the constructor. Without it, registering <see cref="MaskingStrategy.HashMask"/>
+/// throws and the engine falls back to a deny path. This is intentional: an unkeyed hash on
+/// low-cardinality PII (SSN, phone, email) is brute-forceable in seconds and produces
+/// cross-tenant correlation oracles.
+/// </para>
+/// <para>
+/// To separate masks across tenants, pass a non-empty <c>tenantId</c> to <see cref="Mask"/>.
+/// The engine derives a tenant-scoped key via HMAC-SHA256 over the configured hash secret and
+/// the tenantId, then uses that derived key to HMAC the value. Two tenants masking the same
+/// value get different outputs.
+/// </para>
+/// </remarks>
 public class DataMaskingEngine
 {
     /// <summary>
@@ -25,46 +40,86 @@ public class DataMaskingEngine
         LastFourOnly,
         /// <summary>Email mask: "j****@example.com"</summary>
         EmailMask,
-        /// <summary>Hash mask: Replace with hash</summary>
+        /// <summary>Hash mask: replace with a tenant-keyed HMAC of the value.</summary>
         HashMask
     }
 
-    private readonly Dictionary<string, MaskingStrategy> _fieldMasks = new();
-    private readonly Dictionary<string, Regex> _piiPatterns = new();
+    private const int HashOutputBytes = 32;
 
-    /// <summary>Initializes a new instance of the DataMaskingEngine.</summary>
-    public DataMaskingEngine()
+    private readonly Dictionary<string, MaskingStrategy> _fieldMasks = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Regex> _piiPatterns = new(StringComparer.Ordinal);
+    private readonly byte[]? _hashKey;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DataMaskingEngine"/> without a hash key.
+    /// Registering <see cref="MaskingStrategy.HashMask"/> on this instance throws.
+    /// </summary>
+    public DataMaskingEngine() : this(hashKey: null) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DataMaskingEngine"/> with the given hash secret.
+    /// </summary>
+    /// <param name="hashKey">
+    /// Secret key used as the seed for HMAC-based <see cref="MaskingStrategy.HashMask"/>.
+    /// Must be at least 16 bytes when supplied. Pass <c>null</c> only if no field will use
+    /// <see cref="MaskingStrategy.HashMask"/>.
+    /// </param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="hashKey"/> is non-null but shorter than 16 bytes.</exception>
+    public DataMaskingEngine(byte[]? hashKey)
     {
+        if (hashKey is not null && hashKey.Length < 16)
+            throw new ArgumentException("hashKey must be at least 16 bytes when supplied.", nameof(hashKey));
+
+        _hashKey = hashKey is null ? null : (byte[])hashKey.Clone();
         InitializeDefaultPiiPatterns();
     }
 
-    /// <summary>
-    /// Initializes default PII detection patterns.
-    /// </summary>
     private void InitializeDefaultPiiPatterns()
     {
-        _piiPatterns["Email"] = new Regex(@"^[^\@]+@[^\@]+$");
-        _piiPatterns["SSN"] = new Regex(@"^\d{3}-\d{2}-\d{4}$");
-        _piiPatterns["Phone"] = new Regex(@"^\+?1?\d{9,15}$");
-        _piiPatterns["CreditCard"] = new Regex(@"^\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}$");
+        _piiPatterns["Email"] = new Regex(@"^[^\@]+@[^\@]+$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatterns["SSN"] = new Regex(@"^\d{3}-\d{2}-\d{4}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatterns["Phone"] = new Regex(@"^\+?1?\d{9,15}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatterns["CreditCard"] = new Regex(@"^\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
     }
 
     /// <summary>
-    /// Registers a masking strategy for a specific field.
+    /// Registers a masking strategy for the named field.
     /// </summary>
+    /// <param name="fieldName">The field name to register a mask for. Must not be null or whitespace.</param>
+    /// <param name="strategy">The masking strategy to apply.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fieldName"/> is null or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="strategy"/> is <see cref="MaskingStrategy.HashMask"/> but the engine was constructed without a hash key.
+    /// </exception>
     public void RegisterFieldMask(string fieldName, MaskingStrategy strategy)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fieldName);
+
+        if (strategy == MaskingStrategy.HashMask && _hashKey is null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot register field '{fieldName}' for HashMask: this DataMaskingEngine was constructed without a hash key. " +
+                "Pass a per-application secret (>= 16 bytes) to the DataMaskingEngine(byte[]) constructor.");
+        }
+
         _fieldMasks[fieldName] = strategy;
     }
 
     /// <summary>
-    /// Masks a field value based on registered strategy.
+    /// Masks a field value using the strategy registered for <paramref name="fieldName"/>.
     /// </summary>
-    public string Mask(string fieldName, object? value)
+    /// <param name="fieldName">Field name registered via <see cref="RegisterFieldMask"/>.</param>
+    /// <param name="value">Value to mask. Null produces the literal string <c>"null"</c>.</param>
+    /// <param name="tenantId">
+    /// Optional tenant scope. When supplied, <see cref="MaskingStrategy.HashMask"/> derives a
+    /// tenant-specific key so the same value masks differently across tenants.
+    /// </param>
+    /// <returns>The masked value, or the original string representation if no strategy is registered.</returns>
+    public string Mask(string fieldName, object? value, string? tenantId = null)
     {
-        if (value == null) return "null";
+        if (value is null) return "null";
 
-        var strValue = value.ToString() ?? "";
+        var strValue = value.ToString() ?? string.Empty;
 
         if (!_fieldMasks.TryGetValue(fieldName, out var strategy))
             return strValue;
@@ -75,39 +130,62 @@ public class DataMaskingEngine
             MaskingStrategy.PartialMask => MaskPartial(strValue),
             MaskingStrategy.LastFourOnly => MaskLastFour(strValue),
             MaskingStrategy.EmailMask => MaskEmail(strValue),
-            MaskingStrategy.HashMask => MaskHash(strValue),
+            MaskingStrategy.HashMask => MaskHash(strValue, tenantId),
             _ => strValue
         };
     }
 
-    private string MaskFull(string value) => new string('*', value.Length);
-    private string MaskPartial(string value) => value.Length <= 2 ? MaskFull(value) : value[..2] + new string('*', value.Length - 2);
-    private string MaskLastFour(string value) => value.Length <= 4 ? MaskFull(value) : new string('*', value.Length - 4) + value[^4..];
+    private static string MaskFull(string value) => new('*', value.Length);
+    private static string MaskPartial(string value) => value.Length <= 2 ? MaskFull(value) : value[..2] + new string('*', value.Length - 2);
+    private static string MaskLastFour(string value) => value.Length <= 4 ? MaskFull(value) : new string('*', value.Length - 4) + value[^4..];
 
-    private string MaskEmail(string value)
+    private static string MaskEmail(string value)
     {
         var parts = value.Split('@');
         if (parts.Length != 2) return MaskFull(value);
         return parts[0][..Math.Min(1, parts[0].Length)] + new string('*', Math.Max(0, parts[0].Length - 1)) + "@" + parts[1];
     }
 
-    private string MaskHash(string value)
+    private string MaskHash(string value, string? tenantId)
     {
-        using (var sha256 = SHA256.Create())
-        {
-            var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(value));
-            return Convert.ToBase64String(hash)[..8];
-        }
+        if (_hashKey is null)
+            throw new InvalidOperationException("HashMask requires a hash key configured on the DataMaskingEngine constructor.");
+
+        var key = string.IsNullOrEmpty(tenantId)
+            ? _hashKey
+            : DeriveTenantKey(_hashKey, tenantId);
+
+        Span<byte> hash = stackalloc byte[HashOutputBytes];
+        using var hmac = new HMACSHA256(key);
+        var written = hmac.TryComputeHash(Encoding.UTF8.GetBytes(value), hash, out var bytesWritten);
+        if (!written || bytesWritten != HashOutputBytes)
+            throw new CryptographicException("Unexpected HMAC output length.");
+
+        return Convert.ToBase64String(hash);
+    }
+
+    private static byte[] DeriveTenantKey(byte[] rootKey, string tenantId)
+    {
+        using var hmac = new HMACSHA256(rootKey);
+        return hmac.ComputeHash(Encoding.UTF8.GetBytes(tenantId));
     }
 
     /// <summary>
-    /// Detects if a field contains PII based on patterns.
+    /// Detects if a field name and value match a registered PII pattern.
     /// </summary>
+    /// <remarks>
+    /// This heuristic combines a field-name substring match with a regex on the value.
+    /// It is convenient for ad-hoc scanning but produces false positives (e.g. a column
+    /// named "EmailRegistrationToken" classified as Email) and false negatives (e.g. a
+    /// column named "Notes" carrying a SSN-shaped value). Treat the result as advisory,
+    /// not authoritative.
+    /// </remarks>
     public bool IsPii(string fieldName, object? value)
     {
-        if (value == null) return false;
+        if (value is null) return false;
+        if (string.IsNullOrEmpty(fieldName)) return false;
 
-        var strValue = value.ToString() ?? "";
+        var strValue = value.ToString() ?? string.Empty;
 
         foreach (var (pattern, regex) in _piiPatterns)
         {

--- a/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Security.Cryptography;
 using Xunit;
 using QuerySpec.Core.Security;
 
@@ -8,78 +10,209 @@ namespace QuerySpec.Core.Tests.Security;
 /// </summary>
 public class DataMaskingEngineTests
 {
-    /// <summary>Tests that Mask applies FullMask strategy correctly. I see you.</summary>
+    private static byte[] NewKey() => RandomNumberGenerator.GetBytes(32);
+
     [Fact]
     public void Mask_Should_Apply_FullMask()
     {
-        // Arrange
         var engine = new DataMaskingEngine();
         engine.RegisterFieldMask("sensitive", DataMaskingEngine.MaskingStrategy.FullMask);
 
-        // Act
         var result = engine.Mask("sensitive", "sensitive");
 
-        // Assert
         Assert.Equal("*********", result);
     }
 
-    /// <summary>Tests that Mask applies PartialMask strategy correctly.</summary>
     [Fact]
     public void Mask_Should_Apply_PartialMask()
     {
-        // Arrange
         var engine = new DataMaskingEngine();
         engine.RegisterFieldMask("name", DataMaskingEngine.MaskingStrategy.PartialMask);
 
-        // Act
         var result = engine.Mask("name", "JohnDoe");
 
-        // Assert
         Assert.Equal("Jo*****", result);
     }
 
-    /// <summary>Tests that Mask applies LastFourOnly strategy correctly.</summary>
     [Fact]
     public void Mask_Should_Apply_LastFourOnly()
     {
-        // Arrange
         var engine = new DataMaskingEngine();
         engine.RegisterFieldMask("phone", DataMaskingEngine.MaskingStrategy.LastFourOnly);
 
-        // Act
         var result = engine.Mask("phone", "1234567890");
 
-        // Assert
         Assert.Equal("******7890", result);
     }
 
-    /// <summary>Tests that Mask applies EmailMask strategy correctly. With great power comes great responsibility.</summary>
     [Fact]
     public void Mask_Should_Apply_EmailMask()
     {
-        // Arrange
         var engine = new DataMaskingEngine();
         engine.RegisterFieldMask("email", DataMaskingEngine.MaskingStrategy.EmailMask);
 
-        // Act
         var result = engine.Mask("email", "john@example.com");
 
-        // Assert
         Assert.Contains("***", result);
         Assert.Contains("@example.com", result);
     }
 
-    /// <summary>Tests that IsPii detects email addresses.</summary>
     [Fact]
     public void IsPii_Should_Detect_Email()
     {
-        // Arrange
         var engine = new DataMaskingEngine();
 
-        // Act
         var result = engine.IsPii("Email", "john@example.com");
 
-        // Assert
         Assert.True(result);
+    }
+
+    [Fact]
+    public void Constructor_HashKeyShorterThan16Bytes_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new DataMaskingEngine(new byte[15]));
+        Assert.Contains("16 bytes", ex.Message);
+    }
+
+    [Fact]
+    public void RegisterFieldMask_HashMaskWithoutKey_Throws()
+    {
+        var engine = new DataMaskingEngine();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask));
+        Assert.Contains("HashMask", ex.Message);
+        Assert.Contains("hash key", ex.Message);
+    }
+
+    [Fact]
+    public void RegisterFieldMask_HashMaskWithKey_DoesNotThrow()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RegisterFieldMask_EmptyOrWhitespaceFieldName_Throws(string fieldName)
+    {
+        var engine = new DataMaskingEngine(NewKey());
+
+        Assert.Throws<ArgumentException>(() =>
+            engine.RegisterFieldMask(fieldName, DataMaskingEngine.MaskingStrategy.FullMask));
+    }
+
+    [Fact]
+    public void RegisterFieldMask_NullFieldName_Throws()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+
+        Assert.Throws<ArgumentNullException>(() =>
+            engine.RegisterFieldMask(null!, DataMaskingEngine.MaskingStrategy.FullMask));
+    }
+
+    [Fact]
+    public void HashMask_ProducesFullSha256OutputLength()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var masked = engine.Mask("ssn", "123-45-6789");
+
+        var bytes = Convert.FromBase64String(masked);
+        Assert.Equal(32, bytes.Length);
+    }
+
+    [Fact]
+    public void HashMask_SameValueSameKey_IsDeterministic()
+    {
+        var key = NewKey();
+        var engine1 = new DataMaskingEngine(key);
+        var engine2 = new DataMaskingEngine(key);
+        engine1.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine2.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var a = engine1.Mask("ssn", "123-45-6789");
+        var b = engine2.Mask("ssn", "123-45-6789");
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void HashMask_DifferentKeys_ProduceDifferentMasks()
+    {
+        var engine1 = new DataMaskingEngine(NewKey());
+        var engine2 = new DataMaskingEngine(NewKey());
+        engine1.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine2.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var a = engine1.Mask("ssn", "123-45-6789");
+        var b = engine2.Mask("ssn", "123-45-6789");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void HashMask_DifferentTenants_ProduceDifferentMasks()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var maskA = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-A");
+        var maskB = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-B");
+
+        Assert.NotEqual(maskA, maskB);
+    }
+
+    [Fact]
+    public void HashMask_SameTenant_SameValue_IsDeterministic()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var a = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-A");
+        var b = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-A");
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void HashMask_NullTenantId_DoesNotThrow()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var result = engine.Mask("ssn", "123-45-6789", tenantId: null);
+
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void HashMask_EmptyTenantId_BehavesLikeNullTenantId()
+    {
+        var engine = new DataMaskingEngine(NewKey());
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+
+        var nullTenant = engine.Mask("ssn", "123-45-6789", tenantId: null);
+        var emptyTenant = engine.Mask("ssn", "123-45-6789", tenantId: "");
+
+        Assert.Equal(nullTenant, emptyTenant);
+    }
+
+    [Fact]
+    public void Constructor_PreservesKeyImmutability()
+    {
+        var key = NewKey();
+        var copy = (byte[])key.Clone();
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        var before = engine.Mask("ssn", "123-45-6789");
+
+        Array.Clear(key);
+
+        var after = engine.Mask("ssn", "123-45-6789");
+        Assert.Equal(before, after);
     }
 }


### PR DESCRIPTION
## Summary

Closes the brute-force and cross-tenant correlation attacks in `DataMaskingEngine.MaskHash` raised in #14.

The previous implementation truncated SHA-256 to 8 base64 chars (48 bits) and was unkeyed and unsalted. Two practical attacks against it:

1. **Brute-force preimage.** 48 bits is below any modern resistance threshold. Low-cardinality PII (SSN, phone, email) was reversible in seconds with a rainbow table.
2. **Cross-tenant correlation oracle.** The same input in tenant A and tenant B produced the same 8-char mask — a join key by accident.

## What changed

- New constructor `DataMaskingEngine(byte[] hashKey)` requires a >= 16-byte per-instance secret. The default constructor remains for callers using only deterministic non-keyed strategies.
- `RegisterFieldMask` throws `InvalidOperationException` if `HashMask` is registered without a hash key configured.
- `Mask(fieldName, value, tenantId)` accepts an optional `tenantId`. When supplied, the engine derives a tenant-scoped key via `HMAC-SHA256(rootKey, tenantId)` and HMACs the value with the derived key. Same value, different tenants → different masks.
- Output is the full 32-byte HMAC-SHA256 tag base64-encoded (256 bits, no truncation).
- The constructor clones the supplied key so the caller can zero theirs after construction.
- PII regex patterns now use `RegexOptions.CultureInvariant` + 100ms timeout (addresses the regex-DoS analyzer warning on this file).

## Tests

14 new tests on top of the original 5. Covered scenarios:

- Constructor rejects short keys
- Registering HashMask without a key throws
- Empty/whitespace field name throws (split null vs whitespace cases)
- Full HMAC output length
- Same key + same value → deterministic mask
- Different keys → different masks
- Different tenants under the same root key → different masks
- Same tenant + same value → deterministic
- Null and empty `tenantId` are equivalent
- Constructor clones the supplied key (caller can zero it after)

Final test count on each TFM: **224** Core tests pass (was 210).

## SemVer

This is `feat!` — a breaking change. Callers using HashMask must supply a hash key or registration throws.

## Migration

Existing 8-character mask outputs **cannot be reversed** — old SHA-256-truncated values are not migratable. Consumers persisting masked values must:

1. Re-mask all new outputs with the new algorithm and a configured key.
2. Rotate any join keys built on the old 8-char masks (those joins were always insecure; this is the moment to fix them).

The rotation release notes will call this out alongside the strong-name token change.

## Follow-up

The `IsPii` heuristic-based classifier is filed separately as #24. It was advisory only and out of scope for the security fix here, but the XML doc on the method now warns callers to treat the result as advisory.

Fixes #14