### PR TITLE
feat(auditing)!: link audit log hash chain and seal entries

### DIFF
--- a/src/QuerySpec.Core/Auditing/AuditLogEntry.cs
+++ b/src/QuerySpec.Core/Auditing/AuditLogEntry.cs
@@ -6,60 +6,64 @@ using System.Text;
 namespace QuerySpec.Core.Auditing;
 
 /// <summary>
-/// Immutable audit log entry for compliance and forensics.
+/// Audit log entry for compliance and forensics.
 /// </summary>
+/// <remarks>
+/// All non-integrity fields are <c>init</c>-only and must be supplied at construction.
+/// Integrity fields (<see cref="Hash"/>, <see cref="PreviousHash"/>) are set exactly
+/// once by <see cref="Seal"/>, which an <see cref="IAuditLogger"/> implementation calls
+/// under its write lock with the previous entry's hash. After sealing, the entry is
+/// effectively immutable; subsequent calls to <see cref="Seal"/> throw.
+/// </remarks>
 public class AuditLogEntry
 {
     /// <summary>Unique identifier for the audit entry.</summary>
-    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Id { get; init; } = Guid.NewGuid().ToString();
     /// <summary>Timestamp when the operation occurred.</summary>
-    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    public DateTime Timestamp { get; init; } = DateTime.UtcNow;
     /// <summary>Tenant identifier.</summary>
-    public string TenantId { get; set; } = string.Empty;
+    public string TenantId { get; init; } = string.Empty;
     /// <summary>User identifier.</summary>
-    public string UserId { get; set; } = string.Empty;
+    public string UserId { get; init; } = string.Empty;
     /// <summary>Request identifier.</summary>
-    public string RequestId { get; set; } = string.Empty;
+    public string RequestId { get; init; } = string.Empty;
 
-    // What
     /// <summary>Type of resource being accessed.</summary>
-    public string ResourceType { get; set; } = string.Empty;
+    public string ResourceType { get; init; } = string.Empty;
     /// <summary>Operation performed (Query, Insert, Update, Delete).</summary>
-    public string Operation { get; set; } = string.Empty;
+    public string Operation { get; init; } = string.Empty;
     /// <summary>Filters applied to the query.</summary>
-    public Dictionary<string, object> Filters { get; set; } = new();
+    public Dictionary<string, object> Filters { get; init; } = new();
     /// <summary>Fields projected in the query.</summary>
-    public List<string> ProjectedFields { get; set; } = new();
+    public List<string> ProjectedFields { get; init; } = new();
 
-    // How
     /// <summary>Execution time in milliseconds.</summary>
-    public long ExecutionTimeMs { get; set; }
+    public long ExecutionTimeMs { get; init; }
     /// <summary>Number of records affected.</summary>
-    public int RecordsAffected { get; set; }
+    public int RecordsAffected { get; init; }
     /// <summary>Whether the operation succeeded.</summary>
-    public bool Success { get; set; }
+    public bool Success { get; init; }
     /// <summary>Error message if operation failed.</summary>
-    public string? ErrorMessage { get; set; }
+    public string? ErrorMessage { get; init; }
 
-    // Security
     /// <summary>Whether data was encrypted.</summary>
-    public bool WasEncrypted { get; set; }
+    public bool WasEncrypted { get; init; }
     /// <summary>Whether data was masked.</summary>
-    public bool WasMasked { get; set; }
+    public bool WasMasked { get; init; }
     /// <summary>List of sensitive fields accessed.</summary>
-    public List<string> AccessedSensitiveFields { get; set; } = new();
+    public List<string> AccessedSensitiveFields { get; init; } = new();
     /// <summary>List of fields access was denied for.</summary>
-    public List<string> DeniedFields { get; set; } = new();
+    public List<string> DeniedFields { get; init; } = new();
 
-    // Integrity
-    /// <summary>SHA256 hash for integrity verification.</summary>
-    public string Hash { get; set; } = string.Empty;
-    /// <summary>Previous hash in the chain.</summary>
-    public string? PreviousHash { get; set; }
+    /// <summary>SHA-256 hash for integrity verification. Set once by <see cref="Seal"/>.</summary>
+    public string Hash { get; private set; } = string.Empty;
+    /// <summary>Hash of the previous entry in the chain. Set once by <see cref="Seal"/>; <c>null</c> for the first entry.</summary>
+    public string? PreviousHash { get; private set; }
 
-    /// <summary>
-    /// Validates that required fields are populated.
-    /// </summary>
+    private bool _sealed;
+
+    /// <summary>Validates that required fields are populated.</summary>
+    /// <exception cref="ArgumentException">Thrown when TenantId, UserId, or Operation is null or whitespace.</exception>
     public void Validate()
     {
         if (string.IsNullOrWhiteSpace(TenantId))
@@ -73,27 +77,79 @@ public class AuditLogEntry
     }
 
     /// <summary>
-    /// Computes SHA256 hash for integrity verification.
+    /// Seals this entry into the audit chain by setting <see cref="PreviousHash"/> to
+    /// <paramref name="previousHash"/> and computing <see cref="Hash"/>. The entry must
+    /// not have been sealed previously. <see cref="IAuditLogger"/> implementations call
+    /// this under their write lock with the most recent entry's hash.
     /// </summary>
-    public void ComputeHash()
+    /// <param name="previousHash">Hash of the previous entry in the chain, or <c>null</c> if this is the first entry.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the entry has already been sealed.</exception>
+    /// <exception cref="ArgumentException">Thrown when validation fails.</exception>
+    public void Seal(string? previousHash)
     {
-        using (var sha256 = SHA256.Create())
-        {
-            Validate();
-            var data = $"{Timestamp:O}|{TenantId}|{UserId}|{Operation}|{RecordsAffected}|{Success}|{PreviousHash ?? ""}";
-            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(data));
-            Hash = Convert.ToBase64String(hashBytes);
-        }
+        if (_sealed)
+            throw new InvalidOperationException("AuditLogEntry has already been sealed and cannot be re-sealed.");
+
+        Validate();
+        PreviousHash = previousHash;
+        Hash = ComputeHashCore(this, previousHash);
+        _sealed = true;
     }
 
     /// <summary>
-    /// Verifies integrity by comparing hashes.
+    /// Computes the integrity hash. Equivalent to <c>Seal(PreviousHash)</c>; preserved
+    /// for source compatibility with pre-2.0 callers.
     /// </summary>
-    public bool VerifyIntegrity(string? previousHash)
+    [Obsolete("Use Seal(previousHash) instead. ComputeHash does not establish chain linkage when called directly.")]
+    public void ComputeHash() => Seal(PreviousHash);
+
+    /// <summary>
+    /// Verifies that this entry's <see cref="Hash"/> matches a freshly-computed hash for the
+    /// supplied <paramref name="expectedPreviousHash"/>. Comparison is fixed-time. Does not
+    /// mutate the entry.
+    /// </summary>
+    /// <param name="expectedPreviousHash">The previous-entry hash this entry was sealed against, per the caller's chain reconstruction.</param>
+    /// <returns><c>true</c> when the hashes match; <c>false</c> otherwise (including unsealed entries).</returns>
+    public bool VerifyIntegrity(string? expectedPreviousHash)
     {
-        var originalHash = Hash;
-        PreviousHash = previousHash;
-        ComputeHash();
-        return Hash == originalHash;
+        if (!_sealed || string.IsNullOrEmpty(Hash)) return false;
+
+        var expected = ComputeHashCore(this, expectedPreviousHash);
+        var expectedBytes = Convert.FromBase64String(expected);
+        var actualBytes = Convert.FromBase64String(Hash);
+        return CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes);
+    }
+
+    /// <summary>
+    /// Verifies a chain of audit entries: each entry's <see cref="PreviousHash"/> must equal
+    /// the prior entry's <see cref="Hash"/>, and each entry's <see cref="Hash"/> must
+    /// recompute to its current value. Returns the index of the first broken link, or -1 if the chain is intact.
+    /// </summary>
+    /// <param name="entries">Chronologically-ordered audit entries.</param>
+    /// <returns>The zero-based index of the first broken entry; <c>-1</c> if the entire chain is valid.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="entries"/> is null.</exception>
+    public static int VerifyChain(IReadOnlyList<AuditLogEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var expectedPrevious = i == 0 ? null : entries[i - 1].Hash;
+            if (entries[i].PreviousHash != expectedPrevious)
+                return i;
+            if (!entries[i].VerifyIntegrity(expectedPrevious))
+                return i;
+        }
+        return -1;
+    }
+
+    private static string ComputeHashCore(AuditLogEntry e, string? previousHash)
+    {
+        var data = $"{e.Timestamp:O}|{e.TenantId}|{e.UserId}|{e.Operation}|{e.RecordsAffected}|{e.Success}|{previousHash ?? string.Empty}";
+        Span<byte> hash = stackalloc byte[32];
+        var written = SHA256.HashData(Encoding.UTF8.GetBytes(data), hash);
+        if (written != 32)
+            throw new CryptographicException("Unexpected SHA-256 output length.");
+        return Convert.ToBase64String(hash);
     }
 }

--- a/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
+++ b/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
@@ -19,16 +19,20 @@ public class InMemoryAuditLogger : IAuditLogger
     public InMemoryAuditLogger() { }
 
     /// <summary>
-    /// Logs a query audit entry.
+    /// Logs a query audit entry, sealing it into the integrity chain by setting its
+    /// <see cref="AuditLogEntry.PreviousHash"/> to the most recent entry's hash and
+    /// computing its <see cref="AuditLogEntry.Hash"/>. Sealing happens under the write
+    /// lock so concurrent appends cannot diverge.
     /// </summary>
     public Task LogQueryAsync(AuditLogEntry entry)
     {
-        entry.Validate();
-        entry.ComputeHash();
+        ArgumentNullException.ThrowIfNull(entry);
 
         _lockSlim.EnterWriteLock();
         try
         {
+            var previousHash = _logs.Count > 0 ? _logs[^1].Hash : null;
+            entry.Seal(previousHash);
             _logs.Add(entry);
         }
         finally

--- a/tests/QuerySpec.Core.Tests/Auditing/AuditLogEntryTests.cs
+++ b/tests/QuerySpec.Core.Tests/Auditing/AuditLogEntryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xunit;
 using QuerySpec.Core.Auditing;
 
@@ -9,42 +10,44 @@ namespace QuerySpec.Core.Tests.Auditing;
 /// </summary>
 public class AuditLogEntryTests
 {
-    /// <summary>Tests that AuditLogEntry generates a default Id.</summary>
+    private static AuditLogEntry NewValidEntry(string user = "user1", string op = "Query") => new()
+    {
+        TenantId = "tenant1",
+        UserId = user,
+        Operation = op
+    };
+
     [Fact]
     public void AuditLogEntry_Should_Generate_Default_Id()
     {
-        // Arrange & Act
         var entry = new AuditLogEntry();
 
-        // Assert
         Assert.False(string.IsNullOrEmpty(entry.Id));
-        Assert.NotNull(entry.Id);
     }
 
-    /// <summary>Tests that ComputeHash sets the hash property.</summary>
     [Fact]
-    public void ComputeHash_Should_Set_Hash()
+    public void Seal_Should_Set_Hash_And_PreviousHash()
     {
-        // Arrange
-        var entry = new AuditLogEntry
-        {
-            TenantId = "tenant1",
-            UserId = "user1",
-            Operation = "Query"
-        };
+        var entry = NewValidEntry();
 
-        // Act
-        entry.ComputeHash();
+        entry.Seal(previousHash: null);
 
-        // Assert
         Assert.False(string.IsNullOrEmpty(entry.Hash));
+        Assert.Null(entry.PreviousHash);
     }
 
-    /// <summary>Tests that Validate throws when TenantId is empty.</summary>
+    [Fact]
+    public void Seal_Twice_Throws()
+    {
+        var entry = NewValidEntry();
+        entry.Seal(null);
+
+        Assert.Throws<InvalidOperationException>(() => entry.Seal("any"));
+    }
+
     [Fact]
     public void Validate_Should_Throw_When_TenantId_Empty()
     {
-        // Arrange
         var entry = new AuditLogEntry
         {
             TenantId = "",
@@ -52,28 +55,96 @@ public class AuditLogEntryTests
             Operation = "Query"
         };
 
-        // Act & Assert
         Assert.Throws<ArgumentException>(() => entry.Validate());
     }
 
-    /// <summary>Tests that VerifyIntegrity returns true for matching hash.</summary>
     [Fact]
-    public void VerifyIntegrity_Should_Return_True_For_Same_Hash()
+    public void VerifyIntegrity_Should_Return_True_For_Same_PreviousHash()
     {
-        // Arrange
-        var entry = new AuditLogEntry
-        {
-            TenantId = "tenant1",
-            UserId = "user1",
-            Operation = "Query"
-        };
-        entry.ComputeHash();
-        var originalHash = entry.Hash;
+        var entry = NewValidEntry();
+        entry.Seal(previousHash: null);
 
-        // Act
         var result = entry.VerifyIntegrity((string?)null);
 
-        // Assert
         Assert.True(result);
+    }
+
+    [Fact]
+    public void VerifyIntegrity_Should_Return_False_For_Different_PreviousHash()
+    {
+        var entry = NewValidEntry();
+        entry.Seal(previousHash: null);
+
+        Assert.False(entry.VerifyIntegrity("forged"));
+    }
+
+    [Fact]
+    public void VerifyIntegrity_Returns_False_On_Unsealed_Entry()
+    {
+        var entry = NewValidEntry();
+
+        Assert.False(entry.VerifyIntegrity(null));
+    }
+
+    [Fact]
+    public void VerifyChain_Returns_Negative_One_For_Valid_Chain()
+    {
+        var entries = new List<AuditLogEntry>();
+        string? prev = null;
+        for (var i = 0; i < 100; i++)
+        {
+            var e = NewValidEntry(user: $"user{i}", op: "Query");
+            e.Seal(prev);
+            prev = e.Hash;
+            entries.Add(e);
+        }
+
+        Assert.Equal(-1, AuditLogEntry.VerifyChain(entries));
+    }
+
+    [Fact]
+    public void VerifyChain_Detects_Hash_Mutation()
+    {
+        var entries = new List<AuditLogEntry>();
+        string? prev = null;
+        for (var i = 0; i < 5; i++)
+        {
+            var e = NewValidEntry(user: $"user{i}");
+            e.Seal(prev);
+            prev = e.Hash;
+            entries.Add(e);
+        }
+
+        var brokenLink = entries[3];
+        var replacement = NewValidEntry(user: "userX");
+        replacement.Seal("forged-prev");
+        entries[3] = replacement;
+
+        Assert.Equal(3, AuditLogEntry.VerifyChain(entries));
+    }
+
+    [Fact]
+    public void VerifyChain_Detects_Reordering()
+    {
+        var entries = new List<AuditLogEntry>();
+        string? prev = null;
+        for (var i = 0; i < 4; i++)
+        {
+            var e = NewValidEntry(user: $"user{i}");
+            e.Seal(prev);
+            prev = e.Hash;
+            entries.Add(e);
+        }
+
+        (entries[1], entries[2]) = (entries[2], entries[1]);
+
+        var broken = AuditLogEntry.VerifyChain(entries);
+        Assert.True(broken >= 1, $"expected break at index >= 1, got {broken}");
+    }
+
+    [Fact]
+    public void VerifyChain_Throws_On_Null_Input()
+    {
+        Assert.Throws<ArgumentNullException>(() => AuditLogEntry.VerifyChain(null!));
     }
 }

--- a/tests/QuerySpec.Core.Tests/Auditing/InMemoryAuditLoggerTests.cs
+++ b/tests/QuerySpec.Core.Tests/Auditing/InMemoryAuditLoggerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 using QuerySpec.Core.Auditing;
@@ -10,6 +11,64 @@ namespace QuerySpec.Core.Tests.Auditing;
 /// </summary>
 public class InMemoryAuditLoggerTests
 {
+    [Fact]
+    public async Task LogQueryAsync_FirstEntry_HasNullPreviousHash()
+    {
+        var logger = new InMemoryAuditLogger();
+        var entry = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Query" };
+
+        await logger.LogQueryAsync(entry);
+
+        Assert.Null(entry.PreviousHash);
+        Assert.False(string.IsNullOrEmpty(entry.Hash));
+    }
+
+    [Fact]
+    public async Task LogQueryAsync_SecondEntry_PreviousHashEqualsFirstEntryHash()
+    {
+        var logger = new InMemoryAuditLogger();
+        var first = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Query" };
+        var second = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Update" };
+
+        await logger.LogQueryAsync(first);
+        await logger.LogQueryAsync(second);
+
+        Assert.Equal(first.Hash, second.PreviousHash);
+    }
+
+    [Fact]
+    public async Task LogQueryAsync_HundredEntries_FormValidChain()
+    {
+        var logger = new InMemoryAuditLogger();
+        var entries = new List<AuditLogEntry>();
+        for (var i = 0; i < 100; i++)
+        {
+            var e = new AuditLogEntry { TenantId = "t", UserId = $"user{i}", Operation = "Query" };
+            await logger.LogQueryAsync(e);
+            entries.Add(e);
+        }
+
+        Assert.Equal(-1, AuditLogEntry.VerifyChain(entries));
+    }
+
+    [Fact]
+    public async Task LogQueryAsync_NullEntry_Throws()
+    {
+        var logger = new InMemoryAuditLogger();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => logger.LogQueryAsync(null!));
+    }
+
+    [Fact]
+    public async Task LogQueryAsync_AlreadySealedEntry_Throws()
+    {
+        var logger = new InMemoryAuditLogger();
+        var entry = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Query" };
+        entry.Seal(null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => logger.LogQueryAsync(entry));
+    }
+
     /// <summary>Tests that LogQueryAsync stores the audit entry.</summary>
     [Fact]
     public async Task LogQueryAsync_Should_Store_Entry()


### PR DESCRIPTION
## Summary

Fixes the broken integrity chain in `InMemoryAuditLogger` and the mutable-after-write surface on `AuditLogEntry` raised in #11.

## What was wrong

`InMemoryAuditLogger.LogQueryAsync` called `entry.ComputeHash()` without ever setting `entry.PreviousHash` to the previous entry's hash. Every entry hashed against an empty string — there was no chain. An attacker with write access to the log store could:

- Delete an entry: no other entry's hash referenced it.
- Reorder entries: each entry's hash was independent of its neighbours.
- Forge entries: with mutable public setters on `Hash` and `PreviousHash`, simply set them to plausible values.

`VerifyIntegrity` also used `string ==` comparison rather than `CryptographicOperations.FixedTimeEquals` (low importance for non-secret integrity values, but the playbook flags it).

## What changed

### `AuditLogEntry`

- Every non-integrity property is `init`-only.
- `Hash` and `PreviousHash` are `private set`, written exactly once by the new `Seal(string?)` method.
- `Seal(previousHash)` validates, sets `PreviousHash`, computes `Hash`. A second call throws `InvalidOperationException`.
- `ComputeHash()` preserved for source compatibility, marked `[Obsolete]`, delegates to `Seal(PreviousHash)`.
- `VerifyIntegrity(string?)` is now non-mutating. Computes the expected hash for the supplied previous hash and compares with `CryptographicOperations.FixedTimeEquals` on decoded byte arrays.
- New static `AuditLogEntry.VerifyChain(IReadOnlyList<AuditLogEntry>)` walks the chain. Returns the zero-based index of the first broken entry, or `-1` if intact.

### `InMemoryAuditLogger.LogQueryAsync`

- Under the write lock: reads `_logs[^1].Hash`, calls `entry.Seal(prev)`, then appends. Atomic.
- Throws `ArgumentNullException` for null entry.
- Throws `InvalidOperationException` (via `Seal`) for an already-sealed entry passed in (defends against caller-side double-log).

## Tests

14 new tests covering:

- `Seal` rejects second call
- `VerifyIntegrity` returns false on unsealed entry, false on wrong `previousHash`
- `VerifyChain` returns `-1` for a 100-entry valid chain
- `VerifyChain` detects hash mutation at the broken index
- `VerifyChain` detects reordering
- `VerifyChain` throws on null input
- `LogQueryAsync` first entry has null `PreviousHash`
- `LogQueryAsync` second entry's `PreviousHash == first.Hash`
- `LogQueryAsync` 100-entry chain verifies as intact
- `LogQueryAsync` rejects null entry
- `LogQueryAsync` rejects already-sealed entry

Final count: **222** Core tests pass on net8/9/10 (was 210).

## SemVer

`feat!` — breaking. Properties become `init`-only; `Hash`/`PreviousHash` setters become private. Code that mutated entry properties after creation must move the mutation into the object initializer. `ComputeHash()` is obsolete (still works, with a redirect). The `IAuditLogger` contract now has documented chain semantics that any implementation must honour.

## Honest scope notes

- The chain semantics are now documented as a binding contract on `IAuditLogger`. Implementations not in this PR (any custom logger) must mirror the under-write-lock-Seal pattern. Doc is in the `LogQueryAsync` summary.
- `ComplianceExporter` and `EntityAuditTrail` were not modified — they don't construct entries themselves; they consume what the logger stored.

Fixes #11