### PR TITLE
chore(ci): add .editorconfig and gate dotnet format in CI (#65)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,144 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+
+# File-scoped namespaces — the vast majority of the codebase uses this form. One test
+# file (ComplianceExporterTests) uses a block-scoped namespace. Relaxed to :silent until
+# a cleanup PR normalises it; promote to :warning once every file complies.
+csharp_style_namespace_declarations = file_scoped:silent
+
+# using directives go outside the namespace block.
+csharp_using_directive_placement = outside_namespace:warning
+
+# var — use var when the type is apparent from the right-hand side.
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false:silent
+
+# Expression-bodied members — the codebase uses a mix of block-body and expression-body
+# forms. Relaxed to :silent to avoid forcing a mass-format pass on existing files.
+# A separate cleanup PR can promote these to :warning once all sites comply.
+csharp_style_expression_bodied_methods = when_on_single_line:silent
+csharp_style_expression_bodied_properties = when_on_single_line:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = when_on_single_line:silent
+csharp_style_expression_bodied_indexers = when_on_single_line:silent
+csharp_style_expression_bodied_accessors = when_on_single_line:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+
+# Braces — Allman style (opening brace on its own line).
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = true
+
+# Spacing
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Wrapping
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+# Pattern matching — most of the codebase uses modern pattern matching, but a handful of
+# sites in MigratingEncryptionProvider and test files use older forms. IDE0078 and
+# IDE0054/IDE0078 relaxed to :silent until a cleanup PR migrates those sites.
+csharp_style_pattern_matching_over_is_with_cast_check = true:silent
+csharp_style_pattern_matching_over_as_with_null_check = true:silent
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_not_pattern = true:warning
+
+# Null-checking idioms.
+csharp_style_prefer_null_check_over_type_check = true:warning
+csharp_style_throw_expression = true:silent
+csharp_style_conditional_delegate_call = true:warning
+
+# Modifier ordering required by the codebase.
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
+
+# this. qualifier — not used in the codebase.
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Language keywords vs framework type names.
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Object/collection initialisers — used throughout.
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+
+# Null-propagation idioms.
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_coalesce_expression = true:warning
+
+# Explicit tuple names.
+dotnet_style_explicit_tuple_names = true:warning
+
+# Prefer inferred tuple and anonymous-type member names.
+dotnet_style_prefer_inferred_tuple_names = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:silent
+
+# Auto-properties — AuditContext and similar classes use backing fields with null-guard
+# setters that cannot be auto-properties. Relaxed to :silent; a cleanup PR can tighten.
+dotnet_style_prefer_auto_properties = true:silent
+
+# Compound assignment operators.
+dotnet_style_prefer_compound_assignment = true:warning
+
+# Simplified boolean expressions.
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+
+# Readonly fields — enforce where applicable.
+dotnet_style_readonly_field = true:warning
+
+# Accessibility modifiers — always explicit.
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Parentheses preferences.
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+
+[*.{csproj,props,targets}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -65,8 +65,9 @@ csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_call_name_and_opening_parenthesis = false
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
 
-# Wrapping
-csharp_preserve_single_line_statements = false
+# Wrapping — the codebase uses inline single-line statements (e.g. `if (x == null) return;`).
+# csharp_preserve_single_line_statements = true preserves them rather than forcing splits.
+csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 
 # Pattern matching — most of the codebase uses modern pattern matching, but a handful of


### PR DESCRIPTION
## Summary

- Adds a root `.editorconfig` that codifies the conventions already present across all `src/`, `tests/`, and `samples/` `.cs` files: 4-space indentation, Allman braces, `lf` line endings (matching `.gitattributes`), `var`-when-apparent, file-scoped namespaces, `using` directives outside the namespace block.
- The CI `dotnet format` job (`--verify-no-changes --severity warn`) was already present and correct; this file gives it a contributor-visible configuration to enforce rather than relying on IDE convention only.
- No source files are changed. Rules that have non-compliant existing files are set to `:silent`; a follow-up PR can promote each to `:warning` once the affected files are fixed.

## Rules set to :silent (disagreement with current state)

| Rule | Why relaxed |
|---|---|
| `csharp_style_namespace_declarations` | `ComplianceExporterTests.cs` uses a block-scoped namespace. |
| `csharp_style_expression_bodied_methods/properties` | Mixed usage in `CacheKeyGenerator`, `EntityAuditTrail`, `CustomOperatorRegistry`. |
| `dotnet_style_prefer_auto_properties` | `AuditContext` uses null-guard backing fields that cannot be auto-properties. |
| `csharp_style_pattern_matching_over_is_with_cast_check` | `MigratingEncryptionProvider` and `QuerySpecExpressionTranslatorTests` have legacy sites. |

## node_modules/.editorconfig

`node_modules/` is covered by `.gitignore` (line 281: `node_modules/`). The stale copies are invisible to git and are not indexed by `dotnet format`.

## Test plan

- [ ] CI `dotnet format` gate passes (all existing errors are Windows CRLF line-ending artefacts; on Linux CI with LF checkout they are absent).
- [ ] CI build, test, CodeQL, and reproducibility gates unaffected (`.editorconfig` is not a build input).
- [ ] New contributor adds a `.cs` file with a block-scoped namespace; IDE warns via `IDE0161` (once the rule is promoted from :silent to :warning in the follow-up).

Closes #65