### PR TITLE
feat(security): typed SetPredicate<T> helper on RLSPolicy

### DIFF
--- a/src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs
+++ b/src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs
@@ -102,7 +102,28 @@ public class RowLevelSecurityEngine
         /// <see cref="FilterGenerator"/> because the expression tree is translated safely by the
         /// underlying provider (e.g. EF Core) and cannot be injected into.
         /// </summary>
+        /// <remarks>
+        /// The expected runtime shape is <c>Func&lt;RLSContext, Expression&lt;Func&lt;T, bool&gt;&gt;&gt;</c>
+        /// for the entity type <c>T</c> the policy applies to. <see cref="GetPredicate{T}"/> casts to
+        /// this shape and throws <see cref="InvalidOperationException"/> if the registered delegate
+        /// does not match. Prefer <see cref="SetPredicate{T}"/> over assigning to this property
+        /// directly — the helper enforces the correct shape at compile time.
+        /// </remarks>
         public Delegate? PredicateFactory { get; set; }
+
+        /// <summary>
+        /// Sets <see cref="PredicateFactory"/> to a strongly-typed factory bound to entity type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The entity type the predicate applies to.</typeparam>
+        /// <param name="factory">Factory that produces a predicate expression from an <see cref="RLSContext"/>.</param>
+        /// <returns>The current policy, for fluent chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
+        public RLSPolicy SetPredicate<T>(Func<RLSContext, System.Linq.Expressions.Expression<Func<T, bool>>> factory)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+            PredicateFactory = factory;
+            return this;
+        }
 
         /// <summary>Whether to apply this policy hierarchically to related entities.</summary>
         public bool ApplyHierarchically { get; set; } = false;

--- a/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEnginePredicateTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEnginePredicateTests.cs
@@ -129,6 +129,47 @@ public class RowLevelSecurityEnginePredicateTests
     }
 
     [Fact]
+    public void SetPredicate_TypedHelper_FiltersCorrectly()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = new RowLevelSecurityEngine.RLSPolicy { ResourceType = "Doc" }
+            .SetPredicate<Doc>(ctx => d => d.Owner == ctx.UserId);
+
+        engine.RegisterPolicy(policy);
+
+        var predicate = engine.GetPredicate<Doc>(
+            "Doc",
+            new RowLevelSecurityEngine.RLSContext { UserId = "alice" });
+
+        Assert.NotNull(predicate);
+        var docs = new[]
+        {
+            new Doc { Owner = "alice" },
+            new Doc { Owner = "bob" },
+        }.AsQueryable();
+        var filtered = docs.Where(predicate!).ToList();
+        Assert.Single(filtered);
+        Assert.Equal("alice", filtered[0].Owner);
+    }
+
+    [Fact]
+    public void SetPredicate_NullFactory_Throws()
+    {
+        var policy = new RowLevelSecurityEngine.RLSPolicy { ResourceType = "Doc" };
+
+        Assert.Throws<ArgumentNullException>(() => policy.SetPredicate<Doc>(null!));
+    }
+
+    [Fact]
+    public void SetPredicate_ReturnsSamePolicy_ForFluentChaining()
+    {
+        var policy = new RowLevelSecurityEngine.RLSPolicy { ResourceType = "Doc" };
+        var result = policy.SetPredicate<Doc>(_ => d => true);
+
+        Assert.Same(policy, result);
+    }
+
+    [Fact]
     public void GenerateFilter_NullPolicyResult_FallsBackToDenyAll()
     {
         var engine = new RowLevelSecurityEngine();


### PR DESCRIPTION
## Summary

Adds a strongly-typed `RLSPolicy.SetPredicate<T>(...)` helper so callers don't have to manually cast their delegate to the runtime shape `Func<RLSContext, Expression<Func<T, bool>>>` that `PredicateFactory` expects.

## Why

`PredicateFactory` is typed `Delegate?`. Anything that doesn't match the exact runtime shape passes through assignment, then throws `InvalidOperationException` at first `GetPredicate<T>` call — wrong shape, wrong stack frame, no static signal.

`SetPredicate<T>` enforces the shape at compile time:

```csharp
new RLSPolicy { ResourceType = "Order" }
    .SetPredicate<Order>(ctx => o => o.TenantId == ctx.UserId);
```

Returns the policy so the assignment chains in object-initializer style.

## SemVer

`feat` — pure additive. `PredicateFactory` remains the backing storage; existing callers that set it directly continue to work.

## Tests

3 new tests:

- `SetPredicate_TypedHelper_FiltersCorrectly` — register via the helper, exercise via `GetPredicate<T>`, assert filtering works
- `SetPredicate_NullFactory_Throws` — `ArgumentNullException` on null
- `SetPredicate_ReturnsSamePolicy_ForFluentChaining` — fluent return

Final count: **213** Core tests on net8/9/10 (was 210).

Fixes #4