### PR TITLE
perf(efcore): cache Enumerable.Contains open generic + closed instantiations in BuildIn

### DIFF
--- a/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
+++ b/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
@@ -32,6 +32,16 @@ public class QuerySpecExpressionTranslator
     private static readonly MethodInfo StringEndsWithMethod = typeof(StringHelper).GetMethod(nameof(StringHelper.EndsWith))!;
     private static readonly MethodInfo StringToStringMethod = typeof(object).GetMethod("ToString", Type.EmptyTypes)!;
 
+    /// <summary>
+    /// Cached open-generic <c>Enumerable.Contains&lt;T&gt;(IEnumerable&lt;T&gt;, T)</c>. Resolved
+    /// once at type init via a single <c>GetMethods()</c> call instead of per-<c>BuildIn</c>
+    /// invocation; closed instantiations are memoised in <see cref="EnumerableContainsClosedCache"/>.
+    /// </summary>
+    private static readonly MethodInfo EnumerableContainsOpenGeneric = typeof(Enumerable).GetMethods()
+        .First(m => m.Name == nameof(Enumerable.Contains) && m.GetParameters().Length == 2);
+
+    private static readonly ConcurrentDictionary<Type, MethodInfo> EnumerableContainsClosedCache = new();
+
     private static readonly ConcurrentDictionary<(Type, string), PropertyInfo> PropertyCache = new();
 
     /// <summary>
@@ -356,9 +366,9 @@ public class QuerySpecExpressionTranslator
         for (var i = 0; i < items.Count; i++)
             typedArray.SetValue(items[i], i);
 
-        var containsMethod = typeof(Enumerable).GetMethods()
-            .First(m => m.Name == "Contains" && m.GetParameters().Length == 2)
-            .MakeGenericMethod(underlyingType);
+        var containsMethod = EnumerableContainsClosedCache.GetOrAdd(
+            underlyingType,
+            static t => EnumerableContainsOpenGeneric.MakeGenericMethod(t));
 
         var constantArray = Expression.Constant(typedArray, underlyingType.MakeArrayType());
         var containsCall = Expression.Call(containsMethod, constantArray, property);


### PR DESCRIPTION
## Summary
- `BuildIn` called `typeof(Enumerable).GetMethods()` on **every** `In`/`NotIn` filter build:
  - Allocated a ~130-entry `MethodInfo[]` (~2 KB) per call
  - Ran `.First(m => ...)` with a closure allocation
  - Called `MakeGenericMethod(underlyingType)` without memoisation
- Now resolves the open generic `Enumerable.Contains<T>(IEnumerable<T>, T)` **once at type-init** via a single `GetMethods()` pass, and memoises closed instantiations in a `ConcurrentDictionary<Type, MethodInfo>` keyed by element type. Subsequent `BuildIn` calls are dictionary-lookup-only.

## Why
From the v2.0.0 audit (perf-engineer #86). The 4 `MethodInfo` fields at lines 30-33 already use the correct `static readonly` pattern for the string helpers; `BuildIn` was missed.

## Allocation profile
| Path | Before | After |
|---|---|---|
| First `In(int)` filter build (cache miss) | `MethodInfo[]` + closure + new `MethodInfo` (closed generic) | `ConcurrentDictionary.GetOrAdd` lambda + new `MethodInfo` (closed generic) |
| Subsequent `In(int)` filter builds | Same as above (cache miss every time) | Dictionary lookup only — no allocations |
| Subsequent `In(decimal)` filter builds | Same as above | Dictionary lookup only |

## Compatibility
- **No public-API change.** Pure internal hot-path optimisation.
- **No behavior change.** The resolved `MethodInfo` is identical to the previous lookup result.

## Verified
- [x] `dotnet build src/QuerySpec.EFCore` Release: 0 errors
- [x] `dotnet test tests/QuerySpec.EFCore.Tests`: **56 passed** on net8/9/10 (no regressions; In/NotIn-specific tests: 25 passed)