### PR TITLE
ci(release): publish to NuGet.org via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
     - name: Download packages
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -269,13 +270,19 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
+    - name: Login to NuGet.org via OIDC
+      id: nuget-login
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1.2.0
+      with:
+        user: ${{ vars.NUGET_USER }}
+
     - name: Push to NuGet.org
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
         set -euo pipefail
         if [[ -z "${NUGET_API_KEY:-}" ]]; then
-          echo "::error::NUGET_API_KEY secret is not set." >&2
+          echo "::error::OIDC login did not return a NuGet API key. Verify the trusted-publisher entry on nuget.org." >&2
           exit 1
         fi
         for pkg in ./artifacts/*.nupkg; do


### PR DESCRIPTION
## Summary

Refs #59. Replaces the long-lived `NUGET_API_KEY` GitHub Actions secret with a short-lived OIDC-minted token via Microsoft's official `NuGet/login` action. Even if GitHub Actions secrets storage is compromised, an attacker can no longer push arbitrary versions to nuget.org under the package owner's identity — there is no stored push credential to leak.

## Changes (single file: `.github/workflows/release.yml`, publish job)

1. Add `id-token: write` to the publish job's permissions block. Required so `NuGet/login` can mint a GitHub OIDC token for this workflow run.
2. New `Login to NuGet.org via OIDC` step uses `NuGet/login@8d196754` (v1.2.0, SHA-pinned per repo convention). The `user` input reads from `vars.NUGET_USER` — a repository **variable** (not a secret) so the username is non-sensitive and easy to change.
3. `Push to NuGet.org` step now reads its API key from the login step's output (`steps.nuget-login.outputs.NUGET_API_KEY`) — a short-lived token scoped to this push, not a stored secret.

The GitHub Packages mirror step is unchanged — it already uses the per-run `secrets.GITHUB_TOKEN`, which is OIDC-equivalent.

## ⚠️ Maintainer action required BEFORE merging or pushing the next release tag

This PR does not, by itself, complete #59. The trusted-publisher entries on nuget.org and the repository variable are out-of-band actions that only the maintainer can perform:

1. **Create the trusted publisher entries on nuget.org.** For *each* of the three packages (`QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection`):
   - Open the package's "Manage Owners" / "Manage Package" page on nuget.org.
   - Add a Trusted Publisher entry pointing at `AbongileBoja/QuerySpec`, workflow `release.yml`, environment `nuget-release` (matches `release.yml` line 254-256).
2. **Set the `NUGET_USER` repository variable.** GitHub repo → Settings → Secrets and variables → Actions → Variables tab → New repository variable. Name: `NUGET_USER`. Value: your nuget.org username (the one that owns the QuerySpec packages — likely `AbongileBoja`).
3. **Verify on a pre-release tag** (e.g. `v3.0.1-rc1`). Push the tag and confirm the publish job's "Login to NuGet.org via OIDC" step reports a successful exchange and the push succeeds.
4. **Delete the `NUGET_API_KEY` repository secret** (Settings → Secrets and variables → Actions → Secrets) only AFTER step 3 succeeds end-to-end.

If step 3 fails, this PR is fully revertible — `git revert` brings back the API-key push, and the existing `NUGET_API_KEY` secret continues to work.

## Why this stays open until the maintainer steps complete

Issue #59's acceptance criteria require a successful OIDC release before closing. This PR ships the workflow change; the issue stays open until the maintainer completes steps 1-4 above on the next release.

## Static-analyzer note

The IDE/lint flag on `vars.NUGET_USER` is GitHub Actions complaining that it can't statically verify the variable exists. That resolves to a runtime check once the variable is set per step 2 above; the warning is expected and harmless.

## Test plan

- [ ] CI green (the change is workflow-only, no source code touched).
- [ ] dotnet format passes (no .cs files changed).
- [ ] commitlint passes.
- [ ] (Maintainer) Pre-release tag `v3.0.1-rcN` succeeds via OIDC.
- [ ] (Maintainer) Delete `NUGET_API_KEY` secret after #4.
- [ ] (Maintainer) Close #59.