### PR TITLE
fix(auditing): InMemoryAuditLogger implements IDisposable to release ReaderWriterLockSlim

### DIFF
--- a/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
+++ b/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
@@ -8,15 +8,39 @@ namespace QuerySpec.Core.Auditing;
 
 /// <summary>
 /// In-memory audit logger implementation for testing and demo purposes.
-/// Thread-safe with ReaderWriterLockSlim for optimal concurrency.
+/// Thread-safe with <see cref="ReaderWriterLockSlim"/> for optimal concurrency. Implements
+/// <see cref="IDisposable"/> so the kernel-backed lock is released when the DI container
+/// disposes the singleton (or when callers <c>using</c> the type directly).
 /// </summary>
-public class InMemoryAuditLogger : IAuditLogger
+public class InMemoryAuditLogger : IAuditLogger, IDisposable
 {
     private readonly List<AuditLogEntry> _logs = new();
     private readonly ReaderWriterLockSlim _lockSlim = new();
+    private bool _disposed;
 
     /// <summary>Initializes a new in-memory audit logger.</summary>
     public InMemoryAuditLogger() { }
+
+    /// <summary>
+    /// Releases the <see cref="ReaderWriterLockSlim"/> backing this logger. Idempotent.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Dispose pattern hook for subclasses.</summary>
+    /// <param name="disposing"><c>true</c> when called from <see cref="Dispose()"/>, <c>false</c> from a finalizer.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing)
+        {
+            _lockSlim.Dispose();
+        }
+        _disposed = true;
+    }
 
     /// <summary>
     /// Logs a query audit entry, sealing it into the integrity chain by setting its

--- a/tests/QuerySpec.Core.Tests/Auditing/InMemoryAuditLoggerTests.cs
+++ b/tests/QuerySpec.Core.Tests/Auditing/InMemoryAuditLoggerTests.cs
@@ -258,6 +258,33 @@ public class InMemoryAuditLoggerTests
         Assert.Equal(10, logger.Count);
     }
 
+    /// <summary>
+    /// Dispose releases the <see cref="ReaderWriterLockSlim"/>. Calling Dispose twice must
+    /// not throw — IDisposable contract requires idempotency.
+    /// </summary>
+    [Fact]
+    public void Dispose_Idempotent_DoesNotThrow()
+    {
+        var logger = new InMemoryAuditLogger();
+        logger.Dispose();
+        logger.Dispose();
+    }
+
+    /// <summary>
+    /// After disposal, the underlying <see cref="ReaderWriterLockSlim"/> is released. Any
+    /// subsequent attempt to enter the lock surfaces as <see cref="ObjectDisposedException"/>
+    /// from the lock primitive itself.
+    /// </summary>
+    [Fact]
+    public async Task LogQueryAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        var logger = new InMemoryAuditLogger();
+        logger.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            logger.LogQueryAsync(new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Query" }));
+    }
+
     /// <summary>Snapshot semantics must hold for the compliance-report range query as well.</summary>
     [Fact]
     public async Task GetComplianceReportAsync_ReturnsSnapshot_NotAffectedBySubsequentWrites()


### PR DESCRIPTION
## Summary
- `InMemoryAuditLogger` owned a `ReaderWriterLockSlim` (a kernel-backed sync primitive) but did not implement `IDisposable`. A kernel handle leaked for the lifetime of every logger instance, and CA2213 fired silently on the public type.
- Adds the standard `Dispose(bool)` pattern with a `_disposed` sentinel for idempotent disposal. `Dispose()` calls `GC.SuppressFinalize(this)` per the dispose contract.

## Why
From the v2.0.0 audit (quality-reviewer #52). Pairs naturally with the recent `TryAddSingleton` fix (#100) — the DI container disposes singleton `IDisposable` services on container teardown, so `AddQuerySpec` consumers now get clean lock disposal without changing their code.

## Compatibility
- **Source-compat addition.** Existing call sites that used `new InMemoryAuditLogger()` without `using` continue to compile and run; the GC will eventually finalize the lock, just as before. New code can (and should) use `using var logger = ...` or rely on DI lifetime.
- **No breaking change.** Adding `IDisposable` to a class is additive.
- **Subclass-friendly.** `Dispose(bool)` is `protected virtual` so subclasses can extend.

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test --filter InMemoryAuditLogger`: **17 passed** on net8/9/10 (was 15; +2 new tests: idempotent dispose, post-dispose `LogQueryAsync` throws `ObjectDisposedException`)