### PR TITLE
feat(core)!: ICacheProvider returns ValueTask, AssemblyVersion → 3.0.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>0.0.0-local</Version>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
 
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/src/QuerySpec.Core/Caching/DistributedCacheProvider.cs
+++ b/src/QuerySpec.Core/Caching/DistributedCacheProvider.cs
@@ -38,14 +38,18 @@ public class DistributedCacheProvider : ICacheProvider
     /// Gets a value from distributed cache. Transport failures are treated as misses (logged);
     /// corrupt payloads are evicted.
     /// </summary>
-    public async Task<T?> GetAsync<T>(string key) where T : class
+    public async ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
     {
         ValidateKey(key);
 
         byte[]? bytes;
         try
         {
-            bytes = await _cache.GetAsync(key).ConfigureAwait(false);
+            bytes = await _cache.GetAsync(key, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -71,7 +75,11 @@ public class DistributedCacheProvider : ICacheProvider
             _logger.LogError(ex, "Corrupt cache entry for key {Key}; evicting.", key);
             try
             {
-                await _cache.RemoveAsync(key).ConfigureAwait(false);
+                await _cache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception removeEx)
             {
@@ -82,10 +90,8 @@ public class DistributedCacheProvider : ICacheProvider
         }
     }
 
-    /// <summary>
-    /// Sets a value in distributed cache.
-    /// </summary>
-    public async Task SetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class
+    /// <summary>Sets a value in distributed cache.</summary>
+    public async ValueTask SetAsync<T>(string key, T value, TimeSpan? expiration = null, CancellationToken cancellationToken = default) where T : class
     {
         ValidateKey(key);
         if (value is null) throw new ArgumentNullException(nameof(value));
@@ -110,8 +116,12 @@ public class DistributedCacheProvider : ICacheProvider
 
         try
         {
-            await _cache.SetAsync(key, bytes, options).ConfigureAwait(false);
+            await _cache.SetAsync(key, bytes, options, cancellationToken).ConfigureAwait(false);
             _stats.IncrementSets();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -120,16 +130,18 @@ public class DistributedCacheProvider : ICacheProvider
         }
     }
 
-    /// <summary>
-    /// Removes a value from distributed cache.
-    /// </summary>
-    public async Task RemoveAsync(string key)
+    /// <summary>Removes a value from distributed cache.</summary>
+    public async ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
     {
         ValidateKey(key);
         try
         {
-            await _cache.RemoveAsync(key).ConfigureAwait(false);
+            await _cache.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
             _stats.IncrementRemoves();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -138,16 +150,18 @@ public class DistributedCacheProvider : ICacheProvider
         }
     }
 
-    /// <summary>
-    /// Checks if a key exists in distributed cache.
-    /// </summary>
-    public async Task<bool> ExistsAsync(string key)
+    /// <summary>Checks if a key exists in distributed cache.</summary>
+    public async ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
     {
         ValidateKey(key);
         try
         {
-            var value = await _cache.GetAsync(key).ConfigureAwait(false);
+            var value = await _cache.GetAsync(key, cancellationToken).ConfigureAwait(false);
             return value != null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -160,16 +174,19 @@ public class DistributedCacheProvider : ICacheProvider
     /// Resets local stats. <see cref="IDistributedCache"/> has no flush contract; call the
     /// provider-specific API (e.g. <c>FLUSHDB</c>) if global eviction is required.
     /// </summary>
-    public Task FlushAsync()
+    public ValueTask FlushAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         _stats.Reset();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    /// <summary>
-    /// Gets a snapshot of current cache statistics.
-    /// </summary>
-    public Task<CacheStats> GetStatsAsync() => Task.FromResult(_stats.Snapshot());
+    /// <summary>Gets a snapshot of current cache statistics.</summary>
+    public ValueTask<CacheStats> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<CacheStats>(_stats.Snapshot());
+    }
 
     private static void ValidateKey(string key)
     {

--- a/src/QuerySpec.Core/Caching/ICacheProvider.cs
+++ b/src/QuerySpec.Core/Caching/ICacheProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,79 +8,63 @@ namespace QuerySpec.Core.Caching;
 /// Abstraction for pluggable cache implementations.
 /// </summary>
 /// <remarks>
-/// Every async member has a paired <see cref="CancellationToken"/>-accepting overload added in 2.1.
-/// The CT-less overloads are preserved for source compatibility and delegate to the CT overloads
-/// with <see cref="CancellationToken.None"/>. Implementers that ship binary-against 2.0 continue to
-/// satisfy the interface via the default implementations; new implementers should override the
-/// CT overloads to honour cancellation.
+/// All async members return <see cref="ValueTask"/> / <see cref="ValueTask{TResult}"/> so
+/// implementations that complete synchronously (notably <see cref="MemoryCacheProvider"/>) can
+/// avoid the per-call <see cref="Task"/> heap allocation. Existing call sites — <c>await
+/// cache.GetAsync(key)</c> — continue to work unchanged because <c>await</c> binds to both
+/// task types. Custom implementations that previously returned <see cref="Task"/> must update
+/// their return types; this is the binary break that motivates the v3.0 cut.
 /// </remarks>
 public interface ICacheProvider
 {
     /// <summary>Gets a value from cache by key.</summary>
-    Task<T?> GetAsync<T>(string key) where T : class;
-    /// <summary>Gets a value from cache by key with cancellation support.</summary>
-    Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken) where T : class
-        => GetAsync<T>(key);
+    /// <param name="key">Cache key.</param>
+    /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
+    ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>Sets a value in cache with optional expiration.</summary>
-    Task SetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class;
-    /// <summary>Sets a value in cache with optional expiration and cancellation support.</summary>
-    Task SetAsync<T>(string key, T value, TimeSpan? expiration, CancellationToken cancellationToken) where T : class
-        => SetAsync(key, value, expiration);
+    /// <param name="key">Cache key.</param>
+    /// <param name="value">Value to cache.</param>
+    /// <param name="expiration">Optional time-to-live; <c>null</c> uses the implementation default.</param>
+    /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
+    ValueTask SetAsync<T>(string key, T value, TimeSpan? expiration = null, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>Removes a value from cache by key.</summary>
-    Task RemoveAsync(string key);
-    /// <summary>Removes a value from cache by key with cancellation support.</summary>
-    Task RemoveAsync(string key, CancellationToken cancellationToken)
-        => RemoveAsync(key);
+    /// <param name="key">Cache key.</param>
+    /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
+    ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default);
 
     /// <summary>Checks if a key exists in cache.</summary>
-    Task<bool> ExistsAsync(string key);
-    /// <summary>Checks if a key exists in cache with cancellation support.</summary>
-    Task<bool> ExistsAsync(string key, CancellationToken cancellationToken)
-        => ExistsAsync(key);
+    /// <param name="key">Cache key.</param>
+    /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
+    ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default);
 
     /// <summary>Flushes all cache entries.</summary>
-    Task FlushAsync();
-    /// <summary>Flushes all cache entries with cancellation support.</summary>
-    Task FlushAsync(CancellationToken cancellationToken)
-        => FlushAsync();
+    /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
+    ValueTask FlushAsync(CancellationToken cancellationToken = default);
 
     /// <summary>Gets current cache statistics.</summary>
-    Task<CacheStats> GetStatsAsync();
-    /// <summary>Gets current cache statistics with cancellation support.</summary>
-    Task<CacheStats> GetStatsAsync(CancellationToken cancellationToken)
-        => GetStatsAsync();
+    /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
+    ValueTask<CacheStats> GetStatsAsync(CancellationToken cancellationToken = default);
 }
 
 /// <summary>
-/// Cache invalidation strategy for complex scenarios.
+/// Cache invalidation strategy for complex scenarios. All members return <see cref="ValueTask"/>
+/// for consistency with <see cref="ICacheProvider"/>.
 /// </summary>
 public interface ICacheInvalidationStrategy
 {
     /// <summary>Invalidates a specific cache key.</summary>
-    Task InvalidateAsync(string key);
-    /// <summary>Invalidates a specific cache key with cancellation support.</summary>
-    Task InvalidateAsync(string key, CancellationToken cancellationToken)
-        => InvalidateAsync(key);
+    ValueTask InvalidateAsync(string key, CancellationToken cancellationToken = default);
 
     /// <summary>Invalidates cache keys matching a pattern.</summary>
-    Task InvalidatePatternAsync(string pattern);
-    /// <summary>Invalidates cache keys matching a pattern with cancellation support.</summary>
-    Task InvalidatePatternAsync(string pattern, CancellationToken cancellationToken)
-        => InvalidatePatternAsync(pattern);
+    ValueTask InvalidatePatternAsync(string pattern, CancellationToken cancellationToken = default);
 
     /// <summary>Invalidates all cache keys for a tenant.</summary>
-    Task InvalidateByTenantAsync(string tenantId);
-    /// <summary>Invalidates all cache keys for a tenant with cancellation support.</summary>
-    Task InvalidateByTenantAsync(string tenantId, CancellationToken cancellationToken)
-        => InvalidateByTenantAsync(tenantId);
+    ValueTask InvalidateByTenantAsync(string tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>Invalidates all cache keys for a user.</summary>
-    Task InvalidateByUserAsync(string userId);
-    /// <summary>Invalidates all cache keys for a user with cancellation support.</summary>
-    Task InvalidateByUserAsync(string userId, CancellationToken cancellationToken)
-        => InvalidateByUserAsync(userId);
+    ValueTask InvalidateByUserAsync(string userId, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -90,8 +73,5 @@ public interface ICacheInvalidationStrategy
 public interface ICacheWarmer
 {
     /// <summary>Pre-loads frequently accessed data into cache.</summary>
-    Task WarmCacheAsync();
-    /// <summary>Pre-loads frequently accessed data into cache with cancellation support.</summary>
-    Task WarmCacheAsync(CancellationToken cancellationToken)
-        => WarmCacheAsync();
+    ValueTask WarmCacheAsync(CancellationToken cancellationToken = default);
 }

--- a/src/QuerySpec.Core/Caching/MemoryCacheProvider.cs
+++ b/src/QuerySpec.Core/Caching/MemoryCacheProvider.cs
@@ -13,6 +13,8 @@ namespace QuerySpec.Core.Caching;
 /// remains usable after a flush.</para>
 /// <para>Instances are thread-safe: counters are updated via <see cref="Interlocked"/>
 /// and <see cref="MemoryCache"/> itself is safe for concurrent access.</para>
+/// <para>All operations complete synchronously and return <see cref="ValueTask"/> directly so
+/// no <see cref="Task"/> heap allocation occurs on cache hits or stat reads.</para>
 /// </remarks>
 public class MemoryCacheProvider : ICacheProvider, IDisposable
 {
@@ -31,32 +33,30 @@ public class MemoryCacheProvider : ICacheProvider, IDisposable
         _cache = new MemoryCache(_options);
     }
 
-    /// <summary>
-    /// Gets a value from cache.
-    /// </summary>
-    public Task<T?> GetAsync<T>(string key) where T : class
+    /// <summary>Gets a value from cache.</summary>
+    public ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
     {
         ValidateKey(key);
         EnsureNotDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
         if (_cache.TryGetValue(key, out T? value) && value is not null)
         {
             _stats.IncrementHits();
-            return Task.FromResult<T?>(value);
+            return new ValueTask<T?>(value);
         }
         _stats.IncrementMisses();
-        return Task.FromResult<T?>(null);
+        return new ValueTask<T?>((T?)null);
     }
 
-    /// <summary>
-    /// Sets a value in cache with optional expiration.
-    /// </summary>
-    public Task SetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class
+    /// <summary>Sets a value in cache with optional expiration.</summary>
+    public ValueTask SetAsync<T>(string key, T value, TimeSpan? expiration = null, CancellationToken cancellationToken = default) where T : class
     {
         ValidateKey(key);
         if (value is null) throw new ArgumentNullException(nameof(value));
         if (expiration.HasValue && expiration.Value <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(expiration), "Expiration must be positive.");
         EnsureNotDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
 
         var cacheOptions = new MemoryCacheEntryOptions();
         if (expiration.HasValue)
@@ -64,49 +64,50 @@ public class MemoryCacheProvider : ICacheProvider, IDisposable
 
         _cache.Set(key, value, cacheOptions);
         _stats.IncrementSets();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    /// <summary>
-    /// Removes a value from cache.
-    /// </summary>
-    public Task RemoveAsync(string key)
+    /// <summary>Removes a value from cache.</summary>
+    public ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
     {
         ValidateKey(key);
         EnsureNotDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
         _cache.Remove(key);
         _stats.IncrementRemoves();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    /// <summary>
-    /// Checks if a key exists in cache.
-    /// </summary>
-    public Task<bool> ExistsAsync(string key)
+    /// <summary>Checks if a key exists in cache.</summary>
+    public ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
     {
         ValidateKey(key);
         EnsureNotDisposed();
-        return Task.FromResult(_cache.TryGetValue(key, out _));
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<bool>(_cache.TryGetValue(key, out _));
     }
 
     /// <summary>
     /// Atomically replaces the cache with a fresh instance, evicting all entries. The
     /// previous cache instance is disposed; the provider remains usable.
     /// </summary>
-    public Task FlushAsync()
+    public ValueTask FlushAsync(CancellationToken cancellationToken = default)
     {
         EnsureNotDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
         var fresh = new MemoryCache(_options);
         var old = Interlocked.Exchange(ref _cache, fresh);
         old.Dispose();
         _stats.Reset();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    /// <summary>
-    /// Gets a snapshot of current cache statistics.
-    /// </summary>
-    public Task<CacheStats> GetStatsAsync() => Task.FromResult(_stats.Snapshot());
+    /// <summary>Gets a snapshot of current cache statistics.</summary>
+    public ValueTask<CacheStats> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<CacheStats>(_stats.Snapshot());
+    }
 
     /// <summary>Disposes the memory cache.</summary>
     public void Dispose()

--- a/src/QuerySpec.Core/Caching/MultiLevelCache.cs
+++ b/src/QuerySpec.Core/Caching/MultiLevelCache.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace QuerySpec.Core.Caching;
@@ -23,20 +24,20 @@ public class MultiLevelCache : ICacheProvider
     /// <summary>
     /// Gets a value, checking L1 first, then L2. On L2 hit the value is promoted to L1.
     /// </summary>
-    public async Task<T?> GetAsync<T>(string key) where T : class
+    public async ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
     {
-        var result = await _l1.GetAsync<T>(key).ConfigureAwait(false);
+        var result = await _l1.GetAsync<T>(key, cancellationToken).ConfigureAwait(false);
         if (result != null)
         {
             _stats.IncrementHits();
             return result;
         }
 
-        result = await _l2.GetAsync<T>(key).ConfigureAwait(false);
+        result = await _l2.GetAsync<T>(key, cancellationToken).ConfigureAwait(false);
         if (result != null)
         {
             _stats.IncrementHits();
-            await _l1.SetAsync(key, result).ConfigureAwait(false);
+            await _l1.SetAsync(key, result, expiration: null, cancellationToken).ConfigureAwait(false);
             return result;
         }
 
@@ -44,47 +45,41 @@ public class MultiLevelCache : ICacheProvider
         return null;
     }
 
-    /// <summary>
-    /// Sets a value in both L1 and L2 caches.
-    /// </summary>
-    public async Task SetAsync<T>(string key, T value, TimeSpan? expiration = null) where T : class
+    /// <summary>Sets a value in both L1 and L2 caches.</summary>
+    public async ValueTask SetAsync<T>(string key, T value, TimeSpan? expiration = null, CancellationToken cancellationToken = default) where T : class
     {
-        await _l1.SetAsync(key, value, expiration).ConfigureAwait(false);
-        await _l2.SetAsync(key, value, expiration).ConfigureAwait(false);
+        await _l1.SetAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
+        await _l2.SetAsync(key, value, expiration, cancellationToken).ConfigureAwait(false);
         _stats.IncrementSets();
     }
 
-    /// <summary>
-    /// Removes a value from both caches.
-    /// </summary>
-    public async Task RemoveAsync(string key)
+    /// <summary>Removes a value from both caches.</summary>
+    public async ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
     {
-        await _l1.RemoveAsync(key).ConfigureAwait(false);
-        await _l2.RemoveAsync(key).ConfigureAwait(false);
+        await _l1.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
+        await _l2.RemoveAsync(key, cancellationToken).ConfigureAwait(false);
         _stats.IncrementRemoves();
     }
 
-    /// <summary>
-    /// Checks if key exists in either cache.
-    /// </summary>
-    public async Task<bool> ExistsAsync(string key)
+    /// <summary>Checks if key exists in either cache.</summary>
+    public async ValueTask<bool> ExistsAsync(string key, CancellationToken cancellationToken = default)
     {
-        return await _l1.ExistsAsync(key).ConfigureAwait(false)
-            || await _l2.ExistsAsync(key).ConfigureAwait(false);
+        return await _l1.ExistsAsync(key, cancellationToken).ConfigureAwait(false)
+            || await _l2.ExistsAsync(key, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Flushes both cache levels.
-    /// </summary>
-    public async Task FlushAsync()
+    /// <summary>Flushes both cache levels.</summary>
+    public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
     {
-        await _l1.FlushAsync().ConfigureAwait(false);
-        await _l2.FlushAsync().ConfigureAwait(false);
+        await _l1.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await _l2.FlushAsync(cancellationToken).ConfigureAwait(false);
         _stats.Reset();
     }
 
-    /// <summary>
-    /// Gets a snapshot of aggregate multi-level statistics.
-    /// </summary>
-    public Task<CacheStats> GetStatsAsync() => Task.FromResult(_stats.Snapshot());
+    /// <summary>Gets a snapshot of aggregate multi-level statistics.</summary>
+    public ValueTask<CacheStats> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<CacheStats>(_stats.Snapshot());
+    }
 }

--- a/src/QuerySpec.Core/CompatibilitySuppressions.xml
+++ b/src/QuerySpec.Core/CompatibilitySuppressions.xml
@@ -94,7 +94,98 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.FlushAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetStatsAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String)</Target>
     <Left>lib/net10.0/QuerySpec.Core.dll</Left>
     <Right>lib/net10.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -108,7 +199,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByTenantAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String)</Target>
     <Left>lib/net10.0/QuerySpec.Core.dll</Left>
     <Right>lib/net10.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -122,7 +227,28 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidatePatternAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.FlushAsync</Target>
     <Left>lib/net10.0/QuerySpec.Core.dll</Left>
     <Right>lib/net10.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -143,6 +269,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/QuerySpec.Core.dll</Left>
     <Right>lib/net10.0/QuerySpec.Core.dll</Right>
@@ -157,6 +297,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
     <Left>lib/net10.0/QuerySpec.Core.dll</Left>
     <Right>lib/net10.0/QuerySpec.Core.dll</Right>
@@ -164,7 +311,203 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.FlushAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetStatsAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.ExistsAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.FlushAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetAsync``1(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetStatsAsync</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.RemoveAsync(System.String)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Monitoring.N1DetectionEngine.get_MaxStackFrames</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Monitoring.N1DetectionEngine.set_MaxStackFrames(System.Int32)</Target>
     <Left>lib/net10.0/QuerySpec.Core.dll</Left>
     <Right>lib/net10.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -311,7 +654,98 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.FlushAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetStatsAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String)</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>
     <Right>lib/net8.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -325,7 +759,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByTenantAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String)</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>
     <Right>lib/net8.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -339,7 +787,28 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidatePatternAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.FlushAsync</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>
     <Right>lib/net8.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -360,6 +829,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>
     <Right>lib/net8.0/QuerySpec.Core.dll</Right>
@@ -374,6 +857,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>
     <Right>lib/net8.0/QuerySpec.Core.dll</Right>
@@ -381,7 +871,203 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.FlushAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetStatsAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.ExistsAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.FlushAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetAsync``1(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetStatsAsync</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.RemoveAsync(System.String)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Monitoring.N1DetectionEngine.get_MaxStackFrames</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Monitoring.N1DetectionEngine.set_MaxStackFrames(System.Int32)</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>
     <Right>lib/net8.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -528,7 +1214,98 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.FlushAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetStatsAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.DistributedCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String)</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -542,7 +1319,21 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByTenantAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String)</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -556,7 +1347,28 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidatePatternAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.FlushAsync</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -577,6 +1389,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
@@ -591,6 +1417,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
@@ -598,7 +1431,203 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.ExistsAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.FlushAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetAsync``1(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetStatsAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.RemoveAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MemoryCacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.ExistsAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.FlushAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetAsync``1(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetStatsAsync</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.RemoveAsync(System.String)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.MultiLevelCache.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan})</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Monitoring.N1DetectionEngine.get_MaxStackFrames</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:QuerySpec.Core.Monitoring.N1DetectionEngine.set_MaxStackFrames(System.Int32)</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -650,6 +1679,104 @@
     <Target>M:QuerySpec.Core.Security.IEncryptionProvider.RotateKeyAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/net9.0/QuerySpec.Core.dll</Left>
     <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.Core, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.Core, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.Core, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByTenantAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidateByUserAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheInvalidationStrategy.InvalidatePatternAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.ExistsAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.FlushAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetAsync``1(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.GetStatsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.RemoveAsync(System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheProvider.SetAsync``1(System.String,``0,System.Nullable{System.TimeSpan},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:QuerySpec.Core.Caching.ICacheWarmer.WarmCacheAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>

--- a/src/QuerySpec.DependencyInjection/CompatibilitySuppressions.xml
+++ b/src/QuerySpec.DependencyInjection/CompatibilitySuppressions.xml
@@ -148,4 +148,25 @@
     <Right>lib/net9.0/QuerySpec.DependencyInjection.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.DependencyInjection, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net10.0/QuerySpec.DependencyInjection.dll</Left>
+    <Right>lib/net10.0/QuerySpec.DependencyInjection.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.DependencyInjection, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net8.0/QuerySpec.DependencyInjection.dll</Left>
+    <Right>lib/net8.0/QuerySpec.DependencyInjection.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.DependencyInjection, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net9.0/QuerySpec.DependencyInjection.dll</Left>
+    <Right>lib/net9.0/QuerySpec.DependencyInjection.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/src/QuerySpec.EFCore/CompatibilitySuppressions.xml
+++ b/src/QuerySpec.EFCore/CompatibilitySuppressions.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.EFCore, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net10.0/QuerySpec.EFCore.dll</Left>
+    <Right>lib/net10.0/QuerySpec.EFCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.EFCore, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net8.0/QuerySpec.EFCore.dll</Left>
+    <Right>lib/net8.0/QuerySpec.EFCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>QuerySpec.EFCore, Version=2.0.1.0, Culture=neutral, PublicKeyToken=2aa0115813e60a0c</Target>
+    <Left>lib/net9.0/QuerySpec.EFCore.dll</Left>
+    <Right>lib/net9.0/QuerySpec.EFCore.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/tests/QuerySpec.Core.Tests/Caching/DistributedCacheProviderAdditionalTests.cs
+++ b/tests/QuerySpec.Core.Tests/Caching/DistributedCacheProviderAdditionalTests.cs
@@ -118,7 +118,7 @@ public class DistributedCacheProviderAdditionalTests
             .ThrowsAsync(new InvalidOperationException("write failed"));
 
         var p = new DistributedCacheProvider(mock.Object);
-        await Assert.ThrowsAsync<InvalidOperationException>(() => p.SetAsync("k", new Item()));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => p.SetAsync("k", new Item()).AsTask());
     }
 
     [Fact]

--- a/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
+++ b/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
@@ -5,7 +5,10 @@
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
     <OutputType>Exe</OutputType>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- xUnit1051 demands every CT-accepting method is called with TestContext.Current.CancellationToken.
+         For unit tests that don't take meaningful time the noise outweighs the benefit; suppress
+         here and let long-running tests pass the token explicitly when it matters. -->
+    <NoWarn>$(NoWarn);CS1591;xUnit1051</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
+++ b/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;xUnit1051</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
**Binary-breaking change. This PR cuts the v3.0 line.** When you next release after merging, standard-version will see the `!` on this commit and bump to `3.0.0`, capturing both the v2.1 additive work (already merged) and this break in one major release.

Changes every async member on `ICacheProvider`, `ICacheInvalidationStrategy`, and `ICacheWarmer` from `Task` / `Task<T>` to `ValueTask` / `ValueTask<T>`.

## What changes

**Interface surface** — single method per operation, no more dual Task / Task-with-CT shape:
```csharp
// Before (2.x):
Task<T?> GetAsync<T>(string key) where T : class;
Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken) where T : class;  // DIM

// After (3.0):
ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class;
```

**Implementations**:
- `MemoryCacheProvider`: returns `new ValueTask<T?>(value)` / `ValueTask.CompletedTask` directly. **Per-cache-hit `Task<T?>` heap alloc gone** (audit rated this the #4 perf win).
- `DistributedCacheProvider`: ValueTask wraps the underlying `IDistributedCache.Task`. CT now flows into the I/O calls.
- `MultiLevelCache`: threads ValueTask through L1+L2.

## Compatibility

| Audience | Impact |
|---|---|
| Consumers calling `await cache.GetAsync(key)` | **No change.** `await` binds to both Task and ValueTask. |
| Consumers passing CT via the PR-16 overload | Drop the no-CT call; the new method has `CancellationToken cancellationToken = default`. |
| Custom `ICacheProvider` implementers | **Must update return types** from `Task` to `ValueTask` and recompile. |
| Custom `ICacheInvalidationStrategy` / `ICacheWarmer` implementers | Same: update return types. |

## Why a major (`feat!:`)
Existing `ICacheProvider` impls on disk would fail at load time when the runtime expects ValueTask but finds a Task-returning method. Per SemVer, this is a major break. AssemblyVersion bumps to 3.0.0.0; this is the Microsoft.Extensions.* pinning convention.

## Verified
- [x] `dotnet build` Release: 0 errors
- [x] `dotnet test`: **353 + 83 = 436** passing on net8/9/10 (Core + EFCore)
- [x] `dotnet pack -p:Version=3.0.0-validation` succeeds for all 3 projects with regenerated suppression files acknowledging the 2.0.1 → 3.0 break
- [x] xUnit1051 suppressed in test projects (unit tests don't model meaningful cancellation; add token-honouring tests case-by-case where it matters)

## Suppression file impact
- `src/QuerySpec.Core/CompatibilitySuppressions.xml`: 1823 lines (every 2.x → 3.0 surface delta)
- `src/QuerySpec.EFCore/CompatibilitySuppressions.xml`: new, 24 lines (CP0003 assembly version only — no API change)
- `src/QuerySpec.DependencyInjection/CompatibilitySuppressions.xml`: 171 lines

These reset to empty once 3.0.0 ships and the baseline updates to 3.0.0.

## Refs
- perf-engineer audit #90
- Closes the design question raised by api-guardian #68 / quality-reviewer #47 (CT consolidated into the ValueTask methods, no more dual shape)