### PR TITLE
fix(di): WithAuditing uses TryAddSingleton so caller-supplied IAuditLogger wins

### DIFF
--- a/src/QuerySpec.DependencyInjection/QuerySpecBuilder.cs
+++ b/src/QuerySpec.DependencyInjection/QuerySpecBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using QuerySpec.Core.Auditing;
 using QuerySpec.Core.Caching;
 using QuerySpec.Core.Monitoring;
@@ -34,14 +35,19 @@ public class QuerySpecBuilder
         return this;
     }
 
-    /// <summary>Configure comprehensive auditing.</summary>
+    /// <summary>
+    /// Configure comprehensive auditing. Registers <see cref="InMemoryAuditLogger"/> as the
+    /// fallback <see cref="IAuditLogger"/> only if the configure delegate did not register one;
+    /// callers can wire up their own <see cref="IAuditLogger"/> inside <paramref name="configure"/>
+    /// without it being silently overwritten.
+    /// </summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is null.</exception>
     public QuerySpecBuilder WithAuditing(Action<AuditingBuilder> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
         var builder = new AuditingBuilder(_services);
         configure(builder);
-        _services.AddSingleton<IAuditLogger>(sp => new InMemoryAuditLogger());
+        _services.TryAddSingleton<IAuditLogger, InMemoryAuditLogger>();
         return this;
     }
 

--- a/tests/QuerySpec.Core.Tests/DependencyInjection/QuerySpecBuilderTests.cs
+++ b/tests/QuerySpec.Core.Tests/DependencyInjection/QuerySpecBuilderTests.cs
@@ -125,6 +125,35 @@ public class QuerySpecBuilderTests
         Assert.IsType<InMemoryAuditLogger>(logger);
     }
 
+    /// <summary>
+    /// A caller-supplied <see cref="IAuditLogger"/> registered before or inside the
+    /// <c>WithAuditing</c> configure delegate must be preserved. The default
+    /// <see cref="InMemoryAuditLogger"/> registration is a fallback only.
+    /// </summary>
+    [Fact]
+    public void WithAuditing_DoesNotOverride_CallerSuppliedAuditLogger()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IAuditLogger, CustomAuditLogger>();
+
+        services.AddQuerySpec(q => q.WithAuditing(_ => { }));
+
+        using var sp = services.BuildServiceProvider();
+        Assert.IsType<CustomAuditLogger>(sp.GetRequiredService<IAuditLogger>());
+    }
+
+    private sealed class CustomAuditLogger : IAuditLogger
+    {
+        public System.Threading.Tasks.Task LogQueryAsync(AuditLogEntry entry) => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task LogChangeAsync(FieldChange change) => System.Threading.Tasks.Task.CompletedTask;
+        public System.Threading.Tasks.Task<AuditLogEntry?> GetAuditAsync(string id) => System.Threading.Tasks.Task.FromResult<AuditLogEntry?>(null);
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByRequestAsync(string requestId) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since = null) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since = null) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
+        public System.Threading.Tasks.Task PurgeOldLogsAsync(System.TimeSpan olderThan) => System.Threading.Tasks.Task.CompletedTask;
+    }
+
     [Fact]
     public void WithMonitoring_StubsThrowAtConfigTime()
     {


### PR DESCRIPTION
## Summary
- `QuerySpecBuilder.WithAuditing` ran `_services.AddSingleton<IAuditLogger>(...)` unconditionally **after** the configure delegate, shadowing any `IAuditLogger` the caller had already registered (either before `AddQuerySpec` or inside the configure delegate).
- Switches to `TryAddSingleton<IAuditLogger, InMemoryAuditLogger>()` so the in-memory logger is a fallback only.

## Why
From the v2.0.0 enterprise-readiness audit (quality-reviewer #60). Production-grade logger setups (e.g., a database-backed `IAuditLogger`) were silently broken by the override.

## Compatibility
- **No public-API change.**
- **Behavior change for callers who registered their own `IAuditLogger` before/inside `WithAuditing`** — previously their logger was silently overridden, now it wins. The fix matches what every Microsoft DI extension does (`TryAdd*` for fallback registrations).
- **No change for the common path** — callers who don't register a custom logger continue to get `InMemoryAuditLogger`.

## Verified
- [x] `dotnet build src/QuerySpec.DependencyInjection` Release: 0 errors
- [x] `dotnet test --filter DependencyInjection`: **40 passed** on net8/9/10 (was 39; +1 new test `WithAuditing_DoesNotOverride_CallerSuppliedAuditLogger`)
- [x] Existing tests covering the default-fallback path (`WithAuditing_RegistersInMemoryAuditLogger`, `ChainedConfiguration_DoesNotConflict`) continue to pass.