### PR TITLE
test(monitoring): cover N1DetectionEngine eviction/truncation paths and HealthStatus contract

### DIFF
--- a/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
+++ b/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -203,6 +204,7 @@ public class SuspiciousPattern
 /// <summary>
 /// Health check provider for dependency health.
 /// </summary>
+/// <remarks>No concrete implementation ships in this version. Tracked for evaluation in 3.0.</remarks>
 public interface IHealthCheckProvider
 {
     /// <summary>Checks database health.</summary>
@@ -218,6 +220,8 @@ public interface IHealthCheckProvider
 /// <summary>
 /// Health status of a component.
 /// </summary>
+/// <remarks>No concrete implementation ships in this version. Tracked for evaluation in 3.0.</remarks>
+[ExcludeFromCodeCoverage]
 public class HealthStatus
 {
     /// <summary>Whether the component is healthy.</summary>

--- a/tests/QuerySpec.Core.Tests/Monitoring/N1DetectionEngineEvictionTests.cs
+++ b/tests/QuerySpec.Core.Tests/Monitoring/N1DetectionEngineEvictionTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Reflection;
+using Xunit;
+using QuerySpec.Core.Monitoring;
+
+namespace QuerySpec.Core.Tests.Monitoring;
+
+public class N1DetectionEngineEvictionTests
+{
+    private static readonly Type QueryInfoType =
+        typeof(N1DetectionEngine).GetNestedType("QueryInfo", BindingFlags.NonPublic)!;
+
+    private static void SeedEngine(N1DetectionEngine engine, int count, long countPerEntry = 5)
+    {
+        var dictField = typeof(N1DetectionEngine)
+            .GetField("_queriesByHash", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = dictField.GetValue(engine)!;
+        var addMethod = dict.GetType().GetMethod("Add")!;
+        var countField = QueryInfoType.GetField("Count")!;
+        var previewField = QueryInfoType.GetField("StackPreview")!;
+        var totalField = QueryInfoType.GetField("TotalTimeMs")!;
+        var maxField = QueryInfoType.GetField("MaxTimeMs")!;
+
+        for (var i = 0; i < count; i++)
+        {
+            var info = Activator.CreateInstance(QueryInfoType)!;
+            countField.SetValue(info, countPerEntry);
+            previewField.SetValue(info, $"seeded-frame-{i}");
+            totalField.SetValue(info, (long)10);
+            maxField.SetValue(info, (long)10);
+            addMethod.Invoke(dict, new[] { $"SEED{i:X8}", info });
+        }
+    }
+
+    private static string SeedOneEntry(N1DetectionEngine engine, string key, long countValue)
+    {
+        var dictField = typeof(N1DetectionEngine)
+            .GetField("_queriesByHash", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = dictField.GetValue(engine)!;
+        var addMethod = dict.GetType().GetMethod("Add")!;
+        var info = Activator.CreateInstance(QueryInfoType)!;
+        QueryInfoType.GetField("Count")!.SetValue(info, countValue);
+        QueryInfoType.GetField("StackPreview")!.SetValue(info, key);
+        QueryInfoType.GetField("TotalTimeMs")!.SetValue(info, (long)10);
+        QueryInfoType.GetField("MaxTimeMs")!.SetValue(info, (long)10);
+        addMethod.Invoke(dict, new[] { key, info });
+        return key;
+    }
+
+    private static bool DictionaryContainsKey(N1DetectionEngine engine, string key)
+    {
+        var dictField = typeof(N1DetectionEngine)
+            .GetField("_queriesByHash", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = dictField.GetValue(engine)!;
+        var containsMethod = dict.GetType().GetMethod("ContainsKey")!;
+        return (bool)containsMethod.Invoke(dict, new[] { key })!;
+    }
+
+    [Fact]
+    public void N1DetectionEngine_EvictionPath_BoundsPatternCount()
+    {
+        var engine = new N1DetectionEngine();
+        SeedEngine(engine, N1DetectionEngine.MaxTrackedPatterns - 1);
+
+        CallRecordQueryAlpha(engine);
+
+        Assert.Equal(N1DetectionEngine.MaxTrackedPatterns, engine.GetReport().TotalPatterns);
+
+        CallRecordQueryBeta(engine);
+
+        Assert.True(
+            engine.GetReport().TotalPatterns <= N1DetectionEngine.MaxTrackedPatterns,
+            $"TotalPatterns exceeded cap {N1DetectionEngine.MaxTrackedPatterns}");
+    }
+
+    [Fact]
+    public void N1DetectionEngine_EvictionPath_EvictsLeastFrequentEntry()
+    {
+        var engine = new N1DetectionEngine();
+        SeedEngine(engine, N1DetectionEngine.MaxTrackedPatterns - 2, countPerEntry: 100);
+
+        var victimKey = SeedOneEntry(engine, "VICTIM-LOW-FREQ", countValue: 1);
+        SeedOneEntry(engine, "HIGH-FREQ-ANCHOR", countValue: 999);
+
+        Assert.Equal(N1DetectionEngine.MaxTrackedPatterns, engine.GetReport().TotalPatterns);
+
+        CallRecordQueryTriggerEviction(engine);
+
+        Assert.False(
+            DictionaryContainsKey(engine, victimKey),
+            "Expected LFU eviction to remove the entry with the lowest count");
+
+        Assert.True(
+            DictionaryContainsKey(engine, "HIGH-FREQ-ANCHOR"),
+            "Expected the high-frequency entry to survive eviction");
+    }
+
+    [Fact]
+    public void N1DetectionEngine_StackPreview_TruncatesLongStacks()
+    {
+        var engine = new N1DetectionEngine { StackPreviewChars = 10 };
+
+        CallRecordQueryForTruncation(engine);
+
+        var dictField = typeof(N1DetectionEngine)
+            .GetField("_queriesByHash", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = dictField.GetValue(engine)!;
+
+        var enumerator = ((System.Collections.IEnumerable)dict).GetEnumerator();
+        Assert.True(enumerator.MoveNext(), "Expected at least one entry in the dictionary");
+
+        var kvp = enumerator.Current;
+        var value = kvp.GetType().GetProperty("Value")!.GetValue(kvp)!;
+        var stackPreview = (string)QueryInfoType.GetField("StackPreview")!.GetValue(value)!;
+
+        Assert.True(
+            stackPreview.Length <= 10,
+            $"Expected StackPreview.Length <= 10 but was {stackPreview.Length}: '{stackPreview}'");
+    }
+
+    private static void CallRecordQueryAlpha(N1DetectionEngine engine)
+        => engine.RecordQuery("SELECT alpha", 1);
+
+    private static void CallRecordQueryBeta(N1DetectionEngine engine)
+        => engine.RecordQuery("SELECT beta", 1);
+
+    private static void CallRecordQueryTriggerEviction(N1DetectionEngine engine)
+        => engine.RecordQuery("SELECT trigger-eviction", 1);
+
+    private static void CallRecordQueryForTruncation(N1DetectionEngine engine)
+        => engine.RecordQuery("SELECT truncation-test", 1);
+}


### PR DESCRIPTION
## Summary

- Adds three tests covering the previously 0%-covered eviction loop and stack-preview truncation branch in `N1DetectionEngine`
- Applies `[ExcludeFromCodeCoverage]` to `HealthStatus` (Option B) — no concrete `IHealthCheckProvider` implementation ships in this version; the type is speculative and is tracked for evaluation in 3.0

## HealthStatus decision

`IHealthCheckProvider` has no concrete implementation anywhere in the library. Option A (implement a real health-check provider) would add a meaningful feature; however the interface has four methods with no defined semantics, no connection to any existing subsystem, and no caller in the codebase. Shipping a half-baked implementation to satisfy a coverage metric would be worse than acknowledging the gap explicitly. Option B — `[ExcludeFromCodeCoverage]` scoped to `HealthStatus` plus a `<remarks>` note pointing at 3.0 — is the honest choice. A follow-on issue should decide whether to promote the type to a real feature or remove it.

## Tests added

`tests/QuerySpec.Core.Tests/Monitoring/N1DetectionEngineEvictionTests.cs`

| Test | What it covers |
|---|---|
| `N1DetectionEngine_EvictionPath_BoundsPatternCount` | eviction loop executes when dictionary is at cap; `TotalPatterns <= MaxTrackedPatterns` after adding beyond the cap |
| `N1DetectionEngine_EvictionPath_EvictsLeastFrequentEntry` | LFU eviction: victim (count=1) is removed, high-frequency anchor (count=999) survives |
| `N1DetectionEngine_StackPreview_TruncatesLongStacks` | `StackPreviewChars = 10` stores a preview of at most 10 characters |

Tests use reflection to pre-seed the private dictionary (avoiding the need for 1024+ uniquely-named call sites), call `RecordQuery` from uniquely-named static methods to produce distinct stack fingerprints, and contain no wall-clock waits.

## Closes

Closes #83