### PR TITLE
fix(ci): per-run trx filenames so parallel test runners don't race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,15 @@ jobs:
       run: dotnet build QuerySpec.sln --no-restore --configuration Release -p:TreatWarningsAsErrors=true
 
     - name: Test with coverage
+      # `dotnet test QuerySpec.sln` runs all test projects across all target frameworks
+      # in parallel. `LogFileName=` would point all runners at the same trx file and
+      # the resulting overwrite race makes one of the runners exit non-zero on roughly
+      # one matrix slot per run (despite every test passing). `LogFilePrefix=` gives
+      # each test run a unique trx filename and removes the race.
       run: >
         dotnet test QuerySpec.sln
         --no-build --configuration Release
-        --logger "trx;LogFileName=test-results.trx"
+        --logger "trx;LogFilePrefix=test-results"
         --collect:"XPlat Code Coverage"
         --results-directory ./TestResults
         -- RunConfiguration.CollectSourceInformation=true


### PR DESCRIPTION
## Summary
Develop's CodeQL gate is fixed (#44), but `Build & test (.NET 8.0.x)` is now intermittently failing despite every test passing on every TFM. Six parallel trx writes from a single \`dotnet test QuerySpec.sln\` run (Core × 3 TFMs + EFCore × 3 TFMs) all target the same \`test-results.trx\` and overwrite each other — about one matrix slot per run hits a non-zero exit code as a result.

\`LogFilePrefix=test-results\` instructs the trx logger to derive a unique filename per test run, removing the race.

## Test plan
- [x] CI on this PR shows all three matrix slots green for the test step