### PR TITLE
perf(monitoring): bound stack walk in N1DetectionEngine.RecordQuery

### DIFF
--- a/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
+++ b/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -31,6 +32,13 @@ public class N1DetectionEngine
     /// <summary>Maximum characters of stack trace preview to retain per pattern.</summary>
     public int StackPreviewChars { get; set; } = 512;
 
+    /// <summary>
+    /// Maximum number of managed stack frames sampled per <see cref="RecordQuery"/> call. The
+    /// preview and hash key derive from these frames; frames beyond this depth are not consulted.
+    /// Bounded so the per-call cost is constant regardless of call depth.
+    /// </summary>
+    public int MaxStackFrames { get; set; } = 16;
+
     private sealed class QueryInfo
     {
         public string StackPreview = string.Empty;
@@ -48,9 +56,15 @@ public class N1DetectionEngine
     /// <summary>
     /// Records a query execution. Safe to call from multiple threads.
     /// </summary>
+    /// <remarks>
+    /// Captures up to <see cref="MaxStackFrames"/> managed frames via <see cref="StackTrace"/> with
+    /// <c>fNeedFileInfo: false</c>; full <see cref="Environment.StackTrace"/> (which formats every
+    /// frame and resolves PDB info) is not used because its multi-microsecond per-call cost can
+    /// exceed the cost of fast queries it's meant to track.
+    /// </remarks>
     public void RecordQuery(string sql, long executionTimeMs)
     {
-        var stack = Environment.StackTrace;
+        var stack = BuildStackPreview();
         var key = ComputeHash(stack);
         var preview = stack.Length > StackPreviewChars ? stack.Substring(0, StackPreviewChars) : stack;
 
@@ -129,6 +143,28 @@ public class N1DetectionEngine
         Span<byte> hash = stackalloc byte[32];
         SHA256.HashData(Encoding.UTF8.GetBytes(input), hash);
         return Convert.ToHexString(hash);
+    }
+
+    private string BuildStackPreview()
+    {
+        // skipFrames: 1 elides BuildStackPreview; the immediate caller (RecordQuery) is included
+        // because it's a stable anchor that helps disambiguate callers who instrument the engine
+        // through their own helper.
+        var st = new StackTrace(skipFrames: 1, fNeedFileInfo: false);
+        var frameCount = Math.Min(st.FrameCount, MaxStackFrames);
+        if (frameCount == 0) return string.Empty;
+
+        var sb = new StringBuilder(MaxStackFrames * 64);
+        for (var i = 0; i < frameCount; i++)
+        {
+            var method = st.GetFrame(i)?.GetMethod();
+            if (method is null) continue;
+            sb.Append(method.DeclaringType?.FullName ?? "?");
+            sb.Append('.');
+            sb.Append(method.Name);
+            sb.Append('\n');
+        }
+        return sb.ToString();
     }
 }
 


### PR DESCRIPTION
## Summary
- `N1DetectionEngine.RecordQuery` called `Environment.StackTrace` on every recorded query — a multi-microsecond unmanaged-to-managed boundary call that formats every frame and resolves PDB info, producing a 2-10 KB string that's then UTF-8 encoded and SHA-256 hashed.
- For fast queries (cache hits, in-memory projections) the diagnostic overhead exceeded the cost of the operation the engine was meant to track.
- Now uses `new StackTrace(skipFrames: 1, fNeedFileInfo: false)`, walks up to `MaxStackFrames` (default 16) frames, and builds a compact `Type.Method` preview string. Same string is hashed for the aggregation key and truncated for the preview.

## Allocation / latency profile
| | Before | After |
|---|---|---|
| Per-call alloc | 2-10 KB `Environment.StackTrace` string + UTF-8 byte array | ~256-1024 char preview string + proportional byte array |
| Per-call latency | Multi-µs unmanaged transition + PDB resolve | Bounded N-frame managed walk, no PDB I/O |
| Hot-path effect | Diagnostic overhead exceeded fast-query cost | Negligible vs operation cost |

## Why
From the v2.0.0 audit (perf-engineer #88, ranked **#1 perf win** — most expensive per-call operation in the codebase). The engine is meant to *help* callers find slow queries, not become the slow path itself.

## Compatibility
- **Source-compat addition.** New `MaxStackFrames` property defaults to 16; callers who want deeper stacks can tune up.
- **Hash key shape changes** — patterns recorded before/after this change will hash to different keys. The cache key is forward-only (no consumer-visible persistence), so the change has no observable effect beyond a single in-process restart's cold cache.
- **Preview format changes** — was `at FullName.Method(...)\n at ...`, now `Type.Method\nType.Method\n`. Compact and machine-readable.

## Verified
- [x] `dotnet build src/QuerySpec.Core` Release: 0 errors
- [x] `dotnet test --filter N1Detection`: 6/6 pass on net8/9/10
- [x] Full Core suite: 348/348 pass on net8/9/10