### PR TITLE
chore(tests): migrate xunit v2.9.3 -> v3.2.2

### DIFF
--- a/tests/QuerySpec.Core.Tests/Caching/CacheStatsAdditionalTests.cs
+++ b/tests/QuerySpec.Core.Tests/Caching/CacheStatsAdditionalTests.cs
@@ -24,7 +24,7 @@ public class CacheStatsAdditionalTests
             tasks[t] = Task.Run(() =>
             {
                 for (var i = 0; i < perThread; i++) stats.IncrementHits();
-            });
+            }, TestContext.Current.CancellationToken);
         }
         await Task.WhenAll(tasks);
 

--- a/tests/QuerySpec.Core.Tests/Caching/MemoryCacheProviderAdditionalTests.cs
+++ b/tests/QuerySpec.Core.Tests/Caching/MemoryCacheProviderAdditionalTests.cs
@@ -47,7 +47,7 @@ public class MemoryCacheProviderAdditionalTests
     {
         var cache = new MemoryCacheProvider();
         await cache.SetAsync("k", "v", TimeSpan.FromMilliseconds(50));
-        await Task.Delay(120);
+        await Task.Delay(120, TestContext.Current.CancellationToken);
         Assert.Null(await cache.GetAsync<string>("k"));
     }
 

--- a/tests/QuerySpec.Core.Tests/Concurrency/CircuitBreakerStressTests.cs
+++ b/tests/QuerySpec.Core.Tests/Concurrency/CircuitBreakerStressTests.cs
@@ -35,7 +35,7 @@ public class CircuitBreakerStressTests
             {
                 try { await breaker.ExecuteAsync(Fail); }
                 catch { /* expected */ }
-            });
+            }, TestContext.Current.CancellationToken);
         }
         await Task.WhenAll(failureTasks);
 

--- a/tests/QuerySpec.Core.Tests/Concurrency/N1DetectionStressTests.cs
+++ b/tests/QuerySpec.Core.Tests/Concurrency/N1DetectionStressTests.cs
@@ -30,7 +30,7 @@ public class N1DetectionStressTests
                 {
                     RecordSite(engine, id, i);
                 }
-            });
+            }, TestContext.Current.CancellationToken);
         }
         await Task.WhenAll(tasks);
 

--- a/tests/QuerySpec.Core.Tests/Concurrency/RateLimiterStressTests.cs
+++ b/tests/QuerySpec.Core.Tests/Concurrency/RateLimiterStressTests.cs
@@ -38,7 +38,7 @@ public class RateLimiterStressTests
                 {
                     if (limiter.TryAcquire("k")) Interlocked.Increment(ref acquired);
                 }
-            });
+            }, TestContext.Current.CancellationToken);
         }
 
         start.Set();
@@ -71,7 +71,7 @@ public class RateLimiterStressTests
                 {
                     if (limiter.TryAcquire(key)) Interlocked.Increment(ref acquired);
                 }
-            });
+            }, TestContext.Current.CancellationToken);
         }
 
         await Task.WhenAll(tasks);

--- a/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
+++ b/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
@@ -15,8 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/QuerySpec.Core.Tests/Resilience/BulkheadPolicyTests.cs
+++ b/tests/QuerySpec.Core.Tests/Resilience/BulkheadPolicyTests.cs
@@ -43,7 +43,7 @@ public class BulkheadPolicyTests
         // Arrange
         var policy = new BulkheadPolicy(1);
         var t1 = policy.ExecuteAsync(async () => { await Task.Delay(200); return 1; });
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
 
         // Act & Assert
         await Assert.ThrowsAsync<BulkheadException>(() => policy.ExecuteAsync<int>(() => Task.FromResult(2)));

--- a/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
+++ b/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/tests/QuerySpec.EFCore.Tests/QuerySpecExpressionTranslatorTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/QuerySpecExpressionTranslatorTests.cs
@@ -39,7 +39,7 @@ public class QuerySpecExpressionTranslatorTests
             new TestEntity { Id = 1, Name = "John", Age = 25, Email = "john@test.com", CreatedAt = DateTime.UtcNow },
             new TestEntity { Id = 2, Name = "Jane", Age = 30, Email = "jane@test.com", CreatedAt = DateTime.UtcNow }
         );
-        await context.SaveChangesAsync();
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -51,7 +51,7 @@ public class QuerySpecExpressionTranslatorTests
         // Act
         var query = context.TestEntities.AsQueryable();
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(query, filter);
-        var result = await filtered.ToListAsync();
+        var result = await filtered.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -68,7 +68,7 @@ public class QuerySpecExpressionTranslatorTests
             new TestEntity { Id = 1, Name = "John", Age = 25, Email = "john@test.com", CreatedAt = DateTime.UtcNow },
             new TestEntity { Id = 2, Name = "Jane", Age = 30, Email = "jane@test.com", CreatedAt = DateTime.UtcNow }
         );
-        await context.SaveChangesAsync();
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -80,7 +80,7 @@ public class QuerySpecExpressionTranslatorTests
         // Act
         var query = context.TestEntities.AsQueryable();
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(query, filter);
-        var result = await filtered.ToListAsync();
+        var result = await filtered.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -97,7 +97,7 @@ public class QuerySpecExpressionTranslatorTests
             new TestEntity { Id = 1, Name = "John", Age = 25, Email = "john@test.com", CreatedAt = DateTime.UtcNow },
             new TestEntity { Id = 2, Name = "Jane", Age = 30, Email = "jane@test.com", CreatedAt = DateTime.UtcNow }
         );
-        await context.SaveChangesAsync();
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -109,7 +109,7 @@ public class QuerySpecExpressionTranslatorTests
         // Act
         var query = context.TestEntities.AsQueryable();
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(query, filter);
-        var result = await filtered.ToListAsync();
+        var result = await filtered.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -127,7 +127,7 @@ public class QuerySpecExpressionTranslatorTests
             new TestEntity { Id = 2, Name = "Jane", Age = 30, Email = "jane@test.com", CreatedAt = DateTime.UtcNow },
             new TestEntity { Id = 3, Name = "Bob", Age = 35, Email = "bob@test.com", CreatedAt = DateTime.UtcNow }
         );
-        await context.SaveChangesAsync();
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -139,7 +139,7 @@ public class QuerySpecExpressionTranslatorTests
         // Act
         var query = context.TestEntities.AsQueryable();
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(query, filter);
-        var result = await filtered.ToListAsync();
+        var result = await filtered.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -158,7 +158,7 @@ public class QuerySpecExpressionTranslatorTests
             new TestEntity { Id = 2, Name = "Jane", Age = 30, Email = "jane@test.com", CreatedAt = DateTime.UtcNow },
             new TestEntity { Id = 3, Name = "Bob", Age = 35, Email = "bob@test.com", CreatedAt = DateTime.UtcNow }
         );
-        await context.SaveChangesAsync();
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -171,7 +171,7 @@ public class QuerySpecExpressionTranslatorTests
         // Act
         var query = context.TestEntities.AsQueryable();
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(query, filter);
-        var result = await filtered.ToListAsync();
+        var result = await filtered.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -189,7 +189,7 @@ public class QuerySpecExpressionTranslatorTests
             new TestEntity { Id = 2, Name = "Jane", Age = 30, Email = "jane@test.com", CreatedAt = DateTime.UtcNow },
             new TestEntity { Id = 3, Name = "John", Age = 35, Email = "john2@test.com", CreatedAt = DateTime.UtcNow }
         );
-        await context.SaveChangesAsync();
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -211,7 +211,7 @@ public class QuerySpecExpressionTranslatorTests
         // Act
         var query = context.TestEntities.AsQueryable();
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(query, filter);
-        var result = await filtered.ToListAsync();
+        var result = await filtered.ToListAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);

--- a/tests/QuerySpec.EFCore.Tests/TranslatorOperatorTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/TranslatorOperatorTests.cs
@@ -457,7 +457,7 @@ public class TranslatorOperatorTests
     {
         using var ctx = new TestDb();
         ctx.Items.AddRange(Seed());
-        await ctx.SaveChangesAsync();
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var filter = new AdvancedFilterExpression
         {
@@ -467,7 +467,7 @@ public class TranslatorOperatorTests
         };
 
         var filtered = QuerySpecExpressionTranslator.ApplyFilter(ctx.Items, filter);
-        var ids = await filtered.Select(e => e.Id).ToListAsync();
+        var ids = await filtered.Select(e => e.Id).ToListAsync(TestContext.Current.CancellationToken);
         Assert.Equal(new[] { 1, 3, 4 }, ids.OrderBy(x => x));
     }
 


### PR DESCRIPTION
## Summary
Bumps both test projects from xunit 2.9.3 / xunit.runner.visualstudio 3.1.4 to xunit.v3 3.2.2 / xunit.runner.visualstudio 3.1.5. Source edits are mechanical: each `Task.Run` / `Task.Delay` / EF `*Async()` call inside a test now forwards `TestContext.Current.CancellationToken` so the v3 harness can cancel responsively (xUnit1051 analyzer rule, treated as error here because of `TreatWarningsAsErrors`).

## Test plan
- [x] Builds clean on net8/net9/net10 with `TreatWarningsAsErrors=true`
- [x] 329/329 Core tests pass on all three TFMs
- [x] 49/49 EFCore tests pass on all three TFMs

Closes nothing tracked separately; cleans up the v2 → v3 deferred work item.