### PR TITLE
chore(release): explicit deterministic build + sbom generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,47 @@ jobs:
     - name: Lint last commit (push)
       if: github.event_name == 'push'
       run: npx commitlint --from=HEAD~1 --to=HEAD --verbose
+
+  reproducibility:
+    name: Reproducibility check (deterministic build)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: First build
+      run: |
+        dotnet build src/QuerySpec.Core/QuerySpec.Core.csproj \
+          --configuration Release \
+          -p:ContinuousIntegrationBuild=true \
+          -p:Deterministic=true \
+          -p:SignAssembly=false -p:DelaySign=false \
+          /bl:msbuild1.binlog
+        cp src/QuerySpec.Core/bin/Release/net10.0/QuerySpec.Core.dll /tmp/build1.dll
+
+    - name: Clean and second build
+      run: |
+        dotnet clean src/QuerySpec.Core/QuerySpec.Core.csproj --configuration Release
+        rm -rf src/QuerySpec.Core/bin src/QuerySpec.Core/obj
+        dotnet build src/QuerySpec.Core/QuerySpec.Core.csproj \
+          --configuration Release \
+          -p:ContinuousIntegrationBuild=true \
+          -p:Deterministic=true \
+          -p:SignAssembly=false -p:DelaySign=false \
+          /bl:msbuild2.binlog
+        cp src/QuerySpec.Core/bin/Release/net10.0/QuerySpec.Core.dll /tmp/build2.dll
+
+    - name: Compare assembly hashes
+      run: |
+        set -euo pipefail
+        h1=$(sha256sum /tmp/build1.dll | cut -d' ' -f1)
+        h2=$(sha256sum /tmp/build2.dll | cut -d' ' -f1)
+        echo "Build 1 sha256: $h1"
+        echo "Build 2 sha256: $h2"
+        if [[ "$h1" != "$h2" ]]; then
+          echo "::error::Builds are not byte-identical. Deterministic build is broken."
+          exit 1
+        fi
+        echo "Builds are byte-identical."

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,10 @@
     <!-- Single version for all packages -->
     <Version>1.0.0</Version>
 
-    <!-- Deterministic builds for reproducibility -->
+    <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+
+    <GenerateSBOM Condition="'$(IsPackable)' != 'false'">true</GenerateSBOM>
 
     <!-- SourceLink: enables source debugging for NuGet consumers -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -49,6 +51,7 @@
 
   <ItemGroup Condition="'$(IsPackable)' != 'false'">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.24454.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.1" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Unshipped.txt" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Three release-engineering controls enterprise security reviews routinely require:

### 1. Explicit `<Deterministic>true</Deterministic>`

Set in `Directory.Build.props`. The .NET SDK already defaults this to true; this commit makes the intent explicit in source so it survives any future SDK default change.

### 2. SBOM embedded in every shipped .nupkg

`Microsoft.Sbom.Targets` 3.0.1 (Microsoft-published, official) referenced from `Directory.Build.props` with `PrivateAssets=All`, gated on `IsPackable`. `GenerateSBOM=true` triggers automatic SPDX 2.2 manifest generation during `dotnet pack`.

Verified: the produced `.nupkg` now contains:

```
_manifest/spdx_2.2/manifest.spdx.json         (24 KB)
_manifest/spdx_2.2/manifest.spdx.json.sha256
```

Auditors and security tools can extract the SBOM directly from the package without a separate download or release-asset hunt.

### 3. CI reproducibility check

New `reproducibility` job in `ci.yml` builds `QuerySpec.Core` twice from a clean tree (Release, `ContinuousIntegrationBuild=true`, `Deterministic=true`) and asserts the resulting net10 DLL is byte-identical via `sha256sum`. Any future regression in determinism (a new transitive that injects timestamps, a forgotten property override) fails CI.

## What's deferred

**Code-signing the .nupkg with an Authenticode certificate** — paid certificate procurement is out of scope. Tracked as **#34**. The package remains trusted via NuGet's repository-side signing in the meantime.

## Tests

258 tests pass on net8/9/10. No behaviour changes to the runtime code paths.

Fixes #16
Refs #34