### PR TITLE
chore(core): use System.Threading.Lock on .NET 9+ for lock primitives

### DIFF
--- a/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
+++ b/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
@@ -48,7 +48,11 @@ public class N1DetectionEngine
     }
 
     private readonly Dictionary<string, QueryInfo> _queriesByHash = new(StringComparer.Ordinal);
+#if NET9_0_OR_GREATER
+    private readonly System.Threading.Lock _lockObj = new();
+#else
     private readonly object _lockObj = new();
+#endif
 
     /// <summary>Initializes a new N+1 detection engine.</summary>
     public N1DetectionEngine() { }

--- a/src/QuerySpec.Core/Monitoring/QueryMetrics.cs
+++ b/src/QuerySpec.Core/Monitoring/QueryMetrics.cs
@@ -81,7 +81,11 @@ public class MetricsCollector
     private readonly Queue<QueryMetrics> _metrics = new();
     private readonly int _maxRetainedQueries;
     private readonly TimeProvider _timeProvider;
+#if NET9_0_OR_GREATER
+    private readonly System.Threading.Lock _lockObj = new();
+#else
     private readonly object _lockObj = new();
+#endif
 
     /// <summary>
     /// Initialises a new metrics collector with the default retention cap of

--- a/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
+++ b/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
@@ -13,7 +13,11 @@ public class CircuitBreaker
     private CircuitState _state = CircuitState.Closed;
     private DateTime _lastFailureTime = DateTime.MinValue;
     private int _failureCount;
+#if NET9_0_OR_GREATER
+    private readonly System.Threading.Lock _lockObj = new();
+#else
     private readonly object _lockObj = new();
+#endif
 
     /// <summary>Number of failures before opening the circuit.</summary>
     public int FailureThreshold { get; set; } = 5;

--- a/src/QuerySpec.Core/Resilience/RateLimiter.cs
+++ b/src/QuerySpec.Core/Resilience/RateLimiter.cs
@@ -22,7 +22,11 @@ public class RateLimiter
 {
     private sealed class Bucket
     {
+#if NET9_0_OR_GREATER
+        public readonly System.Threading.Lock Sync = new();
+#else
         public readonly object Sync = new();
+#endif
         public double Tokens;
         public long LastRefillTicks;
     }


### PR DESCRIPTION
## Summary

- Replaces `private readonly object _lockObj = new()` with a conditional-compilation block that selects `System.Threading.Lock` on .NET 9+ and falls back to `object` on .NET 8.
- Applied to four sites: `CircuitBreaker`, `RateLimiter.Bucket`, `N1DetectionEngine`, and `MetricsCollector`.
- `lock (_lockObj)` call sites are unchanged — the lock-statement syntax accepts both types identically.
- Silences MA0158 (Meziantou) on all four files on net9+ TFMs.

## Test plan

- [ ] Build passes on net8, net9, and net10 (`dotnet build -warnaserror` per TFM)
- [ ] Resilience tests (CircuitBreaker, RateLimiter) pass unchanged on all three TFMs
- [ ] Monitoring tests (N1DetectionEngine, MetricsCollector) pass unchanged on all three TFMs
- [ ] Zero MA0158 diagnostics on the four touched files on net9+

Closes #48