### PR TITLE
test(efcore): add property-based tests, replace silent catch-all with NotSupportedException

### DIFF
--- a/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
+++ b/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
@@ -259,11 +259,13 @@ public class QuerySpecExpressionTranslator
 
             FilterOperator.DateInRange when filter.TemporalStart.HasValue && filter.TemporalEnd.HasValue =>
                 BuildDateInRange(property, filter.TemporalStart.Value, filter.TemporalEnd.Value, isNullable),
+            FilterOperator.DateInRange =>
+                throw new NotSupportedException($"FilterOperator 'DateInRange' requires both TemporalStart and TemporalEnd to be set."),
             FilterOperator.DateAfter => BuildDateComparison(property, filter.Value, ExpressionType.GreaterThan, isNullable),
             FilterOperator.DateBefore => BuildDateComparison(property, filter.Value, ExpressionType.LessThan, isNullable),
             FilterOperator.DateEquals => BuildDateEquals(property, filter.Value, isNullable),
 
-            _ => Expression.Constant(true)
+            var op => throw new NotSupportedException($"FilterOperator '{op}' is not implemented in the EF Core translator.")
         };
     }
 
@@ -481,6 +483,9 @@ public class QuerySpecExpressionTranslator
             var hasValue = Expression.Property(property, hvProp);
             return Expression.Not(hasValue);
         }
+
+        if (property.Type.IsValueType)
+            return Expression.Constant(false);
 
         return Expression.Equal(property, Expression.Constant(null, property.Type));
     }

--- a/tests/QuerySpec.Core.Tests/Properties/StableHashPropertyTests.cs
+++ b/tests/QuerySpec.Core.Tests/Properties/StableHashPropertyTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using CsCheck;
+using QuerySpec.Core.Advanced;
+using Xunit;
+
+namespace QuerySpec.Core.Tests.Properties;
+
+[Trait("Category", "PropertyBased")]
+public sealed class StableHashPropertyTests
+{
+    private static readonly FilterOperator[] LeafOperators =
+    [
+        FilterOperator.Equal, FilterOperator.NotEqual,
+        FilterOperator.GreaterThan, FilterOperator.LessThan,
+        FilterOperator.Contains, FilterOperator.StartsWith, FilterOperator.EndsWith,
+        FilterOperator.IsNull, FilterOperator.IsNotNull,
+        FilterOperator.IsEmpty, FilterOperator.IsNotEmpty
+    ];
+
+    private static readonly string[] Fields = ["Name", "Age", "IsActive", "Score", "CreatedAt"];
+
+    private static Gen<AdvancedFilterExpression> LeafFilterGen() =>
+        Gen.Select(
+            Gen.OneOfConst(Fields),
+            Gen.OneOfConst(LeafOperators),
+            Gen.String,
+            (field, op, value) => new AdvancedFilterExpression
+            {
+                Field = field,
+                Operator = op,
+                Value = value
+            });
+
+    private static Gen<AdvancedFilterExpression> ComposedFilterGen(int maxDepth = 8)
+    {
+        return Gen.Recursive<AdvancedFilterExpression>((depth, inner) =>
+        {
+            if (depth >= maxDepth)
+                return LeafFilterGen();
+
+            return Gen.Frequency(
+                (3, LeafFilterGen()),
+                (1, Gen.Select(
+                    inner,
+                    inner,
+                    Gen.OneOfConst(new[] { LogicalOperator.And, LogicalOperator.Or }),
+                    (left, right, logic) => new AdvancedFilterExpression
+                    {
+                        Field = left.Field,
+                        Operator = left.Operator,
+                        Value = left.Value,
+                        Logic = logic,
+                        Filters = new System.Collections.Generic.List<AdvancedFilterExpression> { left, right }
+                    })));
+        });
+    }
+
+    [Fact]
+    public void ComputeStableHash_StructurallyDistinctFilters_ProduceDistinctHashes()
+    {
+        const int sampleSize = 5000;
+        const double minDistinctRatio = 0.95;
+
+        var hashes = new System.Collections.Concurrent.ConcurrentBag<long>();
+
+        Check.Sample(ComposedFilterGen(), filter =>
+        {
+            hashes.Add(filter.ComputeStableHash());
+        }, iter: sampleSize, threads: 1);
+
+        var total = hashes.Count;
+        var distinct = new HashSet<long>(hashes).Count;
+        var actualRatio = (double)distinct / total;
+        Assert.True(actualRatio >= minDistinctRatio,
+            $"Hash cardinality ratio {actualRatio:P1} is below minimum {minDistinctRatio:P1} ({distinct} distinct hashes from {total} samples). " +
+            "This indicates a collision rate that is too high for a cache key and signals a bug in ComputeStableHash.");
+    }
+}

--- a/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
+++ b/tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CsCheck" Version="3.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/QuerySpec.EFCore.Tests/Properties/FilterTranslatorPropertyTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/Properties/FilterTranslatorPropertyTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CsCheck;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using QuerySpec.Core.Advanced;
+using QuerySpec.EFCore;
+using Xunit;
+
+namespace QuerySpec.EFCore.Tests.Properties;
+
+[Trait("Category", "PropertyBased")]
+public sealed class FilterTranslatorPropertyTests : IDisposable
+{
+    private sealed class SampleEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Age { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public decimal? Score { get; set; }
+    }
+
+    private sealed class SampleContext : DbContext
+    {
+        public DbSet<SampleEntity> Entities => Set<SampleEntity>();
+        public SampleContext(DbContextOptions<SampleContext> options) : base(options) { }
+    }
+
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<SampleContext> _options;
+
+    public FilterTranslatorPropertyTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<SampleContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using var ctx = new SampleContext(_options);
+        ctx.Database.EnsureCreated();
+        ctx.Entities.AddRange(
+            new SampleEntity { Id = 1, Name = "Alice", Age = 30, IsActive = true, CreatedAt = new DateTime(2024, 1, 1), Score = 9.5m },
+            new SampleEntity { Id = 2, Name = "Bob", Age = 25, IsActive = false, CreatedAt = new DateTime(2024, 6, 15), Score = null },
+            new SampleEntity { Id = 3, Name = "Carol", Age = 40, IsActive = true, CreatedAt = new DateTime(2023, 12, 31), Score = 7.0m });
+        ctx.SaveChanges();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private static readonly FilterOperator[] ImplementedStringOperators =
+    [
+        FilterOperator.Equal, FilterOperator.NotEqual,
+        FilterOperator.Contains, FilterOperator.NotContains,
+        FilterOperator.StartsWith, FilterOperator.EndsWith,
+        FilterOperator.StringMatchCase, FilterOperator.StringMatchIgnoreCase,
+        FilterOperator.Contains_CaseInsensitive,
+        FilterOperator.IsNull, FilterOperator.IsNotNull,
+        FilterOperator.IsEmpty, FilterOperator.IsNotEmpty
+    ];
+
+    private static readonly FilterOperator[] ImplementedIntOperators =
+    [
+        FilterOperator.Equal, FilterOperator.NotEqual,
+        FilterOperator.GreaterThan, FilterOperator.GreaterThanOrEqual,
+        FilterOperator.LessThan, FilterOperator.LessThanOrEqual,
+        FilterOperator.IsNull, FilterOperator.IsNotNull
+    ];
+
+    private static readonly FilterOperator[] ImplementedBoolOperators =
+    [
+        FilterOperator.Equal, FilterOperator.NotEqual
+    ];
+
+    private static readonly FilterOperator[] UnimplementedOperators =
+    [
+        FilterOperator.AnyMatch, FilterOperator.AllMatch,
+        FilterOperator.CountGreaterThan, FilterOperator.CountLessThan,
+        FilterOperator.FullTextSearch, FilterOperator.GeoDistance, FilterOperator.GeoWithin,
+        FilterOperator.RelativeDate, FilterOperator.BitwiseAnd, FilterOperator.BitwiseOr,
+        FilterOperator.Custom
+    ];
+
+    private static Gen<AdvancedFilterExpression> StringFieldFilterGen() =>
+        Gen.Select(
+            Gen.OneOfConst(ImplementedStringOperators),
+            Gen.String,
+            (op, value) => new AdvancedFilterExpression
+            {
+                Field = "Name",
+                Operator = op,
+                Value = value,
+                CaseSensitive = false
+            });
+
+    private static Gen<AdvancedFilterExpression> IntFieldFilterGen() =>
+        Gen.Select(
+            Gen.OneOfConst(ImplementedIntOperators),
+            Gen.Int,
+            (op, value) => new AdvancedFilterExpression
+            {
+                Field = "Age",
+                Operator = op,
+                Value = value
+            });
+
+    private static Gen<AdvancedFilterExpression> BoolFieldFilterGen() =>
+        Gen.Select(
+            Gen.OneOfConst(ImplementedBoolOperators),
+            Gen.Bool,
+            (op, value) => new AdvancedFilterExpression
+            {
+                Field = "IsActive",
+                Operator = op,
+                Value = value
+            });
+
+    private static Gen<AdvancedFilterExpression> ValidFilterGen() =>
+        Gen.OneOf<AdvancedFilterExpression>(
+            StringFieldFilterGen(),
+            IntFieldFilterGen(),
+            BoolFieldFilterGen());
+
+    private static Gen<AdvancedFilterExpression> UnhandledOperatorFilterGen() =>
+        Gen.Select(
+            Gen.OneOfConst(UnimplementedOperators),
+            op => new AdvancedFilterExpression
+            {
+                Field = "Name",
+                Operator = op,
+                Value = "test"
+            });
+
+    [Fact]
+    public void ApplyFilter_OnValidFilter_NeverThrowsArgumentException()
+    {
+        Check.Sample(ValidFilterGen(), filter =>
+        {
+            using var ctx = new SampleContext(_options);
+            try
+            {
+                _ = QuerySpecExpressionTranslator.ApplyFilter(ctx.Entities.AsQueryable(), filter).ToList();
+            }
+            catch (NotSupportedException) { }
+            catch (InvalidCastException) { }
+            catch (Exception ex) when (ex is ArgumentException or NullReferenceException)
+            {
+                throw new Exception(
+                    $"ApplyFilter threw {ex.GetType().Name} for operator {filter.Operator} on field '{filter.Field}': {ex.Message}", ex);
+            }
+        }, iter: 1000, threads: 1);
+    }
+
+    [Fact]
+    public void ApplyFilter_OnUnhandledOperator_ThrowsNotSupportedException()
+    {
+        Check.Sample(UnhandledOperatorFilterGen(), filter =>
+        {
+            using var ctx = new SampleContext(_options);
+            Assert.Throws<NotSupportedException>(() =>
+                QuerySpecExpressionTranslator.ApplyFilter(ctx.Entities.AsQueryable(), filter).ToList());
+        }, iter: 500, threads: 1);
+    }
+}

--- a/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
+++ b/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="CsCheck" Version="3.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Replaces the `_ => Expression.Constant(true)` fall-through arm in `BuildOperatorExpression` with `var op => throw new NotSupportedException(...)`. Any `FilterOperator` value added to the enum without a corresponding case now fails loudly at translation time instead of silently returning every row (a silent over-fetch / data-leak vector).
- Adds `DateInRange` without `TemporalStart`/`TemporalEnd` as its own explicit throwing case, separate from the general fall-through.
- Fixes a pre-existing bug in `BuildIsNull` for non-nullable value types: `Expression.Equal(intExpr, null)` is not a valid expression tree and threw `ArgumentException`. A non-nullable value type can never be null; the fix returns `Expression.Constant(false)`. This bug was found by Property A below.
- Adds CsCheck 3.2.2 to `tests/QuerySpec.EFCore.Tests` and `tests/QuerySpec.Core.Tests`.

## Behavioral change note (SemVer consideration)

Code that previously applied an unhandled operator (e.g. `FilterOperator.Custom`, `FilterOperator.FullTextSearch`) would silently receive all rows from the query. After this change, those calls throw `NotSupportedException` at translation time. This is a defect fix (silent over-fetch is worse than an explicit error), not a feature addition, but callers relying on the old silent behavior must handle the exception or switch to a supported operator.

## Generator design

**Property A** (`FilterTranslatorPropertyTests`): `ValidFilterGen` picks one of three sub-generators — string operators on `Name`, integer operators on `Age`, bool operators on `IsActive` — selecting from the whitelist of implemented operators and pairing each with a correctly-typed random value. `UnhandledOperatorFilterGen` picks from the unimplemented operators exclusively. Both run `threads: 1` to avoid sharing the in-memory SQLite connection across threads.

**Property B** (`StableHashPropertyTests`): `ComposedFilterGen` uses `Gen.Recursive` with a 3:1 leaf-to-composite ratio, building And/Or trees up to depth 8 over a field/operator/value triple. Asserts ≥ 95% hash cardinality across 5000 samples.

## Verification that Property A catches the regression

Temporarily reverted the `var op => throw …` arm to the original `_ => Expression.Constant(true)` and ran the property suite. `ApplyFilter_OnUnhandledOperator_ThrowsNotSupportedException` failed immediately because the old catch-all returned a match-all predicate instead of throwing. Restored the fix; both property tests pass.

## Tests updated due to silent fallback

None. No existing test relied on the silent `Expression.Constant(true)` behavior for unimplemented operators.

Closes #78