### PR TITLE
fix(ci): pin reproducibility job actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,8 +223,8 @@ jobs:
     name: Reproducibility check (deterministic build)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Summary
- The `reproducibility` job in `.github/workflows/ci.yml:226-227` used floating `@v4` tags for `actions/checkout` and `actions/setup-dotnet` while every other job in the workflow was already SHA-pinned.
- Pins both to the same SHAs the rest of the workflow uses:
  - `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`
  - `actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9`

## Why
From the v2.0.0 enterprise-readiness audit (security-auditor finding #6). A maintainer (or an attacker who re-points the v4 tag) could swap the action contents on the next run of this single job; the rest of the matrix was already hardened.

## Verified
- [x] SHAs match those used by every other job in the same file (build-and-test, dotnet-format, codeql, dependency-review, vulnerability-scan, commit-lint).
- [x] No source changes outside `.github/workflows/ci.yml`.