### PR TITLE
perf(core): eliminate params object[] alloc in CacheKeyGenerator hot path

### DIFF
--- a/benchmarks/QuerySpec.Benchmarks/CacheKeyGeneratorBenchmarks.cs
+++ b/benchmarks/QuerySpec.Benchmarks/CacheKeyGeneratorBenchmarks.cs
@@ -38,8 +38,12 @@ public class CacheKeyGeneratorBenchmarks
     public string Long_ForcesHash()
         => CacheKeyGenerator.GenerateKey("query", _longComponents);
 
-    /// <summary>Typed helper used by the query layer.</summary>
-    [Benchmark]
+    /// <summary>
+    /// Typed helper used by the query layer — no boxing of the <c>int page</c> arg,
+    /// no <c>object[]</c> allocation on the params call site.
+    /// This is the primary regression target for issue #58.
+    /// </summary>
+    [Benchmark(Baseline = true)]
     public string QueryCacheKey()
         => CacheKeyGenerator.GenerateQueryCacheKey("tenant-1", "user-42", "qhash", "shash", 1);
 }

--- a/src/QuerySpec.Core/Caching/CacheKeyGenerator.cs
+++ b/src/QuerySpec.Core/Caching/CacheKeyGenerator.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -21,8 +19,16 @@ public class CacheKeyGenerator
     /// into a deterministic SHA-256 digest so they fit within Redis / Memcached key limits.
     /// Uses <see cref="SHA256.HashData(byte[])"/> which is allocation-lean compared with
     /// creating a new <see cref="SHA256"/> instance per call.
+    /// On .NET 9+, the <c>params ReadOnlySpan&lt;object?&gt;</c> overload avoids the
+    /// <c>object[]</c> heap allocation at the call site for inline argument lists.
+    /// Value-type arguments still box individually; use the strongly-typed overloads on
+    /// high-frequency call sites to eliminate that residual boxing.
     /// </summary>
-    public static string GenerateKey(string prefix, params object[] components)
+#if NET9_0_OR_GREATER
+    public static string GenerateKey(string prefix, params ReadOnlySpan<object?> components)
+#else
+    public static string GenerateKey(string prefix, params object?[] components)
+#endif
     {
         // Build the key with a single StringBuilder pass to avoid the intermediate
         // List + LINQ chain + string.Join that the original implementation produced.
@@ -36,6 +42,47 @@ public class CacheKeyGenerator
             sb.Append(':').Append(s);
         }
 
+        return FinaliseKey(prefix, sb);
+    }
+
+    /// <summary>
+    /// Strongly-typed overload for query cache keys. Avoids boxing of <paramref name="page"/>
+    /// on all TFMs by appending the integer directly without going through <c>object?</c>.
+    /// This is the high-frequency path and accounts for the majority of <c>GenerateKey</c>
+    /// call volume under normal application load.
+    /// </summary>
+    public static string GenerateQueryCacheKey(string tenantId, string userId, string queryHash, string sortHash, int page)
+    {
+        var sb = new StringBuilder(64);
+        sb.Append("query");
+        AppendIfNonEmpty(sb, tenantId);
+        AppendIfNonEmpty(sb, userId);
+        AppendIfNonEmpty(sb, queryHash);
+        AppendIfNonEmpty(sb, sortHash);
+        sb.Append(':').Append(page);
+        return FinaliseKey("query", sb);
+    }
+
+    /// <summary>Generates a security policy cache key.</summary>
+    public static string GenerateSecurityPolicyCacheKey(string resourceType)
+    {
+        return GenerateKey("policy", resourceType);
+    }
+
+    /// <summary>Generates a permission cache key.</summary>
+    public static string GeneratePermissionCacheKey(string userId, string resourceType, string fieldName)
+    {
+        return GenerateKey("permission", userId, resourceType, fieldName);
+    }
+
+    private static void AppendIfNonEmpty(StringBuilder sb, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+            sb.Append(':').Append(value);
+    }
+
+    private static string FinaliseKey(string prefix, StringBuilder sb)
+    {
         var key = sb.ToString();
         if (key.Length <= MaxKeyLength)
             return key;
@@ -56,23 +103,5 @@ public class CacheKeyGenerator
             SHA256.HashData(heapBuf, digest);
         }
         return string.Concat(prefix, ":", Convert.ToBase64String(digest));
-    }
-
-    /// <summary>Generates a query cache key.</summary>
-    public static string GenerateQueryCacheKey(string tenantId, string userId, string queryHash, string sortHash, int page)
-    {
-        return GenerateKey("query", tenantId, userId, queryHash, sortHash, page);
-    }
-
-    /// <summary>Generates a security policy cache key.</summary>
-    public static string GenerateSecurityPolicyCacheKey(string resourceType)
-    {
-        return GenerateKey("policy", resourceType);
-    }
-
-    /// <summary>Generates a permission cache key.</summary>
-    public static string GeneratePermissionCacheKey(string userId, string resourceType, string fieldName)
-    {
-        return GenerateKey("permission", userId, resourceType, fieldName);
     }
 }


### PR DESCRIPTION
## Summary

- Multi-targeted `GenerateKey` signature: `params ReadOnlySpan<object?>` on .NET 9+, `params object?[]` fallback on .NET 8. Eliminates the `object[]` heap allocation for inline argument lists on net9+.
- New strongly-typed `GenerateQueryCacheKey` overload builds the key directly via `StringBuilder` without boxing `int page` or allocating a params array on any TFM. This is the highest-frequency call site.
- Shared `FinaliseKey` / `AppendIfNonEmpty` helpers keep the hashing/truncation path DRY.

## Benchmark results (net10.0, Release, BDN v0.14.0, 12th Gen i3-1215U)

| Method | Mean | Allocated |
|---|---|---|
| `QueryCacheKey` (post-fix) | 129 ns | 296 B |
| `QueryCacheKey` (pre-fix, estimated) | ~135 ns | ~396 B |
| `Short_Components` (params path) | 135 ns | 288 B |

Allocation delta on `GenerateQueryCacheKey`: **-100 B/op (~25%)** — the `object[5]` array (~72 B) and the boxed `int` (~28 B) are both eliminated. The remaining 296 B is the returned `string` + `StringBuilder`, which are unavoidable.

Residual boxing: `GenerateKey` callers that pass value types as inline `params` arguments still box individually. `GeneratePermissionCacheKey` and `GenerateSecurityPolicyCacheKey` are string-only — no boxing there.

## Test results

All three TFMs clean:
- net8.0: 355 passed, 0 failed
- net9.0: 355 passed, 0 failed
- net10.0: 355 passed, 0 failed

## Risk and verification

- No public API removed; `GenerateQueryCacheKey` signature is unchanged.
- `GenerateKey` signature change is source-compatible on all TFMs; callers using `params` continue to compile unchanged.
- `#if NET9_0_OR_GREATER` guard keeps net8 on the array path, which is correct.

Closes #58