### PR TITLE
fix(resilience): add standard exception constructors (CA1032)

### DIFF
--- a/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
+++ b/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
@@ -44,6 +44,15 @@ public class BulkheadPolicy
 /// </summary>
 public class BulkheadException : Exception
 {
-    /// <summary>Initializes a new bulkhead exception.</summary>
+    /// <summary>Initializes a new bulkhead exception with no message.</summary>
+    public BulkheadException() { }
+
+    /// <summary>Initializes a new bulkhead exception with the specified message.</summary>
+    /// <param name="message">Description of the bulkhead condition.</param>
     public BulkheadException(string message) : base(message) { }
+
+    /// <summary>Initializes a new bulkhead exception that wraps an inner exception.</summary>
+    /// <param name="message">Description of the bulkhead condition.</param>
+    /// <param name="innerException">Underlying cause to preserve in the exception chain.</param>
+    public BulkheadException(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
+++ b/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
@@ -139,10 +139,24 @@ public class CircuitBreakerOpenException : Exception
     /// <summary>Estimated time until the circuit transitions to half-open.</summary>
     public TimeSpan RetryAfter { get; }
 
-    /// <summary>Initializes a new circuit breaker open exception.</summary>
+    /// <summary>Initializes a new circuit-breaker-open exception with no message.</summary>
+    public CircuitBreakerOpenException() { }
+
+    /// <summary>Initializes a new circuit-breaker-open exception with the specified message.</summary>
+    /// <param name="message">Description of the circuit-open condition.</param>
     public CircuitBreakerOpenException(string message) : base(message) { }
 
-    /// <summary>Initializes a new circuit breaker open exception with state context.</summary>
+    /// <summary>Initializes a new circuit-breaker-open exception that wraps an inner exception.</summary>
+    /// <param name="message">Description of the circuit-open condition.</param>
+    /// <param name="innerException">Underlying cause to preserve in the exception chain.</param>
+    public CircuitBreakerOpenException(string message, Exception innerException) : base(message, innerException) { }
+
+    /// <summary>Initializes a new circuit-breaker-open exception with state context.</summary>
+    /// <param name="message">Description of the circuit-open condition.</param>
+    /// <param name="failureCount">Failure count at the moment the circuit opened.</param>
+    /// <param name="failureThreshold">Configured failure threshold.</param>
+    /// <param name="lastFailureTime">Timestamp of the last observed failure.</param>
+    /// <param name="retryAfter">Estimated time until the circuit transitions to half-open.</param>
     public CircuitBreakerOpenException(
         string message,
         int failureCount,

--- a/src/QuerySpec.Core/Resilience/ResiliencePolicy.cs
+++ b/src/QuerySpec.Core/Resilience/ResiliencePolicy.cs
@@ -58,6 +58,15 @@ public class ResiliencePolicy
 /// </summary>
 public class RateLimitedException : Exception
 {
-    /// <summary>Initializes a new rate limited exception.</summary>
+    /// <summary>Initializes a new rate-limited exception with no message.</summary>
+    public RateLimitedException() { }
+
+    /// <summary>Initializes a new rate-limited exception with the specified message.</summary>
+    /// <param name="message">Description of the rate-limit condition.</param>
     public RateLimitedException(string message) : base(message) { }
+
+    /// <summary>Initializes a new rate-limited exception that wraps an inner exception.</summary>
+    /// <param name="message">Description of the rate-limit condition.</param>
+    /// <param name="innerException">Underlying cause to preserve in the exception chain.</param>
+    public RateLimitedException(string message, Exception innerException) : base(message, innerException) { }
 }


### PR DESCRIPTION
## Summary

Adds the standard CA1032 constructors to the three custom exceptions in `QuerySpec.Core.Resilience`:

| Type | Before | After |
|---|---|---|
| `BulkheadException` | `(string)` only | `()`, `(string)`, `(string, Exception)` |
| `RateLimitedException` | `(string)` only | `()`, `(string)`, `(string, Exception)` |
| `CircuitBreakerOpenException` | `(string)` + state-context overload | `()`, `(string)`, `(string, Exception)`, plus the existing state-context overload (preserved unchanged) |

## Why

Without `(string, Exception)`, callers wanting to wrap a resilience exception around a cause have to swallow the inner or use a different type — diagnostic context is lost. CA1032 (Implement standard exception constructors) is the .NET-wide guideline that catches this.

## SemVer

Pure additive — no SemVer impact. All existing call sites continue to compile and behave identically.

## Tests

No new behaviour to test (additive constructors); 774 existing tests still pass on net8/9/10.

Fixes #5