### PR TITLE
fix(monitoring): bound MetricsCollector, return zero-report on empty, aggregate outside lock

### DIFF
--- a/src/QuerySpec.Core/Monitoring/QueryMetrics.cs
+++ b/src/QuerySpec.Core/Monitoring/QueryMetrics.cs
@@ -65,50 +65,116 @@ public class QueryMetricsReport
 }
 
 /// <summary>
-/// Metrics collector and analyzer.
+/// Metrics collector and analyzer. Retains a bounded rolling window of recorded queries
+/// (FIFO eviction at <see cref="DefaultMaxRetainedQueries"/>) so long-running hosts cannot
+/// leak memory through the metrics pipeline.
 /// </summary>
 public class MetricsCollector
 {
-    private readonly List<QueryMetrics> _metrics = new();
+    /// <summary>
+    /// Default maximum number of <see cref="QueryMetrics"/> entries retained before FIFO
+    /// eviction. Sized to keep worst-case memory at a few MB while preserving enough history
+    /// for windowed reporting on a busy host.
+    /// </summary>
+    public const int DefaultMaxRetainedQueries = 10_000;
+
+    private readonly Queue<QueryMetrics> _metrics = new();
+    private readonly int _maxRetainedQueries;
     private readonly object _lockObj = new();
 
-    /// <summary>Initializes a new metrics collector.</summary>
-    public MetricsCollector() { }
+    /// <summary>
+    /// Initialises a new metrics collector with the default retention cap of
+    /// <see cref="DefaultMaxRetainedQueries"/> entries.
+    /// </summary>
+    public MetricsCollector() : this(DefaultMaxRetainedQueries) { }
 
     /// <summary>
-    /// Records a query metric.
+    /// Initialises a new metrics collector with a configurable retention cap. When the cap
+    /// is reached, the oldest entry is evicted on each subsequent <see cref="Record"/>.
+    /// </summary>
+    /// <param name="maxRetainedQueries">Maximum number of recorded entries retained. Must be positive.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxRetainedQueries"/> is non-positive.</exception>
+    public MetricsCollector(int maxRetainedQueries)
+    {
+        if (maxRetainedQueries <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxRetainedQueries), maxRetainedQueries, "Retention cap must be positive.");
+        _maxRetainedQueries = maxRetainedQueries;
+    }
+
+    /// <summary>
+    /// Records a query metric. Drops the oldest entry when the retention cap is reached.
     /// </summary>
     public void Record(QueryMetrics metrics)
     {
+        ArgumentNullException.ThrowIfNull(metrics);
+
         lock (_lockObj)
         {
-            _metrics.Add(metrics);
+            _metrics.Enqueue(metrics);
+            while (_metrics.Count > _maxRetainedQueries)
+                _metrics.Dequeue();
         }
     }
 
     /// <summary>
-    /// Gets a metrics report for a time period.
+    /// Gets a metrics report. Optionally constrains the report to entries recorded within
+    /// the specified time window. Returns a zero-valued report (with <c>MostExpensiveQuery == null</c>)
+    /// when no entries match — never throws on empty input.
     /// </summary>
+    /// <param name="period">Optional time window measured back from <see cref="DateTime.UtcNow"/>. <c>null</c> covers all retained entries.</param>
     public QueryMetricsReport GetReport(TimeSpan? period = null)
     {
+        QueryMetrics[] snapshot;
+        DateTime? cutoff = period.HasValue ? DateTime.UtcNow.Subtract(period.Value) : null;
+
+        // Take the snapshot under the lock, then aggregate outside it so Record callers are
+        // not blocked by the aggregation pass.
         lock (_lockObj)
         {
-            var filtered = period.HasValue
-                ? _metrics.Where(m => m.ExecutedAt >= DateTime.UtcNow.Subtract(period.Value))
-                : _metrics;
-
-            var list = filtered.ToList();
-
-            return new QueryMetricsReport
-            {
-                TotalQueries = list.Count,
-                AverageExecutionTimeMs = list.Average(m => m.ExecutionTimeMs),
-                SlowQueries = list.Count(m => m.ExecutionTimeMs > 1000),
-                CacheHitRate = list.Count(m => m.CacheHit) / (double)Math.Max(1, list.Count),
-                AverageComplexityScore = list.Average(m => m.ComplexityScore),
-                OptimizedQueriesCount = list.Count(m => m.WasOptimized),
-                MostExpensiveQuery = list.OrderByDescending(m => m.ExecutionTimeMs).FirstOrDefault()
-            };
+            snapshot = _metrics.ToArray();
         }
+
+        var total = 0;
+        long executionTimeSum = 0;
+        var slowQueries = 0;
+        var cacheHits = 0;
+        long complexityScoreSum = 0;
+        var optimized = 0;
+        QueryMetrics? mostExpensive = null;
+        long maxExecutionTime = long.MinValue;
+
+        foreach (var m in snapshot)
+        {
+            if (cutoff.HasValue && m.ExecutedAt < cutoff.Value)
+                continue;
+
+            total++;
+            executionTimeSum += m.ExecutionTimeMs;
+            if (m.ExecutionTimeMs > 1000) slowQueries++;
+            if (m.CacheHit) cacheHits++;
+            complexityScoreSum += m.ComplexityScore;
+            if (m.WasOptimized) optimized++;
+            if (m.ExecutionTimeMs > maxExecutionTime)
+            {
+                maxExecutionTime = m.ExecutionTimeMs;
+                mostExpensive = m;
+            }
+        }
+
+        if (total == 0)
+        {
+            return new QueryMetricsReport();
+        }
+
+        return new QueryMetricsReport
+        {
+            TotalQueries = total,
+            AverageExecutionTimeMs = (double)executionTimeSum / total,
+            SlowQueries = slowQueries,
+            CacheHitRate = cacheHits / (double)total,
+            AverageComplexityScore = (double)complexityScoreSum / total,
+            OptimizedQueriesCount = optimized,
+            MostExpensiveQuery = mostExpensive,
+        };
     }
 }

--- a/tests/QuerySpec.Core.Tests/Monitoring/QueryMetricsReportTests.cs
+++ b/tests/QuerySpec.Core.Tests/Monitoring/QueryMetricsReportTests.cs
@@ -75,10 +75,58 @@ public class QueryMetricsReportTests
             ExecutedAt = DateTime.UtcNow.AddHours(-2)
         });
 
-        // Looking at the last millisecond, nothing qualifies but .Average throws on empty —
-        // so this documents the current contract: callers must ensure at least one match.
-        Assert.Throws<InvalidOperationException>(() =>
-            collector.GetReport(TimeSpan.FromMilliseconds(1)));
+        var report = collector.GetReport(TimeSpan.FromMilliseconds(1));
+
+        Assert.Equal(0, report.TotalQueries);
+        Assert.Equal(0, report.AverageExecutionTimeMs);
+        Assert.Equal(0, report.SlowQueries);
+        Assert.Equal(0, report.CacheHitRate);
+        Assert.Null(report.MostExpensiveQuery);
+    }
+
+    [Fact]
+    public void GetReport_EmptyCollector_ReturnsZeroValuedReport_DoesNotThrow()
+    {
+        var collector = new MetricsCollector();
+
+        var report = collector.GetReport();
+
+        Assert.Equal(0, report.TotalQueries);
+        Assert.Equal(0, report.AverageExecutionTimeMs);
+        Assert.Equal(0, report.AverageComplexityScore);
+        Assert.Equal(0, report.CacheHitRate);
+        Assert.Null(report.MostExpensiveQuery);
+    }
+
+    [Fact]
+    public void Record_BeyondRetentionCap_DropsOldestEntries()
+    {
+        var collector = new MetricsCollector(maxRetainedQueries: 5);
+        for (var i = 0; i < 12; i++)
+        {
+            collector.Record(new QueryMetrics { ExecutionTimeMs = i });
+        }
+
+        var report = collector.GetReport();
+
+        // Only the most recent 5 entries (i = 7..11) survive.
+        Assert.Equal(5, report.TotalQueries);
+        Assert.Equal(11, report.MostExpensiveQuery?.ExecutionTimeMs);
+        Assert.Equal((7 + 8 + 9 + 10 + 11) / 5.0, report.AverageExecutionTimeMs);
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveCap_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MetricsCollector(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MetricsCollector(-1));
+    }
+
+    [Fact]
+    public void Record_NullMetrics_Throws()
+    {
+        var collector = new MetricsCollector();
+        Assert.Throws<ArgumentNullException>(() => collector.Record(null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Three correctness/perf defects in `MetricsCollector`, all fixed in one pass:

1. **Unbounded `List<QueryMetrics>`** — every `Record` call appended forever, leaking memory on long-running hosts.
2. **`Average()` threw on empty list** — `GetReport` on a fresh collector or with a too-tight time window threw `InvalidOperationException` instead of returning a zero-valued report.
3. **6 LINQ passes under a single lock** — `Average / Count / Count / Average / Count / OrderBy.FirstOrDefault` blocked all writers for the full duration of the report.

## Fix
- `List<>` → `Queue<>` with a configurable retention cap. `DefaultMaxRetainedQueries = 10_000`. New ctor `MetricsCollector(int maxRetainedQueries)` for tuning; existing parameterless ctor preserved for binary compatibility.
- `Record` enqueues then dequeues to the cap (FIFO eviction, oldest dropped).
- `GetReport` snapshots the queue **under the lock**, then aggregates **outside the lock** in a single pass. Empty input returns a zero-valued report — never throws.
- Per-call also adds `ArgumentNullException` on `Record(null)` and `ArgumentOutOfRangeException` on non-positive cap.

## Why
From the v2.0.0 audit (quality-reviewer #50, api-guardian #81, perf-engineer #89). All three flagged the same class.

## Compatibility
- **Parameterless ctor preserved.** Source/binary compat for existing callers.
- **No public surface removed.**
- **Behavior change for empty `GetReport`** — previously threw `InvalidOperationException`, now returns zero-valued report. The existing test that locked in the broken throw (`GetReport_MostExpensiveQuery_IsNull_WhenNoMetricsMatchPeriod`, comment: "Average throws on empty — so this documents the current contract") is updated to assert the new contract. The original test name actually matched the new behavior; the assertion was the bug.
- **Behavior change at retention boundary** — 10,001st `Record` now drops the 1st. Hosts that previously relied on unbounded growth (and were leaking memory) get a stable working set instead.

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test --filter Monitoring`: **20 passed** on net8/9/10 (was 16; +4 new tests for empty-collector zero-report, FIFO eviction at cap, non-positive-cap rejection, null-record rejection)
- [x] Full `dotnet test tests/QuerySpec.Core.Tests`: **343 passed** on all 3 TFMs
- [x] Existing `Record_IsThreadSafe_UnderConcurrentWriters` test (4000 concurrent records) passes — well under the 10,000 default cap