### PR TITLE
fix(ci): set OutputType=Exe on xunit.v3 test projects

### DIFF
--- a/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
+++ b/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
-    <!-- Test methods don't need XML docs. -->
+    <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
+++ b/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
Fixes CI CodeQL job failure introduced by the xunit v3 migration in #42.

xunit.v3 test projects must declare `<OutputType>Exe</OutputType>` because v3 ships test assemblies as self-running executables. Without it, the SDK skips generating the apphost binary, but Microsoft.NET.Test.Sdk's build targets still try to copy one — which `dotnet test` hides (it has its own host) but CodeQL's per-TFM `dotnet build` does not, falling over with MSB3030.

## Test plan
- [x] 329 Core + 49 EFCore tests pass on net8/9/10 under Debug
- [x] Same under Release
- [x] `obj/Release/net8.0/apphost` now exists for both test projects