### PR TITLE
fix(release): replace stale Directory.Build.props version with 0.0.0-local sentinel

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,11 @@
     <!-- Target frameworks for all projects -->
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
-    <!-- Single version for all packages -->
-    <Version>1.1.0</Version>
+    <!-- Sentinel version for local builds. The release pipeline (.github/workflows/release.yml)
+         passes -p:Version=<tag> on every dotnet build/pack. A local 'dotnet pack' produces
+         '0.0.0-local' packages, which are obviously non-released and cannot be confused with
+         anything published to NuGet. -->
+    <Version>0.0.0-local</Version>
 
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>


### PR DESCRIPTION
## Summary
- Replaces `<Version>1.1.0</Version>` (stale; shipped is 2.0.0) with `<Version>0.0.0-local</Version>` sentinel in `Directory.Build.props`
- The release pipeline already overrides `Version` from the git tag via `-p:Version=<tag>` ([release.yml#L120](.github/workflows/release.yml)), so the file value is only consumed by local `dotnet pack`
- A `0.0.0-local` sentinel makes a local pack obviously non-released and prevents future drift between this file and the published version

## Why
From the v2.0.0 enterprise-readiness audit (api-guardian #67, release-engineer #53). Anyone running `dotnet pack` locally was producing 1.1.0 packages — confusing, and a real risk if such a package ever made it onto an internal feed.

## Verified
- [x] `dotnet pack src/QuerySpec.Core/QuerySpec.Core.csproj --configuration Release` produces `QuerySpec.Core.0.0.0-local.nupkg` cleanly
- [x] No source changes; CI build/test paths unaffected (release pipeline still passes `-p:Version=<tag>`)