### PR TITLE
ci(release): validate package contents and metadata before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
     - name: List produced packages
       run: ls -la ./artifacts
 
-    - name: Verify packages
+    - name: Verify package count and version-stamped filenames
       run: |
         set -euo pipefail
         count=$(ls ./artifacts/*.nupkg 2>/dev/null | wc -l)
@@ -190,6 +190,30 @@ jobs:
           fi
         done
         echo "Package metadata OK: 3 nupkg + 3 snupkg at version ${{ steps.version.outputs.version }}."
+
+    - name: Validate package contents and metadata
+      # Runs Meziantou.Framework.NuGetPackageValidation.Tool against every produced
+      # .nupkg. This catches structural and metadata gaps before publish: missing
+      # README/icon/license, missing/unsigned assemblies, broken SourceLink, missing
+      # symbols, deterministic-build flag absent, etc. A malformed package fails
+      # this step and never reaches NuGet.org.
+      run: |
+        set -euo pipefail
+        dotnet tool install --global Meziantou.Framework.NuGetPackageValidation.Tool --version 1.0.49
+        export PATH="$PATH:$HOME/.dotnet/tools"
+        failed=0
+        for pkg in ./artifacts/*.nupkg; do
+          echo "::group::Validate $(basename "$pkg")"
+          if ! meziantou.validate-nuget-package "$pkg"; then
+            echo "::error::Package validation failed for $(basename "$pkg")"
+            failed=1
+          fi
+          echo "::endgroup::"
+        done
+        if [[ "$failed" -ne 0 ]]; then
+          exit 1
+        fi
+        echo "All packages passed Meziantou NuGet content/metadata validation."
 
     - name: Upload packages
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4


### PR DESCRIPTION
## Summary

Closes #64.

The release pipeline previously only checked `.nupkg` / `.snupkg` counts and that the version appeared in each filename. A package missing its README, icon, license expression, deterministic-build flag, SourceLink data, or symbols would have shipped silently. This PR adds a Meziantou-validation step before publish so a malformed package fails the workflow and never reaches nuget.org.

## Changes

`.github/workflows/release.yml`:

1. Renamed the existing `Verify packages` step → `Verify package count and version-stamped filenames` (clarifies it's a thin gate).
2. New step `Validate package contents and metadata` runs after, installs `Meziantou.Framework.NuGetPackageValidation.Tool@1.0.49` (pinned), and runs the default rule set against every `.nupkg`:
   - Required metadata: `author`, `description`, `license expression`, `project URL`
   - Required files: `README`, `icon`
   - Assembly hygiene: optimized Release build, strongly named
   - Reproducibility: `ContinuousIntegrationBuild`, deterministic build flag
   - SourceLink configured and resolvable
   - Symbols (`.snupkg`) present and well-formed

The step fails the job (`exit 1`) if any package fails any rule.

## Verification

Ran the same tool locally against `dotnet pack QuerySpec.sln -c Release -p:Version=3.0.1 -p:ContinuousIntegrationBuild=true`:

```
=== QuerySpec.Core.3.0.1.nupkg ===
{ "IsValid": true, "Packages": { "...": { "Errors": [], "IsValid": true } } }

=== QuerySpec.EFCore.3.0.1.nupkg ===
{ "IsValid": true, ... }

=== QuerySpec.DependencyInjection.3.0.1.nupkg ===
{ "IsValid": true, ... }
```

All three packages pass with no errors. The next 3.0.x or 3.1.0 release will exercise this step in CI.

## Acceptance criteria from #64

- [x] Package validation tool step added to `release.yml` after Pack.
- [x] Step validates all three `.nupkg` files.
- [x] Validation checks metadata completeness (author, license, README, icon).
- [x] Release workflow fails if any validation check fails (`failed=1; exit 1`).

## Test plan

- [ ] CI green on the PR-level matrix (`ci.yml` runs build/test/format/CodeQL — release.yml is tag-triggered and won't fire here).
- [ ] commitlint passes.
- [ ] Reproducibility check passes.
- [ ] On the next release tag, the new step runs and passes.