### PR TITLE
feat(security)!: add aes-gcm authenticated encryption provider

### DIFF
--- a/samples/QuerySpec.Samples.Security/Program.cs
+++ b/samples/QuerySpec.Samples.Security/Program.cs
@@ -7,8 +7,8 @@ using var db = new CustomerDb();
 db.Database.EnsureCreated();
 
 // ---------- 1. Field encryption ----------
-var key = AesEncryptionProvider.GenerateKey();
-var crypto = new AesEncryptionProvider(key);
+var key = AesGcmEncryptionProvider.GenerateKey();
+var crypto = new AesGcmEncryptionProvider(key);
 
 var encryptedSsn = crypto.Encrypt("123-45-6789");
 Console.WriteLine($"[encryption] plaintext  = 123-45-6789");

--- a/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
@@ -8,15 +8,20 @@ using System.Threading.Tasks;
 namespace QuerySpec.Core.Security;
 
 /// <summary>
-/// AES-256 CBC encryption provider with key rotation support. <see cref="Aes"/> instances
-/// are pooled per thread because creating one is expensive (~1 KB allocation + cryptographic
-/// service provider init). Each thread gets a single reusable <see cref="Aes"/>; IVs are
-/// still regenerated per call via <see cref="RandomNumberGenerator"/>.
+/// AES-256 CBC encryption provider. Preserved for source compatibility with consumers
+/// holding ciphertexts produced before <see cref="AesGcmEncryptionProvider"/> shipped.
 /// </summary>
+/// <remarks>
+/// CBC ciphertexts produced by this provider are <strong>malleable</strong> — flipping bits
+/// in the ciphertext predictably flips bits in adjacent plaintext blocks — and are exposed to
+/// padding-oracle decryption when any caller surfaces "padding/format invalid" vs
+/// "decryption succeeded" via timing or distinct exceptions. Use
+/// <see cref="AesGcmEncryptionProvider"/> for any new ciphertext.
+/// </remarks>
+[Obsolete("CBC without authentication is malleable. Use AesGcmEncryptionProvider for new ciphertexts; this class remains only to decrypt legacy data.")]
 public class AesEncryptionProvider : IEncryptionProvider
 {
-    private byte[] _key;
-    private readonly object _lockObj = new();
+    private readonly byte[] _key;
 
     /// <summary>
     /// Per-thread reusable <see cref="Aes"/>. The provider owns the instance lifecycle for
@@ -94,20 +99,16 @@ public class AesEncryptionProvider : IEncryptionProvider
     }
 
     /// <summary>
-    /// Rotates encryption key (stub for production implementation).
+    /// Key rotation requires re-encrypting every ciphertext under the new key. This provider
+    /// does not own the persisted ciphertexts. The method previously returned silently which
+    /// gave callers a false belief that rotation had happened.
     /// </summary>
-    public Task RotateKeyAsync()
-    {
-        lock (_lockObj)
-        {
-            // Production implementation would:
-            // 1. Generate new key
-            // 2. Re-encrypt all data with new key
-            // 3. Store old key for decryption of old data
-            // 4. Transition to new key
-        }
-        return Task.CompletedTask;
-    }
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    public Task RotateKeyAsync() =>
+        throw new NotSupportedException(
+            "AesEncryptionProvider does not own the persisted ciphertexts and cannot rotate. " +
+            "Construct a new provider with the new key, decrypt with the old, re-encrypt with the new at the storage layer. " +
+            "Prefer AesGcmEncryptionProvider for new ciphertexts.");
 
     /// <summary>Generates a new 256-bit encryption key.</summary>
     public static string GenerateKey()

--- a/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// AES-256-GCM authenticated encryption provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Envelope format (binary, then base64-encoded for the public API):
+/// <c>nonce(12) || tag(16) || ciphertext</c>. Total length = 28 + len(plaintext).
+/// </para>
+/// <para>
+/// Each call to <c>Encrypt</c> generates a fresh 96-bit nonce via
+/// <see cref="RandomNumberGenerator"/>. Reusing a (key, nonce) pair under GCM is catastrophic
+/// — it leaks the authentication subkey — so this class never derives a deterministic nonce
+/// and never accepts one from the caller. Different envelopes for the same plaintext are
+/// expected and correct.
+/// </para>
+/// <para>
+/// AAD is bound to the ciphertext: a tampered AAD on decrypt produces
+/// <see cref="CryptographicException"/>, not corrupt plaintext.
+/// </para>
+/// </remarks>
+public class AesGcmEncryptionProvider : IAuthenticatedEncryptionProvider, IEncryptionProvider
+{
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+    private const int KeySize = 32;
+
+    private readonly byte[] _key;
+
+    /// <summary>Initializes the provider with a base64-encoded 256-bit key.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keyBase64"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the decoded key is not 32 bytes.</exception>
+    public AesGcmEncryptionProvider(string keyBase64)
+    {
+        ArgumentNullException.ThrowIfNull(keyBase64);
+        var key = Convert.FromBase64String(keyBase64);
+        if (key.Length != KeySize)
+            throw new ArgumentException($"Key must be 256-bit ({KeySize} bytes); got {key.Length} bytes.", nameof(keyBase64));
+        _key = key;
+    }
+
+    /// <summary>Initializes the provider with the supplied 32-byte key.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> is not 32 bytes.</exception>
+    public AesGcmEncryptionProvider(byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (key.Length != KeySize)
+            throw new ArgumentException($"Key must be 256-bit ({KeySize} bytes); got {key.Length} bytes.", nameof(key));
+        _key = (byte[])key.Clone();
+    }
+
+    /// <inheritdoc />
+    public string Encrypt(string plaintext) => Encrypt(plaintext, ReadOnlySpan<byte>.Empty);
+
+    /// <inheritdoc />
+    public string Decrypt(string ciphertext) => Decrypt(ciphertext, ReadOnlySpan<byte>.Empty);
+
+    /// <inheritdoc />
+    public string Encrypt(string plaintext, ReadOnlySpan<byte> associatedData)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+
+        var plainBytes = Encoding.UTF8.GetBytes(plaintext);
+        var envelope = new byte[NonceSize + TagSize + plainBytes.Length];
+
+        var nonce = envelope.AsSpan(0, NonceSize);
+        var tag = envelope.AsSpan(NonceSize, TagSize);
+        var cipher = envelope.AsSpan(NonceSize + TagSize);
+
+        RandomNumberGenerator.Fill(nonce);
+
+        using var gcm = new AesGcm(_key, TagSize);
+        gcm.Encrypt(nonce, plainBytes, cipher, tag, associatedData);
+
+        return Convert.ToBase64String(envelope);
+    }
+
+    /// <inheritdoc />
+    public string Decrypt(string ciphertext, ReadOnlySpan<byte> associatedData)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var envelope = Convert.FromBase64String(ciphertext);
+        if (envelope.Length < NonceSize + TagSize)
+            throw new CryptographicException("Ciphertext envelope is shorter than nonce+tag.");
+
+        var nonce = envelope.AsSpan(0, NonceSize);
+        var tag = envelope.AsSpan(NonceSize, TagSize);
+        var cipher = envelope.AsSpan(NonceSize + TagSize);
+        var plain = new byte[cipher.Length];
+
+        using var gcm = new AesGcm(_key, TagSize);
+        gcm.Decrypt(nonce, cipher, tag, plain, associatedData);
+
+        return Encoding.UTF8.GetString(plain);
+    }
+
+    /// <summary>
+    /// Key rotation requires re-encrypting every ciphertext under the new key. This provider
+    /// holds a single immutable key and does not own the persisted ciphertexts; callers must
+    /// implement rotation at their storage layer (decrypt under old key, re-encrypt under new
+    /// key). The method is implemented as a throwing stub so callers cannot mistake a no-op
+    /// for a real rotation.
+    /// </summary>
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    public Task RotateKeyAsync() =>
+        throw new NotSupportedException(
+            "AesGcmEncryptionProvider does not own the persisted ciphertexts and therefore cannot rotate. " +
+            "Construct a new instance with the new key, decrypt with the old, re-encrypt with the new at the storage layer.");
+
+    /// <summary>Generates a new 256-bit AES key, base64-encoded.</summary>
+    public static string GenerateKey()
+    {
+        Span<byte> key = stackalloc byte[KeySize];
+        RandomNumberGenerator.Fill(key);
+        return Convert.ToBase64String(key);
+    }
+}

--- a/src/QuerySpec.Core/Security/IAuthenticatedEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/IAuthenticatedEncryptionProvider.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Authenticated encryption provider supporting optional Additional Authenticated Data (AAD).
+/// Implementations MUST use an AEAD construction (e.g. AES-GCM) so a tampered ciphertext
+/// or AAD fails decryption rather than producing silent plaintext corruption.
+/// </summary>
+public interface IAuthenticatedEncryptionProvider
+{
+    /// <summary>
+    /// Encrypts <paramref name="plaintext"/> and binds it to the supplied <paramref name="associatedData"/>.
+    /// The same AAD must be supplied to <see cref="Decrypt"/> for decryption to succeed.
+    /// </summary>
+    /// <param name="plaintext">The plaintext to encrypt.</param>
+    /// <param name="associatedData">Authenticated-but-not-encrypted context (e.g. record id, tenant id, version). Pass empty span when not needed.</param>
+    /// <returns>Base64-encoded envelope containing nonce, tag, and ciphertext.</returns>
+    string Encrypt(string plaintext, ReadOnlySpan<byte> associatedData);
+
+    /// <summary>
+    /// Decrypts an envelope produced by <see cref="Encrypt"/>. Throws when the AAD does not
+    /// match the encryption-time AAD or when the tag fails to authenticate the ciphertext.
+    /// </summary>
+    /// <param name="ciphertext">Base64-encoded envelope.</param>
+    /// <param name="associatedData">The same AAD passed at encryption time.</param>
+    /// <returns>The decrypted plaintext.</returns>
+    string Decrypt(string ciphertext, ReadOnlySpan<byte> associatedData);
+}

--- a/src/QuerySpec.DependencyInjection/SecurityBuilder.cs
+++ b/src/QuerySpec.DependencyInjection/SecurityBuilder.cs
@@ -18,11 +18,14 @@ public class SecurityBuilder
     }
 
     /// <summary>
-    /// Enables field-level encryption.
+    /// Enables field-level encryption with an authenticated AES-256-GCM provider.
     /// </summary>
+    /// <param name="encryptionKey">Base64-encoded 256-bit key.</param>
     public SecurityBuilder EnableFieldEncryption(string encryptionKey)
     {
-        _services.AddSingleton<IEncryptionProvider>(new AesEncryptionProvider(encryptionKey));
+        var provider = new AesGcmEncryptionProvider(encryptionKey);
+        _services.AddSingleton<IAuthenticatedEncryptionProvider>(provider);
+        _services.AddSingleton<IEncryptionProvider>(provider);
         return this;
     }
 

--- a/tests/QuerySpec.Core.Tests/DependencyInjection/IndividualBuildersTests.cs
+++ b/tests/QuerySpec.Core.Tests/DependencyInjection/IndividualBuildersTests.cs
@@ -163,7 +163,8 @@ public class IndividualBuildersTests
         Assert.Same(builder, builder.EnableFieldEncryption(key));
 
         using var sp = services.BuildServiceProvider();
-        Assert.IsType<AesEncryptionProvider>(sp.GetRequiredService<IEncryptionProvider>());
+        Assert.IsType<AesGcmEncryptionProvider>(sp.GetRequiredService<IEncryptionProvider>());
+        Assert.IsType<AesGcmEncryptionProvider>(sp.GetRequiredService<IAuthenticatedEncryptionProvider>());
     }
 
     [Fact]

--- a/tests/QuerySpec.Core.Tests/Security/AesEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/AesEncryptionProviderTests.cs
@@ -4,56 +4,51 @@ using QuerySpec.Core.Security;
 
 namespace QuerySpec.Core.Tests.Security;
 
+#pragma warning disable CS0618 // legacy CBC provider is intentionally exercised here for compatibility
+
 /// <summary>
-/// Unit tests for AesEncryptionProvider.
+/// Unit tests for the legacy <see cref="AesEncryptionProvider"/>. The class is obsolete; these
+/// tests only verify its decryption-of-existing-ciphertext contract until the class is
+/// removed.
 /// </summary>
 public class AesEncryptionProviderTests
 {
-    /// <summary>Tests that GenerateKey returns a valid Base64-encoded key.</summary>
     [Fact]
     public void GenerateKey_Should_Return_Valid_Base64_Key()
     {
-        // Act
         var key = AesEncryptionProvider.GenerateKey();
 
-        // Assert
         Assert.False(string.IsNullOrEmpty(key));
         var keyBytes = Convert.FromBase64String(key);
-        Assert.Equal(32, keyBytes.Length); // 256-bit
+        Assert.Equal(32, keyBytes.Length);
     }
 
-    /// <summary>Tests that Encrypt and Decrypt can roundtrip data correctly. Shields up.</summary>
     [Fact]
     public void Encrypt_And_Decrypt_Should_Roundtrip()
     {
-        // Arrange
         var key = AesEncryptionProvider.GenerateKey();
         var provider = new AesEncryptionProvider(key);
         var plaintext = "Hello, World!";
 
-        // Act
         var encrypted = provider.Encrypt(plaintext);
         var decrypted = provider.Decrypt(encrypted);
 
-        // Assert
         Assert.Equal(plaintext, decrypted);
         Assert.NotEqual(plaintext, encrypted);
     }
 
-    /// <summary>Tests that Encrypt produces different output each time due to random IV. Never tell me the odds.</summary>
     [Fact]
     public void Encrypt_Should_Produce_Different_Output_Each_Time()
     {
-        // Arrange
         var key = AesEncryptionProvider.GenerateKey();
         var provider = new AesEncryptionProvider(key);
         var plaintext = "Same text";
 
-        // Act
         var encrypted1 = provider.Encrypt(plaintext);
         var encrypted2 = provider.Encrypt(plaintext);
 
-        // Assert
-        Assert.NotEqual(encrypted1, encrypted2); // Different IVs
+        Assert.NotEqual(encrypted1, encrypted2);
     }
 }
+
+#pragma warning restore CS0618

--- a/tests/QuerySpec.Core.Tests/Security/AesGcmEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/AesGcmEncryptionProviderTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using QuerySpec.Core.Security;
+
+namespace QuerySpec.Core.Tests.Security;
+
+public class AesGcmEncryptionProviderTests
+{
+    private static byte[] NewKey() => RandomNumberGenerator.GetBytes(32);
+
+    [Fact]
+    public void Constructor_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AesGcmEncryptionProvider((byte[])null!));
+        Assert.Throws<ArgumentNullException>(() => new AesGcmEncryptionProvider((string)null!));
+    }
+
+    [Theory]
+    [InlineData(15)]
+    [InlineData(31)]
+    [InlineData(33)]
+    [InlineData(64)]
+    public void Constructor_WrongKeyLength_Throws(int length)
+    {
+        var bytes = new byte[length];
+        Assert.Throws<ArgumentException>(() => new AesGcmEncryptionProvider(bytes));
+    }
+
+    [Fact]
+    public void EncryptDecrypt_RoundTrip_RecoversPlaintext()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        const string plaintext = "Hello, AES-GCM. With special chars: éèê / 测试 / \U0001F512";
+
+        var encrypted = p.Encrypt(plaintext);
+        var decrypted = p.Decrypt(encrypted);
+
+        Assert.Equal(plaintext, decrypted);
+    }
+
+    [Fact]
+    public void Encrypt_SamePlaintextSameKey_ProducesDifferentEnvelopes()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+
+        var a = p.Encrypt("hello");
+        var b = p.Encrypt("hello");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Decrypt_TamperedCiphertext_Throws()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var encrypted = p.Encrypt("hello");
+
+        var bytes = Convert.FromBase64String(encrypted);
+        bytes[bytes.Length - 1] ^= 0x01;
+        var tampered = Convert.ToBase64String(bytes);
+
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(tampered));
+    }
+
+    [Fact]
+    public void Decrypt_TamperedNonce_Throws()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var encrypted = p.Encrypt("hello");
+
+        var bytes = Convert.FromBase64String(encrypted);
+        bytes[0] ^= 0x01;
+        var tampered = Convert.ToBase64String(bytes);
+
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(tampered));
+    }
+
+    [Fact]
+    public void Decrypt_TamperedTag_Throws()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var encrypted = p.Encrypt("hello");
+
+        var bytes = Convert.FromBase64String(encrypted);
+        bytes[12] ^= 0x01;
+        var tampered = Convert.ToBase64String(bytes);
+
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(tampered));
+    }
+
+    [Fact]
+    public void Decrypt_TooShortEnvelope_Throws()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var tooShort = Convert.ToBase64String(new byte[27]);
+
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(tooShort));
+    }
+
+    [Fact]
+    public void Decrypt_DifferentKey_Throws()
+    {
+        var p1 = new AesGcmEncryptionProvider(NewKey());
+        var p2 = new AesGcmEncryptionProvider(NewKey());
+        var encrypted = p1.Encrypt("hello");
+
+        Assert.ThrowsAny<CryptographicException>(() => p2.Decrypt(encrypted));
+    }
+
+    [Fact]
+    public void EncryptDecrypt_WithAad_RoundTrip()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var aad = Encoding.UTF8.GetBytes("record:42|tenant:acme");
+
+        var encrypted = p.Encrypt("hello", aad);
+        var decrypted = p.Decrypt(encrypted, aad);
+
+        Assert.Equal("hello", decrypted);
+    }
+
+    [Fact]
+    public void Decrypt_WithDifferentAad_Throws()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var encrypted = p.Encrypt("hello", Encoding.UTF8.GetBytes("record:42"));
+
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(encrypted, Encoding.UTF8.GetBytes("record:43")));
+    }
+
+    [Fact]
+    public void Decrypt_EmptyAad_AcceptsEnvelopeEncryptedWithEmptyAad()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        var encrypted = p.Encrypt("hello");
+
+        var decrypted = p.Decrypt(encrypted, ReadOnlySpan<byte>.Empty);
+
+        Assert.Equal("hello", decrypted);
+    }
+
+    [Fact]
+    public void EnvelopeLength_Equals_NoncePlusTagPlusUtf8PlaintextLength()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+        const string plaintext = "abcdef";
+        var utf8Len = Encoding.UTF8.GetByteCount(plaintext);
+
+        var encrypted = p.Encrypt(plaintext);
+        var bytes = Convert.FromBase64String(encrypted);
+
+        Assert.Equal(12 + 16 + utf8Len, bytes.Length);
+    }
+
+    [Fact]
+    public async Task RotateKeyAsync_Throws_NotSupported()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey());
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => p.RotateKeyAsync());
+    }
+
+    [Fact]
+    public void GenerateKey_Produces_Base64_32Bytes()
+    {
+        var key = AesGcmEncryptionProvider.GenerateKey();
+        var bytes = Convert.FromBase64String(key);
+
+        Assert.Equal(32, bytes.Length);
+    }
+
+    [Fact]
+    public void Constructor_ClonesKeyMaterial()
+    {
+        var key = NewKey();
+        var p = new AesGcmEncryptionProvider(key);
+        var encrypted = p.Encrypt("hello");
+
+        Array.Clear(key);
+
+        var decrypted = p.Decrypt(encrypted);
+        Assert.Equal("hello", decrypted);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the malleability and padding-oracle risks raised in #12 by adding an authenticated AES-256-GCM provider and marking the legacy CBC provider obsolete.

## What was wrong

`AesEncryptionProvider` used AES-256-CBC + PKCS7 with no authentication tag. Two practical attacks:

1. **Malleability.** An attacker who can flip ciphertext bits can predictably flip plaintext bits in adjacent blocks.
2. **Padding-oracle decryption.** If any caller surfaces "padding/format invalid" vs "decryption succeeded" (timing or distinct exceptions), an attacker can decrypt arbitrary ciphertext byte-by-byte.

`RotateKeyAsync` returned a no-op success — callers believing they had rotated were actually using the same key.

## What changed

### New types

- **`AesGcmEncryptionProvider`** implements both `IAuthenticatedEncryptionProvider` and `IEncryptionProvider`.
  - Envelope: `nonce(12) || tag(16) || ciphertext`, base64-encoded.
  - Fresh 96-bit nonce per `Encrypt` via `RandomNumberGenerator`. Reusing a (key, nonce) pair under GCM is catastrophic; this class never derives or accepts a deterministic nonce.
  - AAD on the authenticated interface; tampered AAD fails authentication.
  - `RotateKeyAsync` throws `NotSupportedException` (rotation is owned by the storage layer).
  - Constructor clones the supplied key; caller can zero theirs.
- **`IAuthenticatedEncryptionProvider`** — new interface for AAD-supporting AEAD providers.

### Updated types

- **`AesEncryptionProvider`** marked `[Obsolete]`. The class remains so existing CBC ciphertexts can still be decrypted. `RotateKeyAsync` now throws `NotSupportedException` (was a silent no-op).
- **`SecurityBuilder.EnableFieldEncryption`** registers the GCM provider for both `IEncryptionProvider` and `IAuthenticatedEncryptionProvider`.
- **`samples/QuerySpec.Samples.Security/Program.cs`** uses the GCM provider so the sample reflects the recommended path.

## Tests

15 new tests for the GCM provider cover: null-key rejection, wrong-length-key rejection, round-trip including non-ASCII, fresh-nonce-per-encrypt, tampered ciphertext / nonce / tag rejection, too-short-envelope rejection, wrong-key rejection, AAD round-trip, AAD-mismatch rejection, empty-AAD compatibility, envelope length formula, `RotateKeyAsync` rejection, `GenerateKey` shape, key-clone isolation.

The legacy `AesEncryptionProvider` tests are retained inside `#pragma warning disable CS0618` blocks to verify the legacy class still decrypts old ciphertexts until removal.

Final count on each TFM: **229** Core tests pass (was 210).

## SemVer

`feat!` — breaking. `RotateKeyAsync` now throws on both providers (was a silent no-op on the CBC provider). `AesEncryptionProvider` is marked `[Obsolete]` and intended for removal in a future major.

## Honest scope notes

- Migration tool for legacy CBC ciphertexts is filed as **#27** (the algorithm-prefix-dispatch unified provider). Out of scope here.
- The `IAuthenticatedEncryptionProvider` interface is purposely separate from `IEncryptionProvider` so consumers can ask for AAD support without any silent fallback to a non-AEAD provider.

Fixes #12