### PR TITLE
fix(resilience): BulkheadPolicy implements IDisposable to release SemaphoreSlim

### DIFF
--- a/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
+++ b/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
@@ -5,11 +5,15 @@ using System.Threading.Tasks;
 namespace QuerySpec.Core.Resilience;
 
 /// <summary>
-/// Bulkhead pattern for resource isolation and concurrent request limiting.
+/// Bulkhead pattern for resource isolation and concurrent request limiting. Implements
+/// <see cref="IDisposable"/> because the backing <see cref="SemaphoreSlim"/> owns a
+/// kernel-allocated wait handle that must be released on teardown.
 /// </summary>
-public class BulkheadPolicy
+public class BulkheadPolicy : IDisposable
 {
     private readonly SemaphoreSlim _semaphore;
+    private bool _disposed;
+
     /// <summary>Maximum number of concurrent requests allowed.</summary>
     public int MaxConcurrentRequests { get; }
 
@@ -36,6 +40,25 @@ public class BulkheadPolicy
         {
             _semaphore.Release();
         }
+    }
+
+    /// <summary>Releases the backing <see cref="SemaphoreSlim"/>. Idempotent.</summary>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Dispose pattern hook for subclasses.</summary>
+    /// <param name="disposing"><c>true</c> when called from <see cref="Dispose()"/>, <c>false</c> from a finalizer.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing)
+        {
+            _semaphore.Dispose();
+        }
+        _disposed = true;
     }
 }
 

--- a/tests/QuerySpec.Core.Tests/Resilience/BulkheadPolicyTests.cs
+++ b/tests/QuerySpec.Core.Tests/Resilience/BulkheadPolicyTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,5 +59,28 @@ public class BulkheadPolicyTests
 
         // Assert
         Assert.Equal(5, policy.MaxConcurrentRequests);
+    }
+
+    /// <summary>Dispose releases the backing SemaphoreSlim. Idempotent.</summary>
+    [Fact]
+    public void Dispose_Idempotent_DoesNotThrow()
+    {
+        var policy = new BulkheadPolicy(2);
+        policy.Dispose();
+        policy.Dispose();
+    }
+
+    /// <summary>
+    /// After disposal, calling ExecuteAsync surfaces ObjectDisposedException from the
+    /// disposed SemaphoreSlim — failing loudly rather than silently mis-acquiring.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_AfterDispose_ThrowsObjectDisposed()
+    {
+        var policy = new BulkheadPolicy(2);
+        policy.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            policy.ExecuteAsync(() => Task.FromResult(42)));
     }
 }


### PR DESCRIPTION
## Summary
- `BulkheadPolicy` owned a `SemaphoreSlim` — a kernel-allocated wait-handle holder — and did not implement `IDisposable`. Same class of CA2213 leak as `InMemoryAuditLogger` fixed in #102.
- Adds the standard `Dispose(bool)` pattern with a `_disposed` sentinel for idempotent disposal. `Dispose(bool)` is `protected virtual` for subclassing.

## Why
Flagged by the quality-reviewer agent during the audit of PR #102 (issue #103). Pattern-identical to PR #102.

## Compatibility
- **Source-compat addition.** Adding `IDisposable` to a class is additive.
- **DI integration:** when `BulkheadPolicy` is registered as a singleton (via `WithResilience(r => r.UseBulkhead(...))`), the container now disposes it on teardown.

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test --filter BulkheadPolicy`: **5 passed** on net8/9/10 (was 3; +2 new tests: idempotent dispose, post-dispose `ExecuteAsync` throws `ObjectDisposedException`)