### PR TITLE
fix(security): bound RegexHelper.RegexCache to prevent heap-DoS over user patterns

### DIFF
--- a/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
+++ b/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
@@ -640,14 +640,30 @@ public class QuerySpecExpressionTranslator
     /// <summary>Helper class for regex operations in EF Core-compatible expressions.</summary>
     public static class RegexHelper
     {
+        /// <summary>
+        /// Maximum number of compiled <see cref="System.Text.RegularExpressions.Regex"/> instances retained in the
+        /// cache before bulk eviction. Patterns are typically supplied by clients via filter payloads,
+        /// so an unbounded cache is a heap-DoS vector. Bulk-clear matches the policy used for
+        /// <c>PropertyCache</c> and <c>PredicateCache</c>: simple, bounded, and cheap on rebuild.
+        /// </summary>
+        internal const int RegexCacheCapacity = 512;
+
         private static readonly ConcurrentDictionary<string, System.Text.RegularExpressions.Regex> RegexCache =
             new(StringComparer.Ordinal);
 
         private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(500);
 
         /// <summary>
+        /// Clears the compiled-regex cache. Intended for tests and diagnostic scenarios; production
+        /// code does not need to call this — the cache self-bounds at <see cref="RegexCacheCapacity"/>.
+        /// </summary>
+        public static void ClearRegexCache() => RegexCache.Clear();
+
+        /// <summary>
         /// Checks if <paramref name="input"/> matches <paramref name="pattern"/>. Patterns are compiled
-        /// once and cached. Invalid patterns throw <see cref="ArgumentException"/>; a match timeout
+        /// once and cached up to <see cref="RegexCacheCapacity"/> distinct patterns; the cache is
+        /// bulk-cleared on overflow to prevent unbounded heap growth from hostile or naturally-diverse
+        /// pattern streams. Invalid patterns throw <see cref="ArgumentException"/>; a match timeout
         /// of 500ms is enforced to prevent catastrophic backtracking from freezing the host.
         /// </summary>
         public static bool IsMatch(string? input, string pattern)
@@ -659,6 +675,9 @@ public class QuerySpecExpressionTranslator
             System.Text.RegularExpressions.Regex regex;
             try
             {
+                if (RegexCache.Count >= RegexCacheCapacity)
+                    RegexCache.Clear();
+
                 regex = RegexCache.GetOrAdd(pattern, static p => new System.Text.RegularExpressions.Regex(
                     p,
                     System.Text.RegularExpressions.RegexOptions.Compiled

--- a/tests/QuerySpec.EFCore.Tests/RegexHelperTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/RegexHelperTests.cs
@@ -1,0 +1,93 @@
+using System;
+using QuerySpec.EFCore;
+using Xunit;
+
+namespace QuerySpec.EFCore.Tests;
+
+/// <summary>
+/// Unit tests for the regex cache that backs <c>FilterOperator.RegexMatch</c>. Patterns are
+/// supplied by clients via filter payloads, so the cache must be bounded — an unbounded cache
+/// over user-controlled keys is a heap-DoS vector. Capacity-bounding behaviour is verified by
+/// pumping more than <c>RegexCacheCapacity</c> distinct patterns and confirming no throw / no
+/// degraded results.
+/// </summary>
+public class RegexHelperTests
+{
+    [Fact]
+    public void IsMatch_NullInput_ReturnsFalse()
+    {
+        Assert.False(QuerySpecExpressionTranslator.RegexHelper.IsMatch(null, "^a"));
+    }
+
+    [Fact]
+    public void IsMatch_EmptyPattern_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            QuerySpecExpressionTranslator.RegexHelper.IsMatch("abc", string.Empty));
+    }
+
+    [Fact]
+    public void IsMatch_InvalidPattern_ThrowsArgumentExceptionWithPatternInMessage()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            QuerySpecExpressionTranslator.RegexHelper.IsMatch("abc", "[unclosed"));
+
+        Assert.Contains("[unclosed", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IsMatch_MatchingPattern_ReturnsTrue()
+    {
+        Assert.True(QuerySpecExpressionTranslator.RegexHelper.IsMatch("abc123", "^[a-z]+\\d+$"));
+    }
+
+    [Fact]
+    public void IsMatch_NonMatchingPattern_ReturnsFalse()
+    {
+        Assert.False(QuerySpecExpressionTranslator.RegexHelper.IsMatch("abc", "^\\d+$"));
+    }
+
+    /// <summary>
+    /// Pumping a stream of distinct patterns well in excess of the cache capacity (512) must
+    /// not crash, throw, or silently corrupt results. The cache bulk-clears on overflow so
+    /// memory stays bounded; correctness is independent of cache state.
+    /// </summary>
+    [Fact]
+    public void IsMatch_BeyondCacheCapacity_DoesNotThrow_AndKeepsCorrectResults()
+    {
+        QuerySpecExpressionTranslator.RegexHelper.ClearRegexCache();
+
+        // RegexHelper.RegexCacheCapacity is internal (512). 1024 patterns guarantee at least
+        // one bulk-clear cycle and still keep this test under a few seconds.
+        for (var i = 0; i < 1024; i++)
+        {
+            var pattern = $"^value-{i}$";
+            Assert.True(QuerySpecExpressionTranslator.RegexHelper.IsMatch($"value-{i}", pattern));
+            Assert.False(QuerySpecExpressionTranslator.RegexHelper.IsMatch($"value-{i + 1}", pattern));
+        }
+    }
+
+    /// <summary>
+    /// A pattern that re-enters after the cache has bulk-cleared must still produce the correct
+    /// result. This is the regression test for the prior unbounded-cache behavior: a hostile
+    /// stream of throwaway patterns must not poison subsequent legitimate ones.
+    /// </summary>
+    [Fact]
+    public void IsMatch_PatternRecompiledAfterEviction_StillCorrect()
+    {
+        QuerySpecExpressionTranslator.RegexHelper.ClearRegexCache();
+
+        var pinnedPattern = "^pinned$";
+        Assert.True(QuerySpecExpressionTranslator.RegexHelper.IsMatch("pinned", pinnedPattern));
+
+        // Force the cache past capacity (512) with throwaway patterns.
+        for (var i = 0; i < 600; i++)
+        {
+            QuerySpecExpressionTranslator.RegexHelper.IsMatch("x", $"^throwaway-{i}$");
+        }
+
+        // The pinned pattern was almost certainly evicted; recompile must produce identical behavior.
+        Assert.True(QuerySpecExpressionTranslator.RegexHelper.IsMatch("pinned", pinnedPattern));
+        Assert.False(QuerySpecExpressionTranslator.RegexHelper.IsMatch("not-pinned", pinnedPattern));
+    }
+}


### PR DESCRIPTION
## Summary
- `RegexHelper.RegexCache` held compiled `Regex` instances keyed by **user-supplied patterns** with no eviction. Hostile (or naturally diverse) pattern streams grew the cache without bound and pinned compiled IL on the heap. The 500ms match timeout protected per-call CPU, not heap.
- Adds `internal const int RegexCacheCapacity = 512` and a bulk-clear-on-overflow check, matching the existing `PropertyCache` (capacity 4096) and `PredicateCache` (capacity 1024) policies in the same file.
- Promotes the existing private `RegexCache` to a public diagnostic `ClearRegexCache()` method for parity with the existing `ClearPredicateCache()`.

## Why
From the v2.0.0 enterprise-readiness audit (security-auditor finding #3). DoS via heap was the only outstanding security finding rated High that was unrelated to the audit-chain fixes.

## Capacity choice
- 512 distinct compiled regex patterns is generous for legitimate workloads (typical APIs use a bounded set of filter patterns) and small enough that worst-case heap pressure is bounded to a few MB even with complex patterns.
- Bulk-clear (matching `PropertyCache` / `PredicateCache`) is simpler than LRU and adequate for a memoization cache where rebuild cost is bounded by the 500ms match timeout.
- Capacity left `internal` (not public) so it isn't locked into the SemVer contract and can be tuned in patches.

## Verified
- [x] `dotnet build src/QuerySpec.EFCore` Release: 0 errors
- [x] `dotnet test tests/QuerySpec.EFCore.Tests` Release: **56 passed** on net8/9/10 (was 49; +7 new tests covering null input, empty pattern, invalid pattern, matching, non-matching, **beyond-capacity (1024 patterns) doesn't throw and stays correct**, and **post-eviction recompile remains correct**)
- [x] No regressions in `ApplyFilterCachedTests` / `TranslatorOperatorTests` / `QuerySpecExpressionTranslatorTests`