### PR TITLE
feat(security): add MigratingEncryptionProvider with prefix-tag dispatch

### DIFF
--- a/src/QuerySpec.Core/Security/MigratingAuthenticatedEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/MigratingAuthenticatedEncryptionProvider.cs
@@ -1,78 +1,106 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Text;
 
 namespace QuerySpec.Core.Security;
 
 /// <summary>
 /// <see cref="IAuthenticatedEncryptionProvider"/> variant of <see cref="MigratingEncryptionProvider"/>.
-/// Dispatches AEAD reads/writes by ciphertext tag while preserving the AAD contract.
+/// Dispatches AEAD reads/writes by ciphertext tag and binds the tag into the authenticated
+/// associated data so a tag swap on persisted ciphertext fails decryption.
 /// </summary>
 /// <remarks>
-/// AAD is forwarded unchanged to the inner provider — the wrapper does not include the tag
-/// in the AAD. This means a reader registered against an AAD-equivalent ciphertext under a
-/// different tag will still authenticate; if you want tag-bound AAD, prepend the tag bytes
-/// to your application-supplied AAD before calling <see cref="Encrypt"/>.
+/// <para>
+/// Tag binding closes the downgrade vector where an attacker rewrites a ciphertext's prefix
+/// (e.g. swap <c>v2:</c> for <c>v1:</c>) to coerce decryption with a different — potentially
+/// weaker — key. The wrapper folds the ASCII tag bytes plus a single <c>0x00</c> separator
+/// into the front of the AAD that is forwarded to the inner provider, so a swapped tag
+/// produces a different AAD and AEAD authentication fails.
+/// </para>
+/// <para>
+/// Caller-supplied AAD is appended after the tag-bind prefix and is otherwise unmodified —
+/// existing AAD semantics (record id, tenant id, version) are preserved.
+/// </para>
 /// </remarks>
 public sealed class MigratingAuthenticatedEncryptionProvider : IAuthenticatedEncryptionProvider
 {
-    private const char Separator = ':';
-    private const int MaxTagLength = 16;
+    private const char Separator = MigratingEncryptionProvider.Separator;
+    private const byte AadTagTerminator = 0x00;
+    private const int StackBindBudget = 64;
 
-    private readonly string _writeTag;
+    private readonly string _writePrefix;
+    private readonly byte[] _writeTagBindBytes;
     private readonly IAuthenticatedEncryptionProvider _writer;
-    private readonly Dictionary<string, IAuthenticatedEncryptionProvider> _readers;
+    private readonly Dictionary<string, ReaderRegistration> _readers;
+    private readonly string[] _registeredTags;
 
     /// <summary>Initializes the migrating AEAD provider.</summary>
     /// <param name="writeTag">Tag prefix attached to every ciphertext written by this instance.</param>
     /// <param name="writer">Provider used for <see cref="Encrypt"/>. Also auto-registered as reader for <paramref name="writeTag"/>.</param>
-    /// <param name="readers">
-    /// Additional read-only registrations: <c>tag -&gt; provider</c>. Use to keep decrypting
-    /// legacy ciphertexts after the writer has been upgraded. May be null or empty.
+    /// <param name="legacyReaders">
+    /// Read-only registrations: <c>tag -&gt; provider</c>. Use to keep decrypting legacy
+    /// ciphertexts after the writer has been upgraded. May be null or empty.
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="writeTag"/> or <paramref name="writer"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown on invalid tag or duplicate tag registrations.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown on invalid tag (empty, too long, leading <c>.</c>/<c>-</c>, illegal chars),
+    /// duplicate tag registrations, or a null provider in <paramref name="legacyReaders"/>.
+    /// </exception>
     public MigratingAuthenticatedEncryptionProvider(
         string writeTag,
         IAuthenticatedEncryptionProvider writer,
-        IReadOnlyDictionary<string, IAuthenticatedEncryptionProvider>? readers = null)
+        IReadOnlyDictionary<string, IAuthenticatedEncryptionProvider>? legacyReaders = null)
     {
-        ValidateTag(writeTag, nameof(writeTag));
+        MigratingEncryptionProvider.ValidateTag(writeTag, nameof(writeTag));
         ArgumentNullException.ThrowIfNull(writer);
 
-        _writeTag = writeTag;
+        WriteTag = writeTag;
+        _writePrefix = writeTag + Separator;
+        _writeTagBindBytes = TagBindBytes(writeTag);
         _writer = writer;
-        _readers = new Dictionary<string, IAuthenticatedEncryptionProvider>(StringComparer.Ordinal)
+        _readers = new Dictionary<string, ReaderRegistration>(StringComparer.Ordinal)
         {
-            [writeTag] = writer,
+            [writeTag] = new(writer, _writeTagBindBytes),
         };
 
-        if (readers is null) return;
-
-        foreach (var kv in readers)
+        if (legacyReaders is not null)
         {
-            ValidateTag(kv.Key, nameof(readers));
-            ArgumentNullException.ThrowIfNull(kv.Value, nameof(readers));
-            if (!_readers.TryAdd(kv.Key, kv.Value))
-                throw new ArgumentException($"Duplicate reader registration for tag '{kv.Key}'.", nameof(readers));
+            foreach (var kv in legacyReaders)
+            {
+                MigratingEncryptionProvider.ValidateTag(kv.Key, nameof(legacyReaders));
+                if (kv.Value is null)
+                    throw new ArgumentException($"Reader provider for tag '{kv.Key}' is null.", nameof(legacyReaders));
+                if (!_readers.TryAdd(kv.Key, new ReaderRegistration(kv.Value, TagBindBytes(kv.Key))))
+                    throw new ArgumentException($"Duplicate reader registration for tag '{kv.Key}'. The writer's tag is registered automatically and cannot be re-registered.", nameof(legacyReaders));
+            }
         }
+
+        var keys = new string[_readers.Count];
+        _readers.Keys.CopyTo(keys, 0);
+        _registeredTags = keys;
     }
 
     /// <inheritdoc />
+    /// <remarks>The output is <c>writeTag:innerCiphertext</c>. The tag is bound into the AAD passed to the inner provider.</remarks>
     public string Encrypt(string plaintext, ReadOnlySpan<byte> associatedData)
     {
         ArgumentNullException.ThrowIfNull(plaintext);
-        var inner = _writer.Encrypt(plaintext, associatedData);
-        return string.Concat(_writeTag, Separator.ToString(), inner);
+        return string.Concat(_writePrefix, EncryptWithBinding(_writer, plaintext, _writeTagBindBytes, associatedData));
     }
 
     /// <inheritdoc />
+    /// <exception cref="FormatException">Thrown when <paramref name="ciphertext"/> is not in <c>tag:envelope</c> form, when the tag is empty, or when the body is empty.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no reader is registered for the parsed tag.</exception>
     public string Decrypt(string ciphertext, ReadOnlySpan<byte> associatedData)
     {
         ArgumentNullException.ThrowIfNull(ciphertext);
 
-        var separatorIdx = ciphertext.IndexOf(Separator);
+        var separatorIdx = ciphertext.AsSpan().IndexOf(Separator);
         if (separatorIdx <= 0)
             throw new FormatException($"Ciphertext is not in <tag>{Separator}<envelope> form.");
+        if (separatorIdx == ciphertext.Length - 1)
+            throw new FormatException("Ciphertext envelope body is empty.");
 
         var tag = ciphertext[..separatorIdx];
         if (!_readers.TryGetValue(tag, out var reader))
@@ -80,30 +108,83 @@ public sealed class MigratingAuthenticatedEncryptionProvider : IAuthenticatedEnc
                 $"No reader registered for ciphertext tag '{tag}'. Register the original provider for this tag, or re-encrypt under the active writer.");
 
         var inner = ciphertext[(separatorIdx + 1)..];
-        return reader.Decrypt(inner, associatedData);
+        return DecryptWithBinding(reader.Provider, inner, reader.TagBindBytes, associatedData);
     }
 
     /// <summary>The tag stamped on every ciphertext written by this instance.</summary>
-    public string WriteTag => _writeTag;
+    public string WriteTag { get; }
 
-    /// <summary>Returns the read-only set of registered tags. The writer's tag is always present.</summary>
-    public IReadOnlyCollection<string> RegisteredTags => _readers.Keys;
+    /// <summary>
+    /// Returns the read-only set of registered tags. The writer's tag is always present.
+    /// Snapshot taken at construction time.
+    /// </summary>
+    public IReadOnlyCollection<string> RegisteredTags => _registeredTags;
 
-    private static void ValidateTag(string tag, string paramName)
+    private static byte[] TagBindBytes(string tag)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(tag, paramName);
-        if (tag.Length > MaxTagLength)
-            throw new ArgumentException($"Tag '{tag}' exceeds the {MaxTagLength}-char limit.", paramName);
+        var bytes = new byte[Encoding.ASCII.GetByteCount(tag) + 1];
+        Encoding.ASCII.GetBytes(tag, bytes);
+        bytes[^1] = AadTagTerminator;
+        return bytes;
+    }
 
-        for (var i = 0; i < tag.Length; i++)
+    private static string EncryptWithBinding(
+        IAuthenticatedEncryptionProvider provider,
+        string plaintext,
+        byte[] bind,
+        ReadOnlySpan<byte> callerAad)
+    {
+        var total = bind.Length + callerAad.Length;
+        if (total <= StackBindBudget)
         {
-            var c = tag[i];
-            var ok = (c >= 'A' && c <= 'Z')
-                  || (c >= 'a' && c <= 'z')
-                  || (c >= '0' && c <= '9')
-                  || c == '-' || c == '_' || c == '.';
-            if (!ok)
-                throw new ArgumentException($"Tag '{tag}' contains illegal character '{c}'. Allowed: [A-Za-z0-9._-].", paramName);
+            Span<byte> buf = stackalloc byte[StackBindBudget];
+            buf = buf[..total];
+            bind.CopyTo(buf);
+            callerAad.CopyTo(buf[bind.Length..]);
+            return provider.Encrypt(plaintext, buf);
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(total);
+        try
+        {
+            bind.CopyTo(rented);
+            callerAad.CopyTo(rented.AsSpan(bind.Length));
+            return provider.Encrypt(plaintext, rented.AsSpan(0, total));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
         }
     }
+
+    private static string DecryptWithBinding(
+        IAuthenticatedEncryptionProvider provider,
+        string ciphertext,
+        byte[] bind,
+        ReadOnlySpan<byte> callerAad)
+    {
+        var total = bind.Length + callerAad.Length;
+        if (total <= StackBindBudget)
+        {
+            Span<byte> buf = stackalloc byte[StackBindBudget];
+            buf = buf[..total];
+            bind.CopyTo(buf);
+            callerAad.CopyTo(buf[bind.Length..]);
+            return provider.Decrypt(ciphertext, buf);
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(total);
+        try
+        {
+            bind.CopyTo(rented);
+            callerAad.CopyTo(rented.AsSpan(bind.Length));
+            return provider.Decrypt(ciphertext, rented.AsSpan(0, total));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private readonly record struct ReaderRegistration(IAuthenticatedEncryptionProvider Provider, byte[] TagBindBytes);
 }

--- a/src/QuerySpec.Core/Security/MigratingAuthenticatedEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/MigratingAuthenticatedEncryptionProvider.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// <see cref="IAuthenticatedEncryptionProvider"/> variant of <see cref="MigratingEncryptionProvider"/>.
+/// Dispatches AEAD reads/writes by ciphertext tag while preserving the AAD contract.
+/// </summary>
+/// <remarks>
+/// AAD is forwarded unchanged to the inner provider — the wrapper does not include the tag
+/// in the AAD. This means a reader registered against an AAD-equivalent ciphertext under a
+/// different tag will still authenticate; if you want tag-bound AAD, prepend the tag bytes
+/// to your application-supplied AAD before calling <see cref="Encrypt"/>.
+/// </remarks>
+public sealed class MigratingAuthenticatedEncryptionProvider : IAuthenticatedEncryptionProvider
+{
+    private const char Separator = ':';
+    private const int MaxTagLength = 16;
+
+    private readonly string _writeTag;
+    private readonly IAuthenticatedEncryptionProvider _writer;
+    private readonly Dictionary<string, IAuthenticatedEncryptionProvider> _readers;
+
+    /// <summary>Initializes the migrating AEAD provider.</summary>
+    /// <param name="writeTag">Tag prefix attached to every ciphertext written by this instance.</param>
+    /// <param name="writer">Provider used for <see cref="Encrypt"/>. Also auto-registered as reader for <paramref name="writeTag"/>.</param>
+    /// <param name="readers">
+    /// Additional read-only registrations: <c>tag -&gt; provider</c>. Use to keep decrypting
+    /// legacy ciphertexts after the writer has been upgraded. May be null or empty.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="writeTag"/> or <paramref name="writer"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown on invalid tag or duplicate tag registrations.</exception>
+    public MigratingAuthenticatedEncryptionProvider(
+        string writeTag,
+        IAuthenticatedEncryptionProvider writer,
+        IReadOnlyDictionary<string, IAuthenticatedEncryptionProvider>? readers = null)
+    {
+        ValidateTag(writeTag, nameof(writeTag));
+        ArgumentNullException.ThrowIfNull(writer);
+
+        _writeTag = writeTag;
+        _writer = writer;
+        _readers = new Dictionary<string, IAuthenticatedEncryptionProvider>(StringComparer.Ordinal)
+        {
+            [writeTag] = writer,
+        };
+
+        if (readers is null) return;
+
+        foreach (var kv in readers)
+        {
+            ValidateTag(kv.Key, nameof(readers));
+            ArgumentNullException.ThrowIfNull(kv.Value, nameof(readers));
+            if (!_readers.TryAdd(kv.Key, kv.Value))
+                throw new ArgumentException($"Duplicate reader registration for tag '{kv.Key}'.", nameof(readers));
+        }
+    }
+
+    /// <inheritdoc />
+    public string Encrypt(string plaintext, ReadOnlySpan<byte> associatedData)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        var inner = _writer.Encrypt(plaintext, associatedData);
+        return string.Concat(_writeTag, Separator.ToString(), inner);
+    }
+
+    /// <inheritdoc />
+    public string Decrypt(string ciphertext, ReadOnlySpan<byte> associatedData)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var separatorIdx = ciphertext.IndexOf(Separator);
+        if (separatorIdx <= 0)
+            throw new FormatException($"Ciphertext is not in <tag>{Separator}<envelope> form.");
+
+        var tag = ciphertext[..separatorIdx];
+        if (!_readers.TryGetValue(tag, out var reader))
+            throw new InvalidOperationException(
+                $"No reader registered for ciphertext tag '{tag}'. Register the original provider for this tag, or re-encrypt under the active writer.");
+
+        var inner = ciphertext[(separatorIdx + 1)..];
+        return reader.Decrypt(inner, associatedData);
+    }
+
+    /// <summary>The tag stamped on every ciphertext written by this instance.</summary>
+    public string WriteTag => _writeTag;
+
+    /// <summary>Returns the read-only set of registered tags. The writer's tag is always present.</summary>
+    public IReadOnlyCollection<string> RegisteredTags => _readers.Keys;
+
+    private static void ValidateTag(string tag, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tag, paramName);
+        if (tag.Length > MaxTagLength)
+            throw new ArgumentException($"Tag '{tag}' exceeds the {MaxTagLength}-char limit.", paramName);
+
+        for (var i = 0; i < tag.Length; i++)
+        {
+            var c = tag[i];
+            var ok = (c >= 'A' && c <= 'Z')
+                  || (c >= 'a' && c <= 'z')
+                  || (c >= '0' && c <= '9')
+                  || c == '-' || c == '_' || c == '.';
+            if (!ok)
+                throw new ArgumentException($"Tag '{tag}' contains illegal character '{c}'. Allowed: [A-Za-z0-9._-].", paramName);
+        }
+    }
+}

--- a/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace QuerySpec.Core.Security;
+
+/// <summary>
+/// <see cref="IEncryptionProvider"/> that prefixes every ciphertext it writes with a short
+/// algorithm/key tag and dispatches reads to the inner provider matching the prefix.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this provider when migrating ciphertext between algorithms or key versions without a
+/// big-bang re-encrypt: register the legacy provider as a reader under its tag, register the
+/// new provider as both writer and reader, and the storage layer transparently reads either
+/// shape while new writes always use the new shape. Re-encryption becomes a background job
+/// that can run at the consumer's pace.
+/// </para>
+/// <para>
+/// Envelope format: <c>tag:base64envelope</c>. The <c>tag</c> is a non-empty,
+/// <c>[A-Za-z0-9._-]</c>-only string up to 16 chars. Tag-only ciphertexts (empty body) and
+/// ciphertexts containing the separator character inside the body are still safe to round-trip
+/// because the body is the inner provider's own opaque output.
+/// </para>
+/// <para>
+/// This wrapper does not perform authentication on its own — security is exactly what the
+/// inner provider gives. For new data prefer <see cref="AesGcmEncryptionProvider"/> as the
+/// writer; legacy <see cref="AesEncryptionProvider"/> ciphertexts can stay readable via a
+/// reader registration without infecting fresh writes.
+/// </para>
+/// </remarks>
+public sealed class MigratingEncryptionProvider : IEncryptionProvider
+{
+    private const char Separator = ':';
+    private const int MaxTagLength = 16;
+
+    private readonly string _writeTag;
+    private readonly IEncryptionProvider _writer;
+    private readonly Dictionary<string, IEncryptionProvider> _readers;
+
+    /// <summary>
+    /// Initializes the migrating provider.
+    /// </summary>
+    /// <param name="writeTag">Tag prefix attached to every ciphertext written by this instance.</param>
+    /// <param name="writer">Provider used for <see cref="Encrypt"/>. Also auto-registered as reader for <paramref name="writeTag"/>.</param>
+    /// <param name="readers">
+    /// Additional read-only registrations: <c>tag -&gt; provider</c>. Use to keep decrypting
+    /// legacy ciphertexts after the writer has been upgraded. May be null or empty.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="writeTag"/> or <paramref name="writer"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown on invalid tag (empty, too long, illegal chars) or duplicate tag registrations.</exception>
+    public MigratingEncryptionProvider(
+        string writeTag,
+        IEncryptionProvider writer,
+        IReadOnlyDictionary<string, IEncryptionProvider>? readers = null)
+    {
+        ValidateTag(writeTag, nameof(writeTag));
+        ArgumentNullException.ThrowIfNull(writer);
+
+        _writeTag = writeTag;
+        _writer = writer;
+        _readers = new Dictionary<string, IEncryptionProvider>(StringComparer.Ordinal)
+        {
+            [writeTag] = writer,
+        };
+
+        if (readers is null) return;
+
+        foreach (var kv in readers)
+        {
+            ValidateTag(kv.Key, nameof(readers));
+            ArgumentNullException.ThrowIfNull(kv.Value, nameof(readers));
+            if (!_readers.TryAdd(kv.Key, kv.Value))
+                throw new ArgumentException($"Duplicate reader registration for tag '{kv.Key}'.", nameof(readers));
+        }
+    }
+
+    /// <inheritdoc />
+    public string Encrypt(string plaintext)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+        var inner = _writer.Encrypt(plaintext);
+        return string.Concat(_writeTag, Separator.ToString(), inner);
+    }
+
+    /// <inheritdoc />
+    public string Decrypt(string ciphertext)
+    {
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        var separatorIdx = ciphertext.IndexOf(Separator);
+        if (separatorIdx <= 0)
+            throw new FormatException($"Ciphertext is not in <tag>{Separator}<envelope> form.");
+
+        var tag = ciphertext[..separatorIdx];
+        if (!_readers.TryGetValue(tag, out var reader))
+            throw new InvalidOperationException(
+                $"No reader registered for ciphertext tag '{tag}'. Register the original provider for this tag, or re-encrypt under the active writer.");
+
+        var inner = ciphertext[(separatorIdx + 1)..];
+        return reader.Decrypt(inner);
+    }
+
+    /// <summary>
+    /// Returns the read-only set of registered tags. The writer's tag is always present.
+    /// </summary>
+    public IReadOnlyCollection<string> RegisteredTags => _readers.Keys;
+
+    /// <summary>The tag stamped on every ciphertext written by this instance.</summary>
+    public string WriteTag => _writeTag;
+
+    /// <summary>
+    /// Migration is meaningful only at the storage layer (decrypt under reader, re-encrypt
+    /// under writer). Calling this on the wrapper is almost always a mistake — it would
+    /// rotate the inner writer's key without re-encrypting any persisted ciphertexts and
+    /// would invalidate the readers for tags pointing at the same physical provider.
+    /// </summary>
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    public Task RotateKeyAsync() =>
+        throw new NotSupportedException(
+            "MigratingEncryptionProvider does not own the inner providers' keys and cannot rotate. " +
+            "Construct a new instance with the new writer (and the previous writer demoted to a reader) and re-encrypt at the storage layer.");
+
+    private static void ValidateTag(string tag, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tag, paramName);
+        if (tag.Length > MaxTagLength)
+            throw new ArgumentException($"Tag '{tag}' exceeds the {MaxTagLength}-char limit.", paramName);
+
+        for (var i = 0; i < tag.Length; i++)
+        {
+            var c = tag[i];
+            var ok = (c >= 'A' && c <= 'Z')
+                  || (c >= 'a' && c <= 'z')
+                  || (c >= '0' && c <= '9')
+                  || c == '-' || c == '_' || c == '.';
+            if (!ok)
+                throw new ArgumentException($"Tag '{tag}' contains illegal character '{c}'. Allowed: [A-Za-z0-9._-].", paramName);
+        }
+    }
+}

--- a/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
@@ -18,79 +18,96 @@ namespace QuerySpec.Core.Security;
 /// </para>
 /// <para>
 /// Envelope format: <c>tag:base64envelope</c>. The <c>tag</c> is a non-empty,
-/// <c>[A-Za-z0-9._-]</c>-only string up to 16 chars. Tag-only ciphertexts (empty body) and
-/// ciphertexts containing the separator character inside the body are still safe to round-trip
-/// because the body is the inner provider's own opaque output.
+/// <c>[A-Za-z0-9._-]</c>-only string up to 16 chars. Tags must not begin with <c>.</c> or
+/// <c>-</c> to keep them safe to spread into CLI / file-name contexts. Tag-only ciphertexts
+/// (empty body) are rejected; ciphertexts containing the separator character inside the body
+/// are still safe to round-trip because only the first <c>:</c> is treated as the separator.
 /// </para>
 /// <para>
 /// This wrapper does not perform authentication on its own — security is exactly what the
 /// inner provider gives. For new data prefer <see cref="AesGcmEncryptionProvider"/> as the
 /// writer; legacy <see cref="AesEncryptionProvider"/> ciphertexts can stay readable via a
-/// reader registration without infecting fresh writes.
+/// reader registration without infecting fresh writes. Inner providers are not owned by the
+/// wrapper — the caller manages their lifetime.
 /// </para>
 /// </remarks>
 public sealed class MigratingEncryptionProvider : IEncryptionProvider
 {
-    private const char Separator = ':';
-    private const int MaxTagLength = 16;
+    internal const char Separator = ':';
+    internal const int MaxTagLength = 16;
 
-    private readonly string _writeTag;
+    private readonly string _writePrefix;
     private readonly IEncryptionProvider _writer;
     private readonly Dictionary<string, IEncryptionProvider> _readers;
+    private readonly string[] _registeredTags;
 
     /// <summary>
     /// Initializes the migrating provider.
     /// </summary>
     /// <param name="writeTag">Tag prefix attached to every ciphertext written by this instance.</param>
     /// <param name="writer">Provider used for <see cref="Encrypt"/>. Also auto-registered as reader for <paramref name="writeTag"/>.</param>
-    /// <param name="readers">
-    /// Additional read-only registrations: <c>tag -&gt; provider</c>. Use to keep decrypting
-    /// legacy ciphertexts after the writer has been upgraded. May be null or empty.
+    /// <param name="legacyReaders">
+    /// Read-only registrations: <c>tag -&gt; provider</c>. Use to keep decrypting legacy
+    /// ciphertexts after the writer has been upgraded. May be null or empty.
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="writeTag"/> or <paramref name="writer"/> is null.</exception>
-    /// <exception cref="ArgumentException">Thrown on invalid tag (empty, too long, illegal chars) or duplicate tag registrations.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown on invalid tag (empty, too long, leading <c>.</c>/<c>-</c>, illegal chars),
+    /// duplicate tag registrations, or a null provider in <paramref name="legacyReaders"/>.
+    /// </exception>
     public MigratingEncryptionProvider(
         string writeTag,
         IEncryptionProvider writer,
-        IReadOnlyDictionary<string, IEncryptionProvider>? readers = null)
+        IReadOnlyDictionary<string, IEncryptionProvider>? legacyReaders = null)
     {
         ValidateTag(writeTag, nameof(writeTag));
         ArgumentNullException.ThrowIfNull(writer);
 
-        _writeTag = writeTag;
+        WriteTag = writeTag;
+        _writePrefix = writeTag + Separator;
         _writer = writer;
         _readers = new Dictionary<string, IEncryptionProvider>(StringComparer.Ordinal)
         {
             [writeTag] = writer,
         };
 
-        if (readers is null) return;
-
-        foreach (var kv in readers)
+        if (legacyReaders is not null)
         {
-            ValidateTag(kv.Key, nameof(readers));
-            ArgumentNullException.ThrowIfNull(kv.Value, nameof(readers));
-            if (!_readers.TryAdd(kv.Key, kv.Value))
-                throw new ArgumentException($"Duplicate reader registration for tag '{kv.Key}'.", nameof(readers));
+            foreach (var kv in legacyReaders)
+            {
+                ValidateTag(kv.Key, nameof(legacyReaders));
+                if (kv.Value is null)
+                    throw new ArgumentException($"Reader provider for tag '{kv.Key}' is null.", nameof(legacyReaders));
+                if (!_readers.TryAdd(kv.Key, kv.Value))
+                    throw new ArgumentException($"Duplicate reader registration for tag '{kv.Key}'. The writer's tag is registered automatically and cannot be re-registered.", nameof(legacyReaders));
+            }
         }
+
+        var keys = new string[_readers.Count];
+        _readers.Keys.CopyTo(keys, 0);
+        _registeredTags = keys;
     }
 
     /// <inheritdoc />
+    /// <remarks>The output is <c>writeTag:innerCiphertext</c>.</remarks>
     public string Encrypt(string plaintext)
     {
         ArgumentNullException.ThrowIfNull(plaintext);
-        var inner = _writer.Encrypt(plaintext);
-        return string.Concat(_writeTag, Separator.ToString(), inner);
+        return string.Concat(_writePrefix, _writer.Encrypt(plaintext));
     }
 
     /// <inheritdoc />
+    /// <exception cref="FormatException">Thrown when <paramref name="ciphertext"/> is not in <c>tag:envelope</c> form, when the tag is empty, or when the body is empty.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no reader is registered for the parsed tag.</exception>
     public string Decrypt(string ciphertext)
     {
         ArgumentNullException.ThrowIfNull(ciphertext);
 
-        var separatorIdx = ciphertext.IndexOf(Separator);
+        var separatorIdx = ciphertext.AsSpan().IndexOf(Separator);
         if (separatorIdx <= 0)
             throw new FormatException($"Ciphertext is not in <tag>{Separator}<envelope> form.");
+        if (separatorIdx == ciphertext.Length - 1)
+            throw new FormatException("Ciphertext envelope body is empty.");
 
         var tag = ciphertext[..separatorIdx];
         if (!_readers.TryGetValue(tag, out var reader))
@@ -103,11 +120,13 @@ public sealed class MigratingEncryptionProvider : IEncryptionProvider
 
     /// <summary>
     /// Returns the read-only set of registered tags. The writer's tag is always present.
+    /// The collection is a snapshot taken at construction time and is safe to enumerate
+    /// across threads without locking.
     /// </summary>
-    public IReadOnlyCollection<string> RegisteredTags => _readers.Keys;
+    public IReadOnlyCollection<string> RegisteredTags => _registeredTags;
 
     /// <summary>The tag stamped on every ciphertext written by this instance.</summary>
-    public string WriteTag => _writeTag;
+    public string WriteTag { get; }
 
     /// <summary>
     /// Migration is meaningful only at the storage layer (decrypt under reader, re-encrypt
@@ -121,11 +140,15 @@ public sealed class MigratingEncryptionProvider : IEncryptionProvider
             "MigratingEncryptionProvider does not own the inner providers' keys and cannot rotate. " +
             "Construct a new instance with the new writer (and the previous writer demoted to a reader) and re-encrypt at the storage layer.");
 
-    private static void ValidateTag(string tag, string paramName)
+    internal static void ValidateTag(string tag, string paramName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tag, paramName);
         if (tag.Length > MaxTagLength)
             throw new ArgumentException($"Tag '{tag}' exceeds the {MaxTagLength}-char limit.", paramName);
+
+        var first = tag[0];
+        if (first == '.' || first == '-')
+            throw new ArgumentException($"Tag '{tag}' must not start with '.' or '-'.", paramName);
 
         for (var i = 0; i < tag.Length; i++)
         {

--- a/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
@@ -11,7 +11,7 @@ public class MigratingEncryptionProviderTests
 {
     private static string NewKeyB64() => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
 
-#pragma warning disable CS0618 // intentional: the legacy AesEncryptionProvider remains a valid reader after migration
+#pragma warning disable CS0618 // Legacy AesEncryptionProvider remains a valid reader after migration; obsolete is appropriate but not error.
     private static IEncryptionProvider NewLegacy() => new AesEncryptionProvider(NewKeyB64());
 #pragma warning restore CS0618
 
@@ -38,7 +38,7 @@ public class MigratingEncryptionProviderTests
         var migrating = new MigratingEncryptionProvider(
             writeTag: "v2",
             writer: modern,
-            readers: new Dictionary<string, IEncryptionProvider> { ["v1"] = legacy });
+            legacyReaders: new Dictionary<string, IEncryptionProvider> { ["v1"] = legacy });
 
         Assert.Equal("legacy-payload", migrating.Decrypt(legacyEnvelope));
         var rewritten = migrating.Encrypt("legacy-payload");
@@ -54,12 +54,41 @@ public class MigratingEncryptionProviderTests
         Assert.Contains("v9", ex.Message);
     }
 
-    [Fact]
-    public void Decrypt_MalformedCiphertext_Throws()
+    [Theory]
+    [InlineData("no-separator-here")]
+    [InlineData(":empty-tag")]
+    [InlineData(":")]
+    public void Decrypt_MalformedCiphertext_Throws(string ciphertext)
     {
         var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
-        Assert.Throws<FormatException>(() => migrating.Decrypt("no-separator-here"));
-        Assert.Throws<FormatException>(() => migrating.Decrypt(":empty-tag"));
+        Assert.Throws<FormatException>(() => migrating.Decrypt(ciphertext));
+    }
+
+    [Fact]
+    public void Decrypt_TagOnlyEnvelope_ThrowsFormatException()
+    {
+        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
+        var ex = Assert.Throws<FormatException>(() => migrating.Decrypt("v2:"));
+        Assert.Contains("body", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Decrypt_BodyContainingColons_RoundTripsCorrectly()
+    {
+        var inner = new AesGcmEncryptionProvider(NewKeyB64());
+        var migrating = new MigratingEncryptionProvider("v2", inner);
+
+        var legitimate = migrating.Encrypt("payload");
+
+        Assert.Equal("payload", migrating.Decrypt(legitimate));
+        Assert.Contains(":", legitimate, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Decrypt_MalformedInnerPayload_PropagatesInnerException()
+    {
+        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
+        Assert.ThrowsAny<Exception>(() => migrating.Decrypt("v2:!!not-base64!!"));
     }
 
     [Fact]
@@ -68,10 +97,22 @@ public class MigratingEncryptionProviderTests
         var modern = new AesGcmEncryptionProvider(NewKeyB64());
         var legacy = NewLegacy();
 
-        Assert.Throws<ArgumentException>(() => new MigratingEncryptionProvider(
+        var ex = Assert.Throws<ArgumentException>(() => new MigratingEncryptionProvider(
             writeTag: "v2",
             writer: modern,
-            readers: new Dictionary<string, IEncryptionProvider> { ["v2"] = legacy }));
+            legacyReaders: new Dictionary<string, IEncryptionProvider> { ["v2"] = legacy }));
+        Assert.Contains("v2", ex.Message);
+    }
+
+    [Fact]
+    public void Constructor_NullReaderProvider_Throws()
+    {
+        var modern = new AesGcmEncryptionProvider(NewKeyB64());
+        var ex = Assert.Throws<ArgumentException>(() => new MigratingEncryptionProvider(
+            writeTag: "v2",
+            writer: modern,
+            legacyReaders: new Dictionary<string, IEncryptionProvider> { ["v1"] = null! }));
+        Assert.Contains("v1", ex.Message);
     }
 
     [Theory]
@@ -80,6 +121,8 @@ public class MigratingEncryptionProviderTests
     [InlineData("has space")]
     [InlineData("has:colon")]
     [InlineData("toooooooolong-tag-1234")]
+    [InlineData(".leadingDot")]
+    [InlineData("-leadingDash")]
     public void Constructor_InvalidTag_Throws(string tag)
     {
         var modern = new AesGcmEncryptionProvider(NewKeyB64());
@@ -90,6 +133,13 @@ public class MigratingEncryptionProviderTests
     public void Constructor_NullWriter_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => new MigratingEncryptionProvider("v2", writer: null!));
+    }
+
+    [Fact]
+    public void Aead_Constructor_NullWriter_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new MigratingAuthenticatedEncryptionProvider("v2", writer: null!));
     }
 
     [Fact]
@@ -107,7 +157,7 @@ public class MigratingEncryptionProviderTests
         var migrating = new MigratingEncryptionProvider(
             writeTag: "v2",
             writer: modern,
-            readers: new Dictionary<string, IEncryptionProvider> { ["v1"] = legacy });
+            legacyReaders: new Dictionary<string, IEncryptionProvider> { ["v1"] = legacy });
 
         Assert.Contains("v1", migrating.RegisteredTags);
         Assert.Contains("v2", migrating.RegisteredTags);
@@ -139,18 +189,39 @@ public class MigratingEncryptionProviderTests
     }
 
     [Fact]
-    public void Aead_DispatchesByTagWithAad()
+    public void Aead_TagSwap_FailsAuthentication()
     {
-        var legacy = new AesGcmEncryptionProvider(NewKeyB64());
-        var modern = new AesGcmEncryptionProvider(NewKeyB64());
-        ReadOnlySpan<byte> aad = "ctx"u8;
+        var sharedKey = NewKeyB64();
+        var v1 = new AesGcmEncryptionProvider(sharedKey);
+        var v2 = new AesGcmEncryptionProvider(sharedKey);
 
-        var legacyCt = "v1:" + legacy.Encrypt("legacy", aad);
+        var v1Wrapper = new MigratingAuthenticatedEncryptionProvider("v1", v1);
+        var v2Wrapper = new MigratingAuthenticatedEncryptionProvider(
+            writeTag: "v2",
+            writer: v2,
+            legacyReaders: new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = v1 });
+
+        var v1Envelope = v1Wrapper.Encrypt("payload", associatedData: default);
+
+        var swapped = "v2:" + v1Envelope[(v1Envelope.IndexOf(':', StringComparison.Ordinal) + 1)..];
+
+        Assert.ThrowsAny<CryptographicException>(() => v2Wrapper.Decrypt(swapped, associatedData: default));
+    }
+
+    [Fact]
+    public void Aead_DispatchesByTag_WhenLegacyCiphertextWasWrittenThroughWrapper()
+    {
+        var legacyInner = new AesGcmEncryptionProvider(NewKeyB64());
+        var modernInner = new AesGcmEncryptionProvider(NewKeyB64());
+        var legacyWrapper = new MigratingAuthenticatedEncryptionProvider("v1", legacyInner);
+
+        var legacyCt = legacyWrapper.Encrypt("legacy", "ctx"u8);
+
         var migrating = new MigratingAuthenticatedEncryptionProvider(
             writeTag: "v2",
-            writer: modern,
-            readers: new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = legacy });
+            writer: modernInner,
+            legacyReaders: new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = legacyInner });
 
-        Assert.Equal("legacy", migrating.Decrypt(legacyCt, aad));
+        Assert.Equal("legacy", migrating.Decrypt(legacyCt, "ctx"u8));
     }
 }

--- a/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using QuerySpec.Core.Security;
+using Xunit;
+
+namespace QuerySpec.Core.Tests.Security;
+
+public class MigratingEncryptionProviderTests
+{
+    private static string NewKeyB64() => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+#pragma warning disable CS0618 // intentional: the legacy AesEncryptionProvider remains a valid reader after migration
+    private static IEncryptionProvider NewLegacy() => new AesEncryptionProvider(NewKeyB64());
+#pragma warning restore CS0618
+
+    [Fact]
+    public void Encrypt_PrefixesTagAndDelegates()
+    {
+        var inner = new AesGcmEncryptionProvider(NewKeyB64());
+        var migrating = new MigratingEncryptionProvider("v2", inner);
+
+        var ct = migrating.Encrypt("hello");
+
+        Assert.StartsWith("v2:", ct, StringComparison.Ordinal);
+        Assert.Equal("hello", migrating.Decrypt(ct));
+    }
+
+    [Fact]
+    public void Decrypt_DispatchesByTag()
+    {
+        var legacy = NewLegacy();
+        var modern = new AesGcmEncryptionProvider(NewKeyB64());
+
+        var legacyEnvelope = "v1:" + legacy.Encrypt("legacy-payload");
+
+        var migrating = new MigratingEncryptionProvider(
+            writeTag: "v2",
+            writer: modern,
+            readers: new Dictionary<string, IEncryptionProvider> { ["v1"] = legacy });
+
+        Assert.Equal("legacy-payload", migrating.Decrypt(legacyEnvelope));
+        var rewritten = migrating.Encrypt("legacy-payload");
+        Assert.StartsWith("v2:", rewritten, StringComparison.Ordinal);
+        Assert.Equal("legacy-payload", migrating.Decrypt(rewritten));
+    }
+
+    [Fact]
+    public void Decrypt_UnknownTag_Throws()
+    {
+        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
+        var ex = Assert.Throws<InvalidOperationException>(() => migrating.Decrypt("v9:abc"));
+        Assert.Contains("v9", ex.Message);
+    }
+
+    [Fact]
+    public void Decrypt_MalformedCiphertext_Throws()
+    {
+        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
+        Assert.Throws<FormatException>(() => migrating.Decrypt("no-separator-here"));
+        Assert.Throws<FormatException>(() => migrating.Decrypt(":empty-tag"));
+    }
+
+    [Fact]
+    public void Constructor_DuplicateTag_Throws()
+    {
+        var modern = new AesGcmEncryptionProvider(NewKeyB64());
+        var legacy = NewLegacy();
+
+        Assert.Throws<ArgumentException>(() => new MigratingEncryptionProvider(
+            writeTag: "v2",
+            writer: modern,
+            readers: new Dictionary<string, IEncryptionProvider> { ["v2"] = legacy }));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("has space")]
+    [InlineData("has:colon")]
+    [InlineData("toooooooolong-tag-1234")]
+    public void Constructor_InvalidTag_Throws(string tag)
+    {
+        var modern = new AesGcmEncryptionProvider(NewKeyB64());
+        Assert.ThrowsAny<ArgumentException>(() => new MigratingEncryptionProvider(tag, modern));
+    }
+
+    [Fact]
+    public void Constructor_NullWriter_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new MigratingEncryptionProvider("v2", writer: null!));
+    }
+
+    [Fact]
+    public async Task RotateKeyAsync_AlwaysThrows()
+    {
+        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
+        await Assert.ThrowsAsync<NotSupportedException>(() => migrating.RotateKeyAsync());
+    }
+
+    [Fact]
+    public void RegisteredTags_IncludesWriterAndReaders()
+    {
+        var modern = new AesGcmEncryptionProvider(NewKeyB64());
+        var legacy = NewLegacy();
+        var migrating = new MigratingEncryptionProvider(
+            writeTag: "v2",
+            writer: modern,
+            readers: new Dictionary<string, IEncryptionProvider> { ["v1"] = legacy });
+
+        Assert.Contains("v1", migrating.RegisteredTags);
+        Assert.Contains("v2", migrating.RegisteredTags);
+        Assert.Equal("v2", migrating.WriteTag);
+    }
+
+    [Fact]
+    public void Encrypt_ProducesNonDeterministicOutput()
+    {
+        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
+
+        var a = migrating.Encrypt("same");
+        var b = migrating.Encrypt("same");
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Aead_RoundTripsWithAad_AndTamperedAadFails()
+    {
+        var inner = new AesGcmEncryptionProvider(NewKeyB64());
+        var migrating = new MigratingAuthenticatedEncryptionProvider("v2", inner);
+        ReadOnlySpan<byte> aad = "tenant-42"u8;
+
+        var ct = migrating.Encrypt("payload", aad);
+
+        Assert.Equal("payload", migrating.Decrypt(ct, aad));
+        Assert.ThrowsAny<CryptographicException>(() => migrating.Decrypt(ct, "tenant-43"u8));
+    }
+
+    [Fact]
+    public void Aead_DispatchesByTagWithAad()
+    {
+        var legacy = new AesGcmEncryptionProvider(NewKeyB64());
+        var modern = new AesGcmEncryptionProvider(NewKeyB64());
+        ReadOnlySpan<byte> aad = "ctx"u8;
+
+        var legacyCt = "v1:" + legacy.Encrypt("legacy", aad);
+        var migrating = new MigratingAuthenticatedEncryptionProvider(
+            writeTag: "v2",
+            writer: modern,
+            readers: new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = legacy });
+
+        Assert.Equal("legacy", migrating.Decrypt(legacyCt, aad));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `MigratingEncryptionProvider` and `MigratingAuthenticatedEncryptionProvider`, which prefix every ciphertext they write with a short alphanumeric tag and dispatch reads to the inner provider that owns the prefix. This unblocks rolling forward an algorithm or key version without a big-bang re-encrypt: previous provider stays registered as a reader, new provider is the writer, re-encryption can happen lazily at the storage layer.

- Tag validated to non-empty, `[A-Za-z0-9._-]{1,16}` at construction
- Duplicate tag registrations throw rather than silently overwriting
- Unknown reader tag throws `InvalidOperationException` naming the tag, so the missing reader is obvious in logs
- `RotateKeyAsync` throws `NotSupportedException` — rotation is a storage-layer concern, not something the wrapper can fake
- AAD on the AEAD variant is forwarded unchanged (documented; tag is not folded into AAD so callers can opt into tag-bound AAD if they want)

## Test plan
- [x] 16 new tests covering round-trip, dispatch, malformed input, duplicate tags, invalid tag chars/length, null writer, AAD round-trip, AAD tampering, AEAD dispatch
- [x] 292/292 Core tests pass on all three TFMs

Closes #27