### PR TITLE
fix(security): default RLSPolicy.FilterGenerator to DenyAll instead of AllowAll

### DIFF
--- a/src/QuerySpec.Core/Security/RLSPolicy.cs
+++ b/src/QuerySpec.Core/Security/RLSPolicy.cs
@@ -14,9 +14,15 @@ public class RLSPolicy
     public string ResourceType { get; set; } = string.Empty;
 
     /// <summary>
-    /// Generates a parameterized SQL fragment for the policy.
+    /// Generates a parameterized SQL fragment for the policy. Defaults to a fail-closed
+    /// generator that returns <see cref="RLSFilter.DenyAll"/> so that a policy registered with
+    /// only a <see cref="PredicateFactory"/> (or with no SQL configured at all) does not
+    /// silently authorise unrestricted access on the SQL path. Callers that legitimately want
+    /// allow-all behaviour for a resource should call
+    /// <see cref="RowLevelSecurityEngine.RegisterUnrestricted{T}(string)"/>, which is explicit
+    /// and surfaces in code review.
     /// </summary>
-    public Func<RLSContext, RLSFilter> FilterGenerator { get; set; } = _ => RLSFilter.AllowAll;
+    public Func<RLSContext, RLSFilter> FilterGenerator { get; set; } = _ => RLSFilter.DenyAll;
 
     /// <summary>
     /// Strongly-typed predicate factory for use with IQueryable. Prefer <see cref="SetPredicate{T}"/>

--- a/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEngineTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/RowLevelSecurityEngineTests.cs
@@ -166,4 +166,22 @@ public class RowLevelSecurityEngineTests
     {
         Assert.Throws<ArgumentException>(() => RowLevelSecurityEngine.EscapeSqlLiteral("a\0b"));
     }
+
+    /// <summary>
+    /// A policy registered with no <see cref="RLSPolicy.FilterGenerator"/> set must default to
+    /// <see cref="RLSFilter.DenyAll"/>, not <see cref="RLSFilter.AllowAll"/>. Otherwise a
+    /// caller registering only a <see cref="RLSPolicy.PredicateFactory"/> would silently get
+    /// unrestricted access on the SQL path.
+    /// </summary>
+    [Fact]
+    public void GenerateFilter_PolicyWithDefaultFilterGenerator_FailsClosed()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = new RLSPolicy { ResourceType = "User" };
+        engine.RegisterPolicy(policy);
+
+        var filter = engine.GenerateFilter("User", new RLSContext { UserId = "u1" });
+
+        Assert.Same(RLSFilter.DenyAll, filter);
+    }
 }


### PR DESCRIPTION
## Summary
- `RLSPolicy.FilterGenerator` defaulted to `_ => RLSFilter.AllowAll`. A caller constructing `new RLSPolicy { ResourceType = "...", PredicateFactory = ... }` without setting `FilterGenerator` silently received an allow-all SQL filter from `RowLevelSecurityEngine.GenerateFilter` — **a fail-open default in security code**.
- Now defaults to `_ => RLSFilter.DenyAll` (fail-closed).
- Callers who legitimately want allow-all for a resource already have an explicit, code-review-visible API: `engine.RegisterUnrestricted<T>(...)`. That method continues to set `FilterGenerator = _ => RLSFilter.AllowAll` explicitly — opt-in, unchanged.

## Why
From the v2.0.0 enterprise-readiness audit (quality-reviewer #56, security-auditor's RLSPolicy fail-open finding). The engine itself is already fail-closed when no policy is registered (the `RLSDefaultBehavior.Throw` default plus `?? RLSFilter.DenyAll` on null returns), but a registered policy with only `PredicateFactory` set bypassed both safeguards.

## Compatibility
- **Behavior change for the narrow case where a policy was registered without setting `FilterGenerator`.** Previously: SQL path silently returned `AllowAll` (1=1). Now: SQL path returns `DenyAll` (1=0).
- **`GetPredicate<T>` path unaffected** — only the `GenerateFilter` (SQL) path changes.
- **Engine-level defaults unaffected** — `RLSDefaultBehavior.{Throw, DenyAll, AllowAll}` continue to work as before for unregistered resources.
- **`RegisterUnrestricted<T>` unaffected** — it explicitly sets `FilterGenerator = _ => AllowAll`, the opt-in path is preserved.
- The change is the right direction for a security fix on a patch release: silent unrestricted access → no rows returned (loud and visible).

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test tests/QuerySpec.Core.Tests` Release: **333 passed** on net8/9/10 (was 332; +1 new test locking in the fail-closed default for `new RLSPolicy { ... }` without explicit `FilterGenerator`)
- [x] Existing tests asserting engine-level `AllowAll` (`GenerateFilter_NoPolicy_DefaultAllowAll_ReturnsAllowAllFilter`, `RegisterUnrestricted_ThenGenerateFilter_ReturnsAllowAll`) continue to pass — those assert engine behavior, not policy default