### PR TITLE
fix(security): promote IsPii(string, object?) Obsolete from warning to error

### DIFF
--- a/src/QuerySpec.Core/Security/DataMaskingEngine.cs
+++ b/src/QuerySpec.Core/Security/DataMaskingEngine.cs
@@ -257,13 +257,13 @@ public sealed class DataMaskingEngine
     /// <see cref="IsPii(System.Type?, string)"/> with an explicit <see cref="IPiiClassifier"/>.
     /// </para>
     /// <para>
-    /// Scheduled to become a build error in <c>2.0.0</c> and to be removed in <c>3.0.0</c>.
+    /// Promoted to a build error in <c>2.0.1</c>; scheduled for removal in <c>3.0.0</c>.
     /// </para>
     /// </remarks>
     [Obsolete("Field-name + value-regex heuristics produce false negatives that leak PII. " +
               "Annotate fields with [Pii(...)] and use IsPii(Type, string) backed by IPiiClassifier instead. " +
-              "Scheduled to become an error in 2.0.0 and to be removed in 3.0.0.",
-              error: false)]
+              "Promoted to a build error in 2.0.1; scheduled for removal in 3.0.0.",
+              error: true)]
     public bool IsPii(string fieldName, object? value)
     {
         if (value is null) return false;

--- a/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineTests.cs
@@ -58,17 +58,6 @@ public class DataMaskingEngineTests
     }
 
     [Fact]
-    public void IsPii_Heuristic_StillDetectsEmailUntilRemoval()
-    {
-#pragma warning disable CS0618 // Pinning legacy heuristic until removal in 3.0.0; obsolete becomes error in 2.0.0.
-        var engine = new DataMaskingEngine();
-        var result = engine.IsPii("Email", "john@example.com");
-#pragma warning restore CS0618
-
-        Assert.True(result);
-    }
-
-    [Fact]
     public void Mask_WithClassifier_AppliesCategoryDefault_WhenNoExplicitRegistration()
     {
         var classifier = new ConfiguredPiiClassifier(new[]


### PR DESCRIPTION
## Summary
- The 1.x heuristic `DataMaskingEngine.IsPii(string, object?)` carried `[Obsolete(..., error: false)]` with a message stating "Scheduled to become an error in 2.0.0". The 2.0.0 release shipped without flipping `error: false` to `error: true`, so the documented contract didn't land.
- This PR promotes the attribute to `error: true` (now CS0619). Updates the message and XML doc to reflect the new state — promoted in 2.0.1, scheduled for removal in 3.0.0.
- Removes the test `IsPii_Heuristic_StillDetectsEmailUntilRemoval` — it suppressed CS0618 to keep calling the obsolete overload, but CS0619 (from `error: true`) cannot be suppressed by warning pragmas. The non-obsolete `IsPii(Type, string)` overload remains covered by tests at lines 148, 156, 158 of `DataMaskingEngineTests.cs`.

## Why
From the v2.0.0 enterprise-readiness audit (api-guardian #73). The original commitment was missed during the 2.0.0 cut; 2.0.1 fulfils it.

## Compatibility
- **Compile break for any external consumer still calling the heuristic overload.** The original obsolete message warned this would land in 2.0.0; this PR finally lands it. Migration target is named in both the message and XML doc.
- **No runtime change** — anyone calling via reflection or pre-compiled binaries continues to get the existing (buggy) behavior. The fix is a compile-time gate, not a runtime change.

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test tests/QuerySpec.Core.Tests`: **342 passed** on net8/9/10 (was 343; -1 from removed test, no other regressions)
- [x] DataMaskingEngine-specific tests: 26/26 pass on all TFMs