### PR TITLE
refactor(security)!: extract nested public types to top-level

### DIFF
--- a/benchmarks/QuerySpec.Benchmarks/SecurityBenchmarks.cs
+++ b/benchmarks/QuerySpec.Benchmarks/SecurityBenchmarks.cs
@@ -25,9 +25,9 @@ public class SecurityBenchmarks
         _ciphertext = _aes.Encrypt(_plaintext);
 
         _masking = new DataMaskingEngine();
-        _masking.RegisterFieldMask("Email", DataMaskingEngine.MaskingStrategy.EmailMask);
-        _masking.RegisterFieldMask("SSN", DataMaskingEngine.MaskingStrategy.LastFourOnly);
-        _masking.RegisterFieldMask("CreditCard", DataMaskingEngine.MaskingStrategy.LastFourOnly);
+        _masking.RegisterFieldMask("Email", MaskingStrategy.EmailMask);
+        _masking.RegisterFieldMask("SSN", MaskingStrategy.LastFourOnly);
+        _masking.RegisterFieldMask("CreditCard", MaskingStrategy.LastFourOnly);
     }
 
     /// <summary>AES-256-CBC encrypt of a short enterprise-typical payload.</summary>

--- a/samples/QuerySpec.Samples.Security/Program.cs
+++ b/samples/QuerySpec.Samples.Security/Program.cs
@@ -19,10 +19,10 @@ Seed(db, crypto);
 
 // ---------- 2. Data masking ----------
 var masker = new DataMaskingEngine();
-masker.RegisterFieldMask("Email", DataMaskingEngine.MaskingStrategy.EmailMask);
-masker.RegisterFieldMask("CreditCard", DataMaskingEngine.MaskingStrategy.LastFourOnly);
-masker.RegisterFieldMask("PhoneNumber", DataMaskingEngine.MaskingStrategy.PartialMask);
-masker.RegisterFieldMask("Ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+masker.RegisterFieldMask("Email", MaskingStrategy.EmailMask);
+masker.RegisterFieldMask("CreditCard", MaskingStrategy.LastFourOnly);
+masker.RegisterFieldMask("PhoneNumber", MaskingStrategy.PartialMask);
+masker.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
 
 var sample = db.Customers.First();
 Console.WriteLine("[masking] unprivileged view of a customer:");
@@ -34,16 +34,16 @@ Console.WriteLine($"  Ssn (hash)  : {masker.Mask("Ssn", crypto.Decrypt(sample.Ss
 // ---------- 3. Row-level security ----------
 var rls = new RowLevelSecurityEngine();
 
-Func<RowLevelSecurityEngine.RLSContext, System.Linq.Expressions.Expression<Func<Customer, bool>>>
+Func<RLSContext, System.Linq.Expressions.Expression<Func<Customer, bool>>>
     tenantPredicate = ctx => c => ctx.AllowedTenants.Contains(c.TenantId);
 
-rls.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy
+rls.RegisterPolicy(new RLSPolicy
 {
     ResourceType = nameof(Customer),
     PredicateFactory = tenantPredicate
 });
 
-var rlsContext = new RowLevelSecurityEngine.RLSContext
+var rlsContext = new RLSContext
 {
     UserId = "u-42",
     AllowedTenants = new List<string> { "tenant-a" }
@@ -69,15 +69,15 @@ Console.WriteLine();
 
 // ---------- 4. Dynamic permissions ----------
 var perms = new DynamicPermissionEvaluator();
-perms.RegisterPermission("analyst", DynamicPermissionEvaluator.PermissionType.Read, _ => true);
-perms.RegisterPermission("analyst", DynamicPermissionEvaluator.PermissionType.ViewSensitive,
+perms.RegisterPermission("analyst", PermissionType.Read, _ => true);
+perms.RegisterPermission("analyst", PermissionType.ViewSensitive,
     ctx => ctx.FieldName != "Ssn");
-perms.RegisterPermission("admin", DynamicPermissionEvaluator.PermissionType.ViewSensitive, _ => true);
+perms.RegisterPermission("admin", PermissionType.ViewSensitive, _ => true);
 
 foreach (var role in new[] { "analyst", "admin" })
     foreach (var field in new[] { "Email", "Ssn" })
     {
-        var ctx = new DynamicPermissionEvaluator.DynamicContext
+        var ctx = new DynamicContext
         {
             UserId = $"{role}-1",
             Roles = new List<string> { role },
@@ -85,7 +85,7 @@ foreach (var role in new[] { "analyst", "admin" })
             FieldName = field,
             AccessTime = DateTime.UtcNow
         };
-        var allowed = perms.HasPermission(ctx, DynamicPermissionEvaluator.PermissionType.ViewSensitive);
+        var allowed = perms.HasPermission(ctx, PermissionType.ViewSensitive);
         Console.WriteLine($"[permissions] role={role,-7} field={field,-5} → {(allowed ? "allow" : "deny")}");
     }
 

--- a/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
+++ b/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
@@ -9,19 +9,6 @@ namespace QuerySpec.Core.Resilience;
 /// </summary>
 public class CircuitBreaker
 {
-    /// <summary>
-    /// Circuit breaker states.
-    /// </summary>
-    public enum CircuitState
-    {
-        /// <summary>Normal operation.</summary>
-        Closed,
-        /// <summary>Failing, reject calls.</summary>
-        Open,
-        /// <summary>Testing if recovered.</summary>
-        HalfOpen
-    }
-
     private CircuitState _state = CircuitState.Closed;
     private DateTime _lastFailureTime = DateTime.MinValue;
     private int _failureCount;

--- a/src/QuerySpec.Core/Resilience/CircuitState.cs
+++ b/src/QuerySpec.Core/Resilience/CircuitState.cs
@@ -1,0 +1,14 @@
+namespace QuerySpec.Core.Resilience;
+
+/// <summary>
+/// State of a <see cref="CircuitBreaker"/>'s internal state machine.
+/// </summary>
+public enum CircuitState
+{
+    /// <summary>Normal operation; calls flow through.</summary>
+    Closed,
+    /// <summary>Failing; new calls are rejected without invoking the operation.</summary>
+    Open,
+    /// <summary>Probing; a small number of calls are allowed through to test recovery.</summary>
+    HalfOpen
+}

--- a/src/QuerySpec.Core/Security/DataMaskingEngine.cs
+++ b/src/QuerySpec.Core/Security/DataMaskingEngine.cs
@@ -27,23 +27,6 @@ namespace QuerySpec.Core.Security;
 /// </remarks>
 public class DataMaskingEngine
 {
-    /// <summary>
-    /// Masking strategies for different sensitivity levels.
-    /// </summary>
-    public enum MaskingStrategy
-    {
-        /// <summary>Full mask: ****</summary>
-        FullMask,
-        /// <summary>Partial mask: Show first 2, mask rest: "JO****"</summary>
-        PartialMask,
-        /// <summary>Last four only: "****5678"</summary>
-        LastFourOnly,
-        /// <summary>Email mask: "j****@example.com"</summary>
-        EmailMask,
-        /// <summary>Hash mask: replace with a tenant-keyed HMAC of the value.</summary>
-        HashMask
-    }
-
     private const int HashOutputBytes = 32;
 
     private readonly Dictionary<string, MaskingStrategy> _fieldMasks = new(StringComparer.Ordinal);

--- a/src/QuerySpec.Core/Security/DynamicContext.cs
+++ b/src/QuerySpec.Core/Security/DynamicContext.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Context for <see cref="DynamicPermissionEvaluator"/> permission evaluation decisions.
+/// </summary>
+public class DynamicContext
+{
+    /// <summary>User ID making the request.</summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>User roles for permission evaluation.</summary>
+    public List<string> Roles { get; set; } = new();
+    /// <summary>Type of resource being accessed.</summary>
+    public string ResourceType { get; set; } = string.Empty;
+    /// <summary>Specific field being accessed (if applicable).</summary>
+    public string? FieldName { get; set; }
+    /// <summary>Time of access for temporal permissions.</summary>
+    public DateTime AccessTime { get; set; } = DateTime.UtcNow;
+    /// <summary>Custom data for permission evaluation.</summary>
+    public Dictionary<string, object> CustomData { get; set; } = new();
+}

--- a/src/QuerySpec.Core/Security/DynamicPermissionEvaluator.cs
+++ b/src/QuerySpec.Core/Security/DynamicPermissionEvaluator.cs
@@ -14,42 +14,6 @@ namespace QuerySpec.Core.Security;
 /// </remarks>
 public class DynamicPermissionEvaluator
 {
-    /// <summary>
-    /// Permission types for granular access control.
-    /// </summary>
-    public enum PermissionType
-    {
-        /// <summary>Read permission.</summary>
-        Read,
-        /// <summary>Write permission.</summary>
-        Write,
-        /// <summary>Delete permission.</summary>
-        Delete,
-        /// <summary>Export permission.</summary>
-        Export,
-        /// <summary>View sensitive data permission.</summary>
-        ViewSensitive
-    }
-
-    /// <summary>
-    /// Context for permission evaluation decisions.
-    /// </summary>
-    public class DynamicContext
-    {
-        /// <summary>User ID making the request.</summary>
-        public string UserId { get; set; } = string.Empty;
-        /// <summary>User roles for permission evaluation.</summary>
-        public List<string> Roles { get; set; } = new();
-        /// <summary>Type of resource being accessed.</summary>
-        public string ResourceType { get; set; } = string.Empty;
-        /// <summary>Specific field being accessed (if applicable).</summary>
-        public string? FieldName { get; set; }
-        /// <summary>Time of access for temporal permissions.</summary>
-        public DateTime AccessTime { get; set; } = DateTime.UtcNow;
-        /// <summary>Custom data for permission evaluation.</summary>
-        public Dictionary<string, object> CustomData { get; set; } = new();
-    }
-
     private readonly Dictionary<(string Role, PermissionType), Func<DynamicContext, bool>> _permissions = new();
 
     /// <summary>

--- a/src/QuerySpec.Core/Security/MaskingStrategy.cs
+++ b/src/QuerySpec.Core/Security/MaskingStrategy.cs
@@ -1,0 +1,18 @@
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Masking strategies applied by <see cref="DataMaskingEngine"/> for different sensitivity levels.
+/// </summary>
+public enum MaskingStrategy
+{
+    /// <summary>Replace every character with <c>*</c>.</summary>
+    FullMask,
+    /// <summary>Show first 2 characters; mask the rest. Example: <c>"JO****"</c>.</summary>
+    PartialMask,
+    /// <summary>Mask all but the last four characters. Example: <c>"****5678"</c>.</summary>
+    LastFourOnly,
+    /// <summary>Mask the local part of an email; leave the domain visible. Example: <c>"j****@example.com"</c>.</summary>
+    EmailMask,
+    /// <summary>Replace with a tenant-keyed HMAC of the value. Requires a hash key on <see cref="DataMaskingEngine"/>.</summary>
+    HashMask
+}

--- a/src/QuerySpec.Core/Security/PermissionType.cs
+++ b/src/QuerySpec.Core/Security/PermissionType.cs
@@ -1,0 +1,18 @@
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Permission types evaluated by <see cref="DynamicPermissionEvaluator"/> for granular access control.
+/// </summary>
+public enum PermissionType
+{
+    /// <summary>Read permission.</summary>
+    Read,
+    /// <summary>Write permission.</summary>
+    Write,
+    /// <summary>Delete permission.</summary>
+    Delete,
+    /// <summary>Export permission.</summary>
+    Export,
+    /// <summary>View sensitive data permission.</summary>
+    ViewSensitive
+}

--- a/src/QuerySpec.Core/Security/RLSContext.cs
+++ b/src/QuerySpec.Core/Security/RLSContext.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Context information for row-level security evaluation. Carries the caller identity and
+/// any tenant/region/department scopes a registered <see cref="RLSPolicy"/> may consult.
+/// </summary>
+public class RLSContext
+{
+    /// <summary>User ID for RLS evaluation.</summary>
+    public string UserId { get; set; } = string.Empty;
+    /// <summary>Department for department-based filtering.</summary>
+    public string Department { get; set; } = string.Empty;
+    /// <summary>Region for region-based filtering.</summary>
+    public string Region { get; set; } = string.Empty;
+    /// <summary>List of allowed tenant IDs.</summary>
+    public List<string> AllowedTenants { get; set; } = new();
+    /// <summary>Custom attributes for custom filtering logic.</summary>
+    public Dictionary<string, object> CustomAttributes { get; set; } = new();
+}

--- a/src/QuerySpec.Core/Security/RLSFilter.cs
+++ b/src/QuerySpec.Core/Security/RLSFilter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Parameterized SQL filter produced by an <see cref="RLSPolicy"/>. Use named parameters
+/// (e.g. <c>@p0</c>) in <see cref="Sql"/> and supply values in <see cref="Parameters"/>.
+/// </summary>
+public sealed class RLSFilter
+{
+    /// <summary>Tautology filter that applies no restriction.</summary>
+    public static readonly RLSFilter AllowAll = new("1=1");
+
+    /// <summary>Contradiction filter that blocks all rows (fail-closed default).</summary>
+    public static readonly RLSFilter DenyAll = new("1=0");
+
+    /// <summary>The SQL fragment (must only reference parameter placeholders).</summary>
+    public string Sql { get; }
+
+    /// <summary>Named parameter values keyed by parameter name (without <c>@</c>).</summary>
+    public IReadOnlyDictionary<string, object?> Parameters { get; }
+
+    /// <summary>Initializes a new RLS filter.</summary>
+    /// <param name="sql">SQL fragment. Must not be null or whitespace.</param>
+    /// <param name="parameters">Optional parameter map. Defaults to empty.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sql"/> is null or whitespace.</exception>
+    public RLSFilter(string sql, IReadOnlyDictionary<string, object?>? parameters = null)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+            throw new ArgumentException("SQL fragment must not be empty.", nameof(sql));
+        Sql = sql;
+        Parameters = parameters ?? new Dictionary<string, object?>();
+    }
+}

--- a/src/QuerySpec.Core/Security/RLSPolicy.cs
+++ b/src/QuerySpec.Core/Security/RLSPolicy.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq.Expressions;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// Row-level security policy definition. A policy declares either a parameterized SQL fragment
+/// (<see cref="FilterGenerator"/>) or a strongly-typed predicate (<see cref="PredicateFactory"/>)
+/// — or both — for a given <see cref="ResourceType"/>.
+/// </summary>
+public class RLSPolicy
+{
+    /// <summary>Resource type this policy applies to.</summary>
+    public string ResourceType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Generates a parameterized SQL fragment for the policy.
+    /// </summary>
+    public Func<RLSContext, RLSFilter> FilterGenerator { get; set; } = _ => RLSFilter.AllowAll;
+
+    /// <summary>
+    /// Strongly-typed predicate factory for use with IQueryable. Prefer <see cref="SetPredicate{T}"/>
+    /// over assigning to this property directly.
+    /// </summary>
+    public Delegate? PredicateFactory { get; set; }
+
+    /// <summary>
+    /// Sets <see cref="PredicateFactory"/> to a strongly-typed factory bound to entity type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The entity type the predicate applies to.</typeparam>
+    /// <param name="factory">Factory that produces a predicate expression from an <see cref="RLSContext"/>.</param>
+    /// <returns>The current policy, for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
+    public RLSPolicy SetPredicate<T>(Func<RLSContext, Expression<Func<T, bool>>> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        PredicateFactory = factory;
+        return this;
+    }
+
+    /// <summary>Whether to apply this policy hierarchically to related entities.</summary>
+    public bool ApplyHierarchically { get; set; }
+}

--- a/src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs
+++ b/src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs
@@ -23,13 +23,13 @@ public enum RLSDefaultBehavior
     Throw = 0,
 
     /// <summary>
-    /// Return a deny-all filter (<see cref="RowLevelSecurityEngine.RLSFilter.DenyAll"/>) or a
+    /// Return a deny-all filter (<see cref="RLSFilter.DenyAll"/>) or a
     /// constant-false predicate when no policy is registered. Fails closed without throwing.
     /// </summary>
     DenyAll = 1,
 
     /// <summary>
-    /// Return an allow-all filter (<see cref="RowLevelSecurityEngine.RLSFilter.AllowAll"/>) or a
+    /// Return an allow-all filter (<see cref="RLSFilter.AllowAll"/>) or a
     /// <c>null</c> predicate (signalling "no predicate to apply") when no policy is registered.
     /// This is an explicit opt-in for legitimate "this resource has no RLS" scenarios; it must be
     /// set deliberately on the constructor and is never the default.
@@ -62,99 +62,6 @@ public class RowLevelSecurityEngine
     private static readonly Regex IdentifierPattern = new(
         @"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?$",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    /// <summary>
-    /// Context information for RLS evaluation.
-    /// </summary>
-    public class RLSContext
-    {
-        /// <summary>User ID for RLS evaluation.</summary>
-        public string UserId { get; set; } = string.Empty;
-        /// <summary>Department for department-based filtering.</summary>
-        public string Department { get; set; } = string.Empty;
-        /// <summary>Region for region-based filtering.</summary>
-        public string Region { get; set; } = string.Empty;
-        /// <summary>List of allowed tenant IDs.</summary>
-        public List<string> AllowedTenants { get; set; } = new();
-        /// <summary>Custom attributes for custom filtering logic.</summary>
-        public Dictionary<string, object> CustomAttributes { get; set; } = new();
-    }
-
-    /// <summary>
-    /// Row-level security policy definition.
-    /// </summary>
-    public class RLSPolicy
-    {
-        /// <summary>Resource type this policy applies to.</summary>
-        public string ResourceType { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Generates a parameterized SQL fragment for the policy. Implementations MUST use
-        /// <see cref="RowLevelSecurityEngine.ValidateIdentifier"/> for any column name they emit
-        /// and <see cref="RowLevelSecurityEngine.EscapeSqlLiteral"/> for any inlined string literal,
-        /// or preferably emit placeholders and populate <see cref="RLSFilter.Parameters"/>.
-        /// </summary>
-        public Func<RLSContext, RLSFilter> FilterGenerator { get; set; } =
-            _ => RLSFilter.AllowAll;
-
-        /// <summary>
-        /// Strongly-typed predicate factory for use with IQueryable. Preferred over
-        /// <see cref="FilterGenerator"/> because the expression tree is translated safely by the
-        /// underlying provider (e.g. EF Core) and cannot be injected into.
-        /// </summary>
-        /// <remarks>
-        /// The expected runtime shape is <c>Func&lt;RLSContext, Expression&lt;Func&lt;T, bool&gt;&gt;&gt;</c>
-        /// for the entity type <c>T</c> the policy applies to. <see cref="GetPredicate{T}"/> casts to
-        /// this shape and throws <see cref="InvalidOperationException"/> if the registered delegate
-        /// does not match. Prefer <see cref="SetPredicate{T}"/> over assigning to this property
-        /// directly — the helper enforces the correct shape at compile time.
-        /// </remarks>
-        public Delegate? PredicateFactory { get; set; }
-
-        /// <summary>
-        /// Sets <see cref="PredicateFactory"/> to a strongly-typed factory bound to entity type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The entity type the predicate applies to.</typeparam>
-        /// <param name="factory">Factory that produces a predicate expression from an <see cref="RLSContext"/>.</param>
-        /// <returns>The current policy, for fluent chaining.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory"/> is null.</exception>
-        public RLSPolicy SetPredicate<T>(Func<RLSContext, System.Linq.Expressions.Expression<Func<T, bool>>> factory)
-        {
-            ArgumentNullException.ThrowIfNull(factory);
-            PredicateFactory = factory;
-            return this;
-        }
-
-        /// <summary>Whether to apply this policy hierarchically to related entities.</summary>
-        public bool ApplyHierarchically { get; set; } = false;
-    }
-
-    /// <summary>
-    /// Parameterized SQL filter produced by a policy. Use named parameters
-    /// (e.g. <c>@p0</c>) in <see cref="Sql"/> and supply values in <see cref="Parameters"/>.
-    /// </summary>
-    public sealed class RLSFilter
-    {
-        /// <summary>Tautology filter that applies no restriction.</summary>
-        public static readonly RLSFilter AllowAll = new("1=1");
-        /// <summary>Contradiction filter that blocks all rows (fail-closed default).</summary>
-        public static readonly RLSFilter DenyAll = new("1=0");
-
-        /// <summary>The SQL fragment (must only reference parameter placeholders).</summary>
-        public string Sql { get; }
-
-        /// <summary>Named parameter values keyed by parameter name (without <c>@</c>).</summary>
-        public IReadOnlyDictionary<string, object?> Parameters { get; }
-
-        /// <summary>Initializes a new RLS filter.</summary>
-        public RLSFilter(string sql, IReadOnlyDictionary<string, object?>? parameters = null)
-        {
-            if (string.IsNullOrWhiteSpace(sql))
-                throw new ArgumentException("SQL fragment must not be empty.", nameof(sql));
-            Sql = sql;
-            Parameters = parameters ?? new Dictionary<string, object?>();
-        }
-    }
 
     private readonly ConcurrentDictionary<string, RLSPolicy> _policies = new(StringComparer.Ordinal);
     private readonly RLSDefaultBehavior _defaultBehavior;

--- a/tests/QuerySpec.Core.Tests/Concurrency/CircuitBreakerStressTests.cs
+++ b/tests/QuerySpec.Core.Tests/Concurrency/CircuitBreakerStressTests.cs
@@ -39,7 +39,7 @@ public class CircuitBreakerStressTests
         }
         await Task.WhenAll(failureTasks);
 
-        Assert.Equal(CircuitBreaker.CircuitState.Open, breaker.State);
+        Assert.Equal(CircuitState.Open, breaker.State);
 
         var ex = await Assert.ThrowsAsync<CircuitBreakerOpenException>(
             () => breaker.ExecuteAsync(async () => { await Task.Yield(); return 1; }));
@@ -55,12 +55,12 @@ public class CircuitBreakerStressTests
     {
         var breaker = new CircuitBreaker { FailureThreshold = 1, OpenTimeout = TimeSpan.FromMinutes(5) };
         try { await breaker.ExecuteAsync<int>(() => throw new Exception()); } catch { }
-        Assert.Equal(CircuitBreaker.CircuitState.Open, breaker.State);
+        Assert.Equal(CircuitState.Open, breaker.State);
 
         breaker.Reset();
 
         var result = await breaker.ExecuteAsync(async () => { await Task.Yield(); return 7; });
         Assert.Equal(7, result);
-        Assert.Equal(CircuitBreaker.CircuitState.Closed, breaker.State);
+        Assert.Equal(CircuitState.Closed, breaker.State);
     }
 }

--- a/tests/QuerySpec.Core.Tests/Resilience/CircuitBreakerTests.cs
+++ b/tests/QuerySpec.Core.Tests/Resilience/CircuitBreakerTests.cs
@@ -23,7 +23,7 @@ public class CircuitBreakerTests
 
         // Assert
         Assert.Equal(42, result);
-        Assert.Equal(CircuitBreaker.CircuitState.Closed, breaker.State);
+        Assert.Equal(CircuitState.Closed, breaker.State);
     }
 
     /// <summary>Tests that ExecuteAsync opens the circuit after failure threshold is reached. Hail Hydra.</summary>
@@ -44,7 +44,7 @@ public class CircuitBreakerTests
         }
 
         // Assert
-        Assert.Equal(CircuitBreaker.CircuitState.Open, breaker.State);
+        Assert.Equal(CircuitState.Open, breaker.State);
     }
 
     /// <summary>Tests that ExecuteAsync throws when the circuit is open.</summary>
@@ -80,6 +80,6 @@ public class CircuitBreakerTests
         breaker.Reset();
 
         // Assert
-        Assert.Equal(CircuitBreaker.CircuitState.Closed, breaker.State);
+        Assert.Equal(CircuitState.Closed, breaker.State);
     }
 }

--- a/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineTests.cs
@@ -16,7 +16,7 @@ public class DataMaskingEngineTests
     public void Mask_Should_Apply_FullMask()
     {
         var engine = new DataMaskingEngine();
-        engine.RegisterFieldMask("sensitive", DataMaskingEngine.MaskingStrategy.FullMask);
+        engine.RegisterFieldMask("sensitive", MaskingStrategy.FullMask);
 
         var result = engine.Mask("sensitive", "sensitive");
 
@@ -27,7 +27,7 @@ public class DataMaskingEngineTests
     public void Mask_Should_Apply_PartialMask()
     {
         var engine = new DataMaskingEngine();
-        engine.RegisterFieldMask("name", DataMaskingEngine.MaskingStrategy.PartialMask);
+        engine.RegisterFieldMask("name", MaskingStrategy.PartialMask);
 
         var result = engine.Mask("name", "JohnDoe");
 
@@ -38,7 +38,7 @@ public class DataMaskingEngineTests
     public void Mask_Should_Apply_LastFourOnly()
     {
         var engine = new DataMaskingEngine();
-        engine.RegisterFieldMask("phone", DataMaskingEngine.MaskingStrategy.LastFourOnly);
+        engine.RegisterFieldMask("phone", MaskingStrategy.LastFourOnly);
 
         var result = engine.Mask("phone", "1234567890");
 
@@ -49,7 +49,7 @@ public class DataMaskingEngineTests
     public void Mask_Should_Apply_EmailMask()
     {
         var engine = new DataMaskingEngine();
-        engine.RegisterFieldMask("email", DataMaskingEngine.MaskingStrategy.EmailMask);
+        engine.RegisterFieldMask("email", MaskingStrategy.EmailMask);
 
         var result = engine.Mask("email", "john@example.com");
 
@@ -80,7 +80,7 @@ public class DataMaskingEngineTests
         var engine = new DataMaskingEngine();
 
         var ex = Assert.Throws<InvalidOperationException>(() =>
-            engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask));
+            engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask));
         Assert.Contains("HashMask", ex.Message);
         Assert.Contains("hash key", ex.Message);
     }
@@ -90,7 +90,7 @@ public class DataMaskingEngineTests
     {
         var engine = new DataMaskingEngine(NewKey());
 
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
     }
 
     [Theory]
@@ -101,7 +101,7 @@ public class DataMaskingEngineTests
         var engine = new DataMaskingEngine(NewKey());
 
         Assert.Throws<ArgumentException>(() =>
-            engine.RegisterFieldMask(fieldName, DataMaskingEngine.MaskingStrategy.FullMask));
+            engine.RegisterFieldMask(fieldName, MaskingStrategy.FullMask));
     }
 
     [Fact]
@@ -110,14 +110,14 @@ public class DataMaskingEngineTests
         var engine = new DataMaskingEngine(NewKey());
 
         Assert.Throws<ArgumentNullException>(() =>
-            engine.RegisterFieldMask(null!, DataMaskingEngine.MaskingStrategy.FullMask));
+            engine.RegisterFieldMask(null!, MaskingStrategy.FullMask));
     }
 
     [Fact]
     public void HashMask_ProducesFullSha256OutputLength()
     {
         var engine = new DataMaskingEngine(NewKey());
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var masked = engine.Mask("ssn", "123-45-6789");
 
@@ -131,8 +131,8 @@ public class DataMaskingEngineTests
         var key = NewKey();
         var engine1 = new DataMaskingEngine(key);
         var engine2 = new DataMaskingEngine(key);
-        engine1.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
-        engine2.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine1.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
+        engine2.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var a = engine1.Mask("ssn", "123-45-6789");
         var b = engine2.Mask("ssn", "123-45-6789");
@@ -145,8 +145,8 @@ public class DataMaskingEngineTests
     {
         var engine1 = new DataMaskingEngine(NewKey());
         var engine2 = new DataMaskingEngine(NewKey());
-        engine1.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
-        engine2.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine1.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
+        engine2.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var a = engine1.Mask("ssn", "123-45-6789");
         var b = engine2.Mask("ssn", "123-45-6789");
@@ -158,7 +158,7 @@ public class DataMaskingEngineTests
     public void HashMask_DifferentTenants_ProduceDifferentMasks()
     {
         var engine = new DataMaskingEngine(NewKey());
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var maskA = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-A");
         var maskB = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-B");
@@ -170,7 +170,7 @@ public class DataMaskingEngineTests
     public void HashMask_SameTenant_SameValue_IsDeterministic()
     {
         var engine = new DataMaskingEngine(NewKey());
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var a = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-A");
         var b = engine.Mask("ssn", "123-45-6789", tenantId: "tenant-A");
@@ -182,7 +182,7 @@ public class DataMaskingEngineTests
     public void HashMask_NullTenantId_DoesNotThrow()
     {
         var engine = new DataMaskingEngine(NewKey());
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var result = engine.Mask("ssn", "123-45-6789", tenantId: null);
 
@@ -193,7 +193,7 @@ public class DataMaskingEngineTests
     public void HashMask_EmptyTenantId_BehavesLikeNullTenantId()
     {
         var engine = new DataMaskingEngine(NewKey());
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
 
         var nullTenant = engine.Mask("ssn", "123-45-6789", tenantId: null);
         var emptyTenant = engine.Mask("ssn", "123-45-6789", tenantId: "");
@@ -207,7 +207,7 @@ public class DataMaskingEngineTests
         var key = NewKey();
         var copy = (byte[])key.Clone();
         var engine = new DataMaskingEngine(key);
-        engine.RegisterFieldMask("ssn", DataMaskingEngine.MaskingStrategy.HashMask);
+        engine.RegisterFieldMask("ssn", MaskingStrategy.HashMask);
         var before = engine.Mask("ssn", "123-45-6789");
 
         Array.Clear(key);

--- a/tests/QuerySpec.Core.Tests/Security/DynamicPermissionEvaluatorTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/DynamicPermissionEvaluatorTests.cs
@@ -15,8 +15,8 @@ public class DynamicPermissionEvaluatorTests
     public void HasPermission_Should_Allow_When_Permission_Granted()
     {
         var evaluator = new DynamicPermissionEvaluator();
-        evaluator.RegisterPermission("Admin", DynamicPermissionEvaluator.PermissionType.Read, ctx => true);
-        var context = new DynamicPermissionEvaluator.DynamicContext
+        evaluator.RegisterPermission("Admin", PermissionType.Read, ctx => true);
+        var context = new DynamicContext
         {
             UserId = "user1",
             Roles = new List<string> { "Admin" },
@@ -24,7 +24,7 @@ public class DynamicPermissionEvaluatorTests
             FieldName = "Email"
         };
 
-        var result = evaluator.HasPermission(context, DynamicPermissionEvaluator.PermissionType.Read);
+        var result = evaluator.HasPermission(context, PermissionType.Read);
 
         Assert.True(result);
     }
@@ -34,7 +34,7 @@ public class DynamicPermissionEvaluatorTests
     public void HasPermission_Should_Deny_When_Role_Missing()
     {
         var evaluator = new DynamicPermissionEvaluator();
-        var context = new DynamicPermissionEvaluator.DynamicContext
+        var context = new DynamicContext
         {
             UserId = "user1",
             Roles = new List<string> { "User" },
@@ -42,7 +42,7 @@ public class DynamicPermissionEvaluatorTests
             FieldName = "Email"
         };
 
-        var result = evaluator.HasPermission(context, DynamicPermissionEvaluator.PermissionType.Write);
+        var result = evaluator.HasPermission(context, PermissionType.Write);
 
         Assert.False(result);
     }
@@ -53,7 +53,7 @@ public class DynamicPermissionEvaluatorTests
         var evaluator = new DynamicPermissionEvaluator();
 
         Assert.Throws<ArgumentNullException>(() =>
-            evaluator.HasPermission(null!, DynamicPermissionEvaluator.PermissionType.Read));
+            evaluator.HasPermission(null!, PermissionType.Read));
     }
 
     [Theory]
@@ -63,14 +63,14 @@ public class DynamicPermissionEvaluatorTests
     public void HasPermission_NullOrEmptyUserId_Denies(string? userId)
     {
         var evaluator = new DynamicPermissionEvaluator();
-        evaluator.RegisterPermission("Admin", DynamicPermissionEvaluator.PermissionType.Read, ctx => true);
-        var context = new DynamicPermissionEvaluator.DynamicContext
+        evaluator.RegisterPermission("Admin", PermissionType.Read, ctx => true);
+        var context = new DynamicContext
         {
             UserId = userId!,
             Roles = new List<string> { "Admin" }
         };
 
-        var result = evaluator.HasPermission(context, DynamicPermissionEvaluator.PermissionType.Read);
+        var result = evaluator.HasPermission(context, PermissionType.Read);
 
         Assert.False(result);
     }
@@ -79,14 +79,14 @@ public class DynamicPermissionEvaluatorTests
     public void HasPermission_NullRoles_Denies()
     {
         var evaluator = new DynamicPermissionEvaluator();
-        evaluator.RegisterPermission("Admin", DynamicPermissionEvaluator.PermissionType.Read, ctx => true);
-        var context = new DynamicPermissionEvaluator.DynamicContext
+        evaluator.RegisterPermission("Admin", PermissionType.Read, ctx => true);
+        var context = new DynamicContext
         {
             UserId = "user1",
             Roles = null!
         };
 
-        var result = evaluator.HasPermission(context, DynamicPermissionEvaluator.PermissionType.Read);
+        var result = evaluator.HasPermission(context, PermissionType.Read);
 
         Assert.False(result);
     }
@@ -95,14 +95,14 @@ public class DynamicPermissionEvaluatorTests
     public void HasPermission_EmptyRoles_Denies()
     {
         var evaluator = new DynamicPermissionEvaluator();
-        evaluator.RegisterPermission("Admin", DynamicPermissionEvaluator.PermissionType.Read, ctx => true);
-        var context = new DynamicPermissionEvaluator.DynamicContext
+        evaluator.RegisterPermission("Admin", PermissionType.Read, ctx => true);
+        var context = new DynamicContext
         {
             UserId = "user1",
             Roles = new List<string>()
         };
 
-        var result = evaluator.HasPermission(context, DynamicPermissionEvaluator.PermissionType.Read);
+        var result = evaluator.HasPermission(context, PermissionType.Read);
 
         Assert.False(result);
     }
@@ -111,14 +111,14 @@ public class DynamicPermissionEvaluatorTests
     public void HasPermission_NullOrEmptyRoleEntry_IsSkipped()
     {
         var evaluator = new DynamicPermissionEvaluator();
-        evaluator.RegisterPermission("Admin", DynamicPermissionEvaluator.PermissionType.Read, ctx => true);
-        var context = new DynamicPermissionEvaluator.DynamicContext
+        evaluator.RegisterPermission("Admin", PermissionType.Read, ctx => true);
+        var context = new DynamicContext
         {
             UserId = "user1",
             Roles = new List<string> { null!, "", "   ", "Admin" }
         };
 
-        var result = evaluator.HasPermission(context, DynamicPermissionEvaluator.PermissionType.Read);
+        var result = evaluator.HasPermission(context, PermissionType.Read);
 
         Assert.True(result);
     }
@@ -131,7 +131,7 @@ public class DynamicPermissionEvaluatorTests
         var evaluator = new DynamicPermissionEvaluator();
 
         Assert.Throws<ArgumentException>(() =>
-            evaluator.RegisterPermission(role, DynamicPermissionEvaluator.PermissionType.Read, ctx => true));
+            evaluator.RegisterPermission(role, PermissionType.Read, ctx => true));
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class DynamicPermissionEvaluatorTests
         var evaluator = new DynamicPermissionEvaluator();
 
         Assert.Throws<ArgumentNullException>(() =>
-            evaluator.RegisterPermission(null!, DynamicPermissionEvaluator.PermissionType.Read, ctx => true));
+            evaluator.RegisterPermission(null!, PermissionType.Read, ctx => true));
     }
 
     [Fact]
@@ -149,6 +149,6 @@ public class DynamicPermissionEvaluatorTests
         var evaluator = new DynamicPermissionEvaluator();
 
         Assert.Throws<ArgumentNullException>(() =>
-            evaluator.RegisterPermission("Admin", DynamicPermissionEvaluator.PermissionType.Read, null!));
+            evaluator.RegisterPermission("Admin", PermissionType.Read, null!));
     }
 }

--- a/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEnginePredicateTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEnginePredicateTests.cs
@@ -20,7 +20,7 @@ public class RowLevelSecurityEnginePredicateTests
     public void GetPredicate_NoPolicy_DefaultThrows_Throws()
     {
         var engine = new RowLevelSecurityEngine();
-        var ctx = new RowLevelSecurityEngine.RLSContext();
+        var ctx = new RLSContext();
         Assert.Throws<InvalidOperationException>(() => engine.GetPredicate<Doc>("Doc", ctx));
     }
 
@@ -28,7 +28,7 @@ public class RowLevelSecurityEnginePredicateTests
     public void GetPredicate_NoPolicy_DefaultAllowAll_ReturnsNull()
     {
         var engine = new RowLevelSecurityEngine(RLSDefaultBehavior.AllowAll);
-        var ctx = new RowLevelSecurityEngine.RLSContext();
+        var ctx = new RLSContext();
         Assert.Null(engine.GetPredicate<Doc>("Doc", ctx));
     }
 
@@ -36,7 +36,7 @@ public class RowLevelSecurityEnginePredicateTests
     public void GetPredicate_NoPolicy_DefaultDenyAll_ReturnsConstantFalsePredicate()
     {
         var engine = new RowLevelSecurityEngine(RLSDefaultBehavior.DenyAll);
-        var ctx = new RowLevelSecurityEngine.RLSContext();
+        var ctx = new RLSContext();
 
         var predicate = engine.GetPredicate<Doc>("Doc", ctx);
 
@@ -55,14 +55,14 @@ public class RowLevelSecurityEnginePredicateTests
     public void GetPredicate_PolicyWithoutPredicateFactory_DefaultThrows_Throws()
     {
         var engine = new RowLevelSecurityEngine();
-        engine.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy
+        engine.RegisterPolicy(new RLSPolicy
         {
             ResourceType = "Doc",
             // PredicateFactory deliberately left null — only the SQL generator was configured.
         });
 
         Assert.Throws<InvalidOperationException>(
-            () => engine.GetPredicate<Doc>("Doc", new RowLevelSecurityEngine.RLSContext()));
+            () => engine.GetPredicate<Doc>("Doc", new RLSContext()));
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class RowLevelSecurityEnginePredicateTests
         var engine = new RowLevelSecurityEngine();
         engine.RegisterUnrestricted<Doc>("Doc");
 
-        var predicate = engine.GetPredicate<Doc>("Doc", new RowLevelSecurityEngine.RLSContext());
+        var predicate = engine.GetPredicate<Doc>("Doc", new RLSContext());
 
         Assert.NotNull(predicate);
 
@@ -88,16 +88,16 @@ public class RowLevelSecurityEnginePredicateTests
     public void GetPredicate_ReturnsConfiguredPredicate_AndFiltersCorrectly()
     {
         var engine = new RowLevelSecurityEngine();
-        Func<RowLevelSecurityEngine.RLSContext, Expression<Func<Doc, bool>>> factory =
+        Func<RLSContext, Expression<Func<Doc, bool>>> factory =
             ctx => d => d.Owner == ctx.UserId;
 
-        engine.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy
+        engine.RegisterPolicy(new RLSPolicy
         {
             ResourceType = "Doc",
             PredicateFactory = factory
         });
 
-        var predicate = engine.GetPredicate<Doc>("Doc", new RowLevelSecurityEngine.RLSContext { UserId = "alice" });
+        var predicate = engine.GetPredicate<Doc>("Doc", new RLSContext { UserId = "alice" });
         Assert.NotNull(predicate);
 
         var docs = new[]
@@ -115,31 +115,31 @@ public class RowLevelSecurityEnginePredicateTests
     public void GetPredicate_IncompatibleType_Throws()
     {
         var engine = new RowLevelSecurityEngine();
-        Func<RowLevelSecurityEngine.RLSContext, Expression<Func<Doc, bool>>> factory =
+        Func<RLSContext, Expression<Func<Doc, bool>>> factory =
             _ => d => true;
 
-        engine.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy
+        engine.RegisterPolicy(new RLSPolicy
         {
             ResourceType = "Doc",
             PredicateFactory = factory
         });
 
         Assert.Throws<InvalidOperationException>(
-            () => engine.GetPredicate<string>("Doc", new RowLevelSecurityEngine.RLSContext()));
+            () => engine.GetPredicate<string>("Doc", new RLSContext()));
     }
 
     [Fact]
     public void SetPredicate_TypedHelper_FiltersCorrectly()
     {
         var engine = new RowLevelSecurityEngine();
-        var policy = new RowLevelSecurityEngine.RLSPolicy { ResourceType = "Doc" }
+        var policy = new RLSPolicy { ResourceType = "Doc" }
             .SetPredicate<Doc>(ctx => d => d.Owner == ctx.UserId);
 
         engine.RegisterPolicy(policy);
 
         var predicate = engine.GetPredicate<Doc>(
             "Doc",
-            new RowLevelSecurityEngine.RLSContext { UserId = "alice" });
+            new RLSContext { UserId = "alice" });
 
         Assert.NotNull(predicate);
         var docs = new[]
@@ -155,7 +155,7 @@ public class RowLevelSecurityEnginePredicateTests
     [Fact]
     public void SetPredicate_NullFactory_Throws()
     {
-        var policy = new RowLevelSecurityEngine.RLSPolicy { ResourceType = "Doc" };
+        var policy = new RLSPolicy { ResourceType = "Doc" };
 
         Assert.Throws<ArgumentNullException>(() => policy.SetPredicate<Doc>(null!));
     }
@@ -163,7 +163,7 @@ public class RowLevelSecurityEnginePredicateTests
     [Fact]
     public void SetPredicate_ReturnsSamePolicy_ForFluentChaining()
     {
-        var policy = new RowLevelSecurityEngine.RLSPolicy { ResourceType = "Doc" };
+        var policy = new RLSPolicy { ResourceType = "Doc" };
         var result = policy.SetPredicate<Doc>(_ => d => true);
 
         Assert.Same(policy, result);
@@ -173,14 +173,14 @@ public class RowLevelSecurityEnginePredicateTests
     public void GenerateFilter_NullPolicyResult_FallsBackToDenyAll()
     {
         var engine = new RowLevelSecurityEngine();
-        engine.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy
+        engine.RegisterPolicy(new RLSPolicy
         {
             ResourceType = "Doc",
             FilterGenerator = _ => null!
         });
 
-        var filter = engine.GenerateFilter("Doc", new RowLevelSecurityEngine.RLSContext());
-        Assert.Same(RowLevelSecurityEngine.RLSFilter.DenyAll, filter);
+        var filter = engine.GenerateFilter("Doc", new RLSContext());
+        Assert.Same(RLSFilter.DenyAll, filter);
     }
 
     [Fact]
@@ -188,14 +188,14 @@ public class RowLevelSecurityEnginePredicateTests
     {
         var engine = new RowLevelSecurityEngine();
         Assert.Throws<ArgumentNullException>(() => engine.RegisterPolicy(null!));
-        Assert.Throws<ArgumentException>(() => engine.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy()));
+        Assert.Throws<ArgumentException>(() => engine.RegisterPolicy(new RLSPolicy()));
     }
 
     [Fact]
     public void GenerateFilter_InvalidInput_Throws()
     {
         var engine = new RowLevelSecurityEngine();
-        var ctx = new RowLevelSecurityEngine.RLSContext();
+        var ctx = new RLSContext();
         Assert.Throws<ArgumentException>(() => engine.GenerateFilter("", ctx));
         Assert.Throws<ArgumentNullException>(() => engine.GenerateFilter("Doc", null!));
     }
@@ -236,7 +236,7 @@ public class RowLevelSecurityEnginePredicateTests
         var engine = new RowLevelSecurityEngine();
         engine.RegisterPolicy(policy);
 
-        var filter = engine.GenerateFilter("Doc", new RowLevelSecurityEngine.RLSContext { UserId = "u1" });
+        var filter = engine.GenerateFilter("Doc", new RLSContext { UserId = "u1" });
 
         Assert.Equal("Owner = @rls_owner", filter.Sql);
         Assert.Equal("u1", filter.Parameters["rls_owner"]);

--- a/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEngineTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEngineTests.cs
@@ -18,7 +18,7 @@ public class RowLevelSecurityEngineTests
     public void GenerateFilter_NoPolicy_DefaultThrows_Throws()
     {
         var engine = new RowLevelSecurityEngine();
-        var context = new RowLevelSecurityEngine.RLSContext { UserId = "user1" };
+        var context = new RLSContext { UserId = "user1" };
 
         Assert.Throws<InvalidOperationException>(() => engine.GenerateFilter("User", context));
     }
@@ -31,11 +31,11 @@ public class RowLevelSecurityEngineTests
     public void GenerateFilter_NoPolicy_DefaultDenyAll_ReturnsDenyAllFilter()
     {
         var engine = new RowLevelSecurityEngine(RLSDefaultBehavior.DenyAll);
-        var context = new RowLevelSecurityEngine.RLSContext { UserId = "user1" };
+        var context = new RLSContext { UserId = "user1" };
 
         var filter = engine.GenerateFilter("User", context);
 
-        Assert.Same(RowLevelSecurityEngine.RLSFilter.DenyAll, filter);
+        Assert.Same(RLSFilter.DenyAll, filter);
         Assert.Equal("1=0", filter.Sql);
     }
 
@@ -47,11 +47,11 @@ public class RowLevelSecurityEngineTests
     public void GenerateFilter_NoPolicy_DefaultAllowAll_ReturnsAllowAllFilter()
     {
         var engine = new RowLevelSecurityEngine(RLSDefaultBehavior.AllowAll);
-        var context = new RowLevelSecurityEngine.RLSContext { UserId = "user1" };
+        var context = new RLSContext { UserId = "user1" };
 
         var filter = engine.GenerateFilter("User", context);
 
-        Assert.Same(RowLevelSecurityEngine.RLSFilter.AllowAll, filter);
+        Assert.Same(RLSFilter.AllowAll, filter);
         Assert.Equal("1=1", filter.Sql);
     }
 
@@ -65,9 +65,9 @@ public class RowLevelSecurityEngineTests
         var engine = new RowLevelSecurityEngine();
         engine.RegisterUnrestricted<object>("User");
 
-        var filter = engine.GenerateFilter("User", new RowLevelSecurityEngine.RLSContext());
+        var filter = engine.GenerateFilter("User", new RLSContext());
 
-        Assert.Same(RowLevelSecurityEngine.RLSFilter.AllowAll, filter);
+        Assert.Same(RLSFilter.AllowAll, filter);
     }
 
     /// <summary>Tests that department-based policy parameterizes the value.</summary>
@@ -78,7 +78,7 @@ public class RowLevelSecurityEngineTests
         var policy = RowLevelSecurityEngine.CreateDepartmentBased("Department");
         policy.ResourceType = "User";
         engine.RegisterPolicy(policy);
-        var context = new RowLevelSecurityEngine.RLSContext { UserId = "user1", Department = "Sales" };
+        var context = new RLSContext { UserId = "user1", Department = "Sales" };
 
         var filter = engine.GenerateFilter("User", context);
 
@@ -94,7 +94,7 @@ public class RowLevelSecurityEngineTests
         var policy = RowLevelSecurityEngine.CreateTenantBased("TenantId");
         policy.ResourceType = "User";
         engine.RegisterPolicy(policy);
-        var context = new RowLevelSecurityEngine.RLSContext
+        var context = new RLSContext
         {
             UserId = "user1",
             AllowedTenants = new List<string> { "tenant1", "tenant2" }
@@ -115,11 +115,11 @@ public class RowLevelSecurityEngineTests
         var policy = RowLevelSecurityEngine.CreateTenantBased("TenantId");
         policy.ResourceType = "User";
         engine.RegisterPolicy(policy);
-        var context = new RowLevelSecurityEngine.RLSContext { UserId = "user1" };
+        var context = new RLSContext { UserId = "user1" };
 
         var filter = engine.GenerateFilter("User", context);
 
-        Assert.Same(RowLevelSecurityEngine.RLSFilter.DenyAll, filter);
+        Assert.Same(RLSFilter.DenyAll, filter);
     }
 
     /// <summary>Injection attempt via tenant value does not break the SQL.</summary>
@@ -131,7 +131,7 @@ public class RowLevelSecurityEngineTests
         policy.ResourceType = "User";
         engine.RegisterPolicy(policy);
         var malicious = "x') OR 1=1 --";
-        var context = new RowLevelSecurityEngine.RLSContext
+        var context = new RLSContext
         {
             AllowedTenants = new List<string> { malicious }
         };


### PR DESCRIPTION
## Summary

Extracts seven types nested inside their host engine classes to top-level types in the same namespaces. Closes #7.

| Was (nested) | Now (top-level) | Namespace |
|---|---|---|
| `RowLevelSecurityEngine.RLSContext` | `RLSContext` | `QuerySpec.Core.Security` |
| `RowLevelSecurityEngine.RLSPolicy` | `RLSPolicy` | `QuerySpec.Core.Security` |
| `RowLevelSecurityEngine.RLSFilter` | `RLSFilter` | `QuerySpec.Core.Security` |
| `DataMaskingEngine.MaskingStrategy` | `MaskingStrategy` | `QuerySpec.Core.Security` |
| `DynamicPermissionEvaluator.PermissionType` | `PermissionType` | `QuerySpec.Core.Security` |
| `DynamicPermissionEvaluator.DynamicContext` | `DynamicContext` | `QuerySpec.Core.Security` |
| `CircuitBreaker.CircuitState` | `CircuitState` | `QuerySpec.Core.Resilience` |

Each new type lives in its own file under the same namespace. Host engines reference them by simple name.

## Why

Nesting froze the containment as a binding contract: any future move broke consumer code qualifying as `Engine.NestedType`. None of the seven types depended on any private engine state — they are pure data carriers and enums — so nesting bought no encapsulation in exchange for the SemVer cost.

## Migration

Consumers using a `using QuerySpec.Core.Security;` (or `QuerySpec.Core.Resilience;`) remove the `HostEngine.` qualifier:

```diff
- var ctx = new RowLevelSecurityEngine.RLSContext { UserId = "u1" };
+ var ctx = new RLSContext { UserId = "u1" };

- engine.RegisterPolicy(new RowLevelSecurityEngine.RLSPolicy { ... });
+ engine.RegisterPolicy(new RLSPolicy { ... });

- masker.RegisterFieldMask("Email", DataMaskingEngine.MaskingStrategy.EmailMask);
+ masker.RegisterFieldMask("Email", MaskingStrategy.EmailMask);
```

The namespace stays the same, so a single search-replace across the consumer's solution covers it.

## Why no source-compat shim

- C# enums can't be subclassed, so `MaskingStrategy`, `PermissionType`, `CircuitState` cannot have a `[Obsolete]` nested alias.
- For the class types, a nested class inheriting from the top-level would create a distinct CLR type — not transparent for `is`/`as`/method overload resolution.
- The mechanical rename is one search-replace per consumer; the shim would weigh more than it saves.

The rename is documented for the rotation release notes.

## Tests

258 tests still pass on net8/9/10 (210 Core + 48 EFCore). All test/sample/benchmark files updated by mechanical sed.

## SemVer

`refactor!` — every consumer using a fully-qualified nested name must drop the `HostEngine.` prefix.

Fixes #7