### PR TITLE
fix(resilience): add ConfigureAwait(false) to library awaits in resilience and compliance paths

### DIFF
--- a/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
+++ b/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
@@ -35,23 +35,23 @@ public class ComplianceExporter : IComplianceExporter
     /// <summary>Gets all audit data for a user.</summary>
     public async Task<IEnumerable<AuditLogEntry>> GetUserDataAsync(string userId, string tenantId)
     {
-        var audits = await _auditReader.GetAuditsByUserAsync(userId);
+        var audits = await _auditReader.GetAuditsByUserAsync(userId).ConfigureAwait(false);
         return audits.Where(a => a.TenantId == tenantId);
     }
 
     /// <summary>Checks if a user has accessed a specific field.</summary>
     public async Task<bool> UserHasAccessedFieldAsync(string userId, string fieldName, DateTime since)
     {
-        var audits = await _auditReader.GetAuditsByUserAsync(userId, since);
+        var audits = await _auditReader.GetAuditsByUserAsync(userId, since).ConfigureAwait(false);
         return audits.Any(a => a.AccessedSensitiveFields.Contains(fieldName));
     }
 
     /// <summary>Generates a GDPR export for a user.</summary>
     public async Task GenerateGDPRExportAsync(string userId, string tenantId, Stream outputStream)
     {
-        var audits = await GetUserDataAsync(userId, tenantId);
+        var audits = await GetUserDataAsync(userId, tenantId).ConfigureAwait(false);
         var json = JsonSerializer.Serialize(audits, new JsonSerializerOptions { WriteIndented = true });
         var bytes = Encoding.UTF8.GetBytes(json);
-        await outputStream.WriteAsync(bytes, 0, bytes.Length);
+        await outputStream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
     }
 }

--- a/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
+++ b/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
@@ -25,12 +25,12 @@ public class BulkheadPolicy
     /// </summary>
     public async Task<T> ExecuteAsync<T>(Func<Task<T>> operation)
     {
-        if (!await _semaphore.WaitAsync(0))
+        if (!await _semaphore.WaitAsync(0).ConfigureAwait(false))
             throw new BulkheadException($"Bulkhead limit exceeded ({MaxConcurrentRequests})");
 
         try
         {
-            return await operation();
+            return await operation().ConfigureAwait(false);
         }
         finally
         {

--- a/src/QuerySpec.Core/Resilience/ResiliencePolicy.cs
+++ b/src/QuerySpec.Core/Resilience/ResiliencePolicy.cs
@@ -46,10 +46,10 @@ public class ResiliencePolicy
 
         if (RetryPolicy != null)
         {
-            return await RetryPolicy.ExecuteAsync(() => resilientOp());
+            return await RetryPolicy.ExecuteAsync(() => resilientOp()).ConfigureAwait(false);
         }
 
-        return await resilientOp();
+        return await resilientOp().ConfigureAwait(false);
     }
 }
 

--- a/src/QuerySpec.Core/Resilience/RetryPolicy.cs
+++ b/src/QuerySpec.Core/Resilience/RetryPolicy.cs
@@ -34,12 +34,12 @@ public class RetryPolicy
         {
             try
             {
-                return await operation();
+                return await operation().ConfigureAwait(false);
             }
             catch (Exception) when (retryCount < MaxRetries)
             {
                 retryCount++;
-                await Task.Delay(delay);
+                await Task.Delay(delay).ConfigureAwait(false);
 
                 if (UseExponentialBackoff)
                 {


### PR DESCRIPTION
## Summary
- Library code must not capture the synchronization context. Sync-over-async hosts (.NET Framework 4.x ASP.NET, WPF, WinForms) deadlock when a captured context tries to resume on a thread already blocked waiting on the `Task`.
- `CircuitBreaker.ExecuteAsync` already had `ConfigureAwait(false)` (line 62 — the in-repo reference). `RetryPolicy`, `BulkheadPolicy`, `ResiliencePolicy`, and `ComplianceExporter` did not.
- Adds `ConfigureAwait(false)` on the **10 awaits** flagged by the audit, none changed semantically.

## Why
From the v2.0.0 enterprise-readiness audit (quality-reviewer #46). `ConfigureAwaitChecker.Analyzer` and `Meziantou.Analyzer` both confirmed all 10 sites.

## Files changed
- `src/QuerySpec.Core/Resilience/RetryPolicy.cs` (lines 37, 42)
- `src/QuerySpec.Core/Resilience/BulkheadPolicy.cs` (lines 28, 33)
- `src/QuerySpec.Core/Resilience/ResiliencePolicy.cs` (lines 49, 52)
- `src/QuerySpec.Core/Auditing/ComplianceExporter.cs` (lines 38, 45, 52, 55)

## Compatibility
- **No public-API change.** Pure internal hygiene.
- **Behavior change:** library awaits no longer attempt to resume on the captured context. This is the correct contract for library code.

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test --filter "Resilience|Compliance"`: **30 passed** on net8/9/10 (no regressions)