### PR TITLE
build(release): trim PackageTags and lead with queryspec brand

### DIFF
--- a/src/QuerySpec.Core/QuerySpec.Core.csproj
+++ b/src/QuerySpec.Core/QuerySpec.Core.csproj
@@ -5,7 +5,7 @@
     <PackageId>QuerySpec.Core</PackageId>
     <Title>QuerySpec Core</Title>
     <Description>Core abstractions for QuerySpec: build serializable query specifications (filters, sorts, projections) and apply cross-cutting concerns — auditing, data masking and row-level security, caching, resilience (retry, circuit breaker, rate limiting), and monitoring — without hand-rolling them per query. Pair with QuerySpec.EFCore to translate specifications to LINQ against EF Core.</Description>
-    <PackageTags>query;specification;filter;sort;linq;auditing;security;caching;resilience;monitoring;dotnet</PackageTags>
+    <PackageTags>queryspec;specification;filter;linq;dotnet</PackageTags>
     <!-- Signing is governed by Directory.Build.props. Do not override here. -->
   </PropertyGroup>
 

--- a/src/QuerySpec.DependencyInjection/QuerySpec.DependencyInjection.csproj
+++ b/src/QuerySpec.DependencyInjection/QuerySpec.DependencyInjection.csproj
@@ -5,7 +5,7 @@
     <PackageId>QuerySpec.DependencyInjection</PackageId>
     <Title>QuerySpec Dependency Injection</Title>
     <Description>Wires QuerySpec into Microsoft.Extensions.DependencyInjection with a fluent AddQuerySpec(...) builder for auditing, security, caching (in-memory or Redis via StackExchange.Redis), resilience, monitoring, performance, and plugins. Start here if you use ASP.NET Core or any Generic Host app — it saves you from registering each concern by hand.</Description>
-    <PackageTags>query;specification;dependency-injection;aspnetcore;generic-host;redis;caching;dotnet</PackageTags>
+    <PackageTags>queryspec;dependency-injection;aspnetcore;specification;dotnet</PackageTags>
     <!-- Signing is governed by Directory.Build.props. Do not override here. -->
   </PropertyGroup>
 

--- a/src/QuerySpec.EFCore/QuerySpec.EFCore.csproj
+++ b/src/QuerySpec.EFCore/QuerySpec.EFCore.csproj
@@ -5,7 +5,7 @@
     <PackageId>QuerySpec.EFCore</PackageId>
     <Title>QuerySpec for EF Core</Title>
     <Description>Translates QuerySpec filter specifications into LINQ expression trees that Entity Framework Core turns into SQL. Supports 50+ operators (comparison, string, collection, temporal, null/membership) plus nested AND/OR groups, with a compiled expression cache to keep translation cheap on hot paths. Use this when you need to accept filter/sort input from clients or config without writing expression trees by hand.</Description>
-    <PackageTags>query;specification;filter;linq;expression-tree;efcore;entity-framework-core;orm;dotnet</PackageTags>
+    <PackageTags>queryspec;specification;efcore;entity-framework-core;linq</PackageTags>
     <!-- Signing is governed by Directory.Build.props. Do not override here. -->
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Closes #51.

NuGet's search algorithm penalises tag stuffing — the docs recommend ≤ 5 highly-relevant tags. Each package now leads with the brand identifier `queryspec` (which was missing from every package's tag list before this PR) and trims to the canonical search terms users actually type into nuget.org.

## Changes

| Package | Before | After |
|---|---|---|
| QuerySpec.Core | `query;specification;filter;sort;linq;auditing;security;caching;resilience;monitoring;dotnet` (11) | `queryspec;specification;filter;linq;dotnet` (5) |
| QuerySpec.EFCore | `query;specification;filter;linq;expression-tree;efcore;entity-framework-core;orm;dotnet` (9) | `queryspec;specification;efcore;entity-framework-core;linq` (5) |
| QuerySpec.DependencyInjection | `query;specification;dependency-injection;aspnetcore;generic-host;redis;caching;dotnet` (8) | `queryspec;dependency-injection;aspnetcore;specification;dotnet` (5) |

## Acceptance criteria from #51

- [x] Each package has ≤ 5 tags
- [x] `queryspec` appears as the first tag in every package's `<PackageTags>`
- [x] Tags use canonical nuget.org search terms (`entity-framework-core`, `dependency-injection`)

## Verification

```
dotnet pack QuerySpec.sln -c Release -p:Version=3.0.1
```

Each generated `.nuspec` records the trimmed tags:

```
QuerySpec.Core.nuspec:                <tags>queryspec specification filter linq dotnet</tags>
QuerySpec.EFCore.nuspec:              <tags>queryspec specification efcore entity-framework-core linq</tags>
QuerySpec.DependencyInjection.nuspec: <tags>queryspec dependency-injection aspnetcore specification dotnet</tags>
```

PackageValidation against the v3.0.0 baseline continues to pass — no API surface changes.

## Test plan

- [ ] CI green on the .NET 8/9/10 matrix
- [ ] dotnet format passes
- [ ] CodeQL clean
- [ ] commitlint passes
- [ ] After next release: search nuget.org for "queryspec" and confirm all three packages appear in results