### PR TITLE
fix(security)!: seal DataMaskingEngine

### DIFF
--- a/src/QuerySpec.Core/Security/DataMaskingEngine.cs
+++ b/src/QuerySpec.Core/Security/DataMaskingEngine.cs
@@ -30,7 +30,7 @@ namespace QuerySpec.Core.Security;
 /// to drive masking decisions from explicit metadata rather than name guesses.
 /// </para>
 /// </remarks>
-public class DataMaskingEngine
+public sealed class DataMaskingEngine
 {
     private const int HashOutputBytes = 32;
 


### PR DESCRIPTION
## Summary
Adds `sealed` to `DataMaskingEngine`. Closes #38.

`DataMaskingEngine` was the only non-sealed concrete type in `src/QuerySpec.Core/Security/` — every other classifier and provider type is sealed. The engine clones a caller-supplied secret on construction and is the central masking entry point; allowing inheritance creates a silent path for a subclass to override `Mask` / `Classify` / `IsPii` and bypass masking.

## Why now
- No virtual members, no protected ctor, no consumer subclass in the repo.
- The other Security types are already sealed; this is an inconsistency.
- Project has no demonstrable consumer base yet, so the binary-break risk is theoretical.
- The breaking-change `!` marker is on the commit so future changelog tooling picks it up.

## Test plan
- [x] 329/329 Core tests pass on net8/net9/net10
- [x] Build clean of new warnings

Closes #38