### PR TITLE
chore(security): mark IEncryptionProvider.RotateKeyAsync obsolete for 3.0 removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to QuerySpec are documented here. Generated from Conventiona
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Deprecations
+
+* **security:** `IEncryptionProvider.RotateKeyAsync()` and `IEncryptionProvider.RotateKeyAsync(CancellationToken)` are marked `[Obsolete(error: true)]` and will be **removed in 3.0**. Every shipping implementation already throws `NotSupportedException` because the provider does not own the persisted ciphertexts. Implement key rotation at the storage layer instead (Azure Key Vault, AWS KMS, etc.): decrypt with the old provider, re-encrypt with the new provider. Closes [#73](https://github.com/AbongileBoja/QuerySpec/issues/73).
+
 ### [3.0.1-rc1](https://github.com/AbongileBoja/QuerySpec/compare/v3.0.0...v3.0.1-rc1) (2026-04-26)
 
 

--- a/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
@@ -113,9 +113,11 @@ public class AesEncryptionProvider : IEncryptionProvider
     /// <summary>
     /// Key rotation requires re-encrypting every ciphertext under the new key. This provider
     /// does not own the persisted ciphertexts. The method previously returned silently which
-    /// gave callers a false belief that rotation had happened.
+    /// gave callers a false belief that rotation had happened. Deprecated and will be removed
+    /// in 3.0; implement rotation at the storage layer.
     /// </summary>
     /// <exception cref="NotSupportedException">Always thrown.</exception>
+    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
     public Task RotateKeyAsync() =>
         throw new NotSupportedException(
             "AesEncryptionProvider does not own the persisted ciphertexts and cannot rotate. " +

--- a/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
@@ -107,9 +107,10 @@ public class AesGcmEncryptionProvider : IAuthenticatedEncryptionProvider, IEncry
     /// holds a single immutable key and does not own the persisted ciphertexts; callers must
     /// implement rotation at their storage layer (decrypt under old key, re-encrypt under new
     /// key). The method is implemented as a throwing stub so callers cannot mistake a no-op
-    /// for a real rotation.
+    /// for a real rotation. Deprecated and will be removed in 3.0.
     /// </summary>
     /// <exception cref="NotSupportedException">Always thrown.</exception>
+    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
     public Task RotateKeyAsync() =>
         throw new NotSupportedException(
             "AesGcmEncryptionProvider does not own the persisted ciphertexts and therefore cannot rotate. " +

--- a/src/QuerySpec.Core/Security/IEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/IEncryptionProvider.cs
@@ -7,11 +7,6 @@ namespace QuerySpec.Core.Security;
 /// <summary>
 /// Defines contract for encryption providers.
 /// </summary>
-/// <remarks>
-/// <see cref="RotateKeyAsync()"/> has a paired <see cref="CancellationToken"/>-accepting overload
-/// added in 2.1. The CT-less overload is preserved for source compatibility and delegates to the
-/// CT overload with <see cref="CancellationToken.None"/>.
-/// </remarks>
 public interface IEncryptionProvider
 {
     /// <summary>Encrypts plaintext using the configured algorithm.</summary>
@@ -23,12 +18,24 @@ public interface IEncryptionProvider
     /// <returns>The recovered UTF-8 plaintext.</returns>
     string Decrypt(string ciphertext);
 
-    /// <summary>Rotates the encryption key for enhanced security.</summary>
+    /// <summary>
+    /// Rotates the encryption key. Deprecated: every shipping implementation throws
+    /// <see cref="NotSupportedException"/> because the provider does not own the persisted
+    /// ciphertexts. Implement rotation at the storage layer (Azure Key Vault, AWS KMS, etc.):
+    /// decrypt under the old provider, re-encrypt under the new provider.
+    /// </summary>
     /// <returns>A task that completes once the rotation has been performed by the implementation.</returns>
+    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
     Task RotateKeyAsync();
-    /// <summary>Rotates the encryption key for enhanced security with cancellation support.</summary>
+    /// <summary>
+    /// Cancellation-aware overload of <see cref="RotateKeyAsync()"/>. Deprecated alongside the
+    /// no-token overload; will be removed in 3.0. Implement key rotation at the storage layer.
+    /// </summary>
     /// <param name="cancellationToken">Token observed by implementations that perform I/O during rotation.</param>
     /// <returns>A task that completes once the rotation has been performed by the implementation.</returns>
+    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
     Task RotateKeyAsync(CancellationToken cancellationToken)
+#pragma warning disable CS0619 // Obsolete-error self-reference: the DIM delegates to the CT-less overload that is itself obsolete; both ship as a coupled deprecation pair removed together in 3.0.
         => RotateKeyAsync();
+#pragma warning restore CS0619
 }

--- a/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
@@ -133,8 +133,10 @@ public sealed class MigratingEncryptionProvider : IEncryptionProvider
     /// under writer). Calling this on the wrapper is almost always a mistake — it would
     /// rotate the inner writer's key without re-encrypting any persisted ciphertexts and
     /// would invalidate the readers for tags pointing at the same physical provider.
+    /// Deprecated and will be removed in 3.0.
     /// </summary>
     /// <exception cref="NotSupportedException">Always thrown.</exception>
+    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
     public Task RotateKeyAsync() =>
         throw new NotSupportedException(
             "MigratingEncryptionProvider does not own the inner providers' keys and cannot rotate. " +

--- a/tests/QuerySpec.Core.Tests/Security/AesGcmEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/AesGcmEncryptionProviderTests.cs
@@ -156,11 +156,13 @@ public class AesGcmEncryptionProviderTests
     }
 
     [Fact]
-    public async Task RotateKeyAsync_Throws_NotSupported()
+    public void RotateKeyAsync_Throws_NotSupported()
     {
         var p = new AesGcmEncryptionProvider(NewKey());
 
-        await Assert.ThrowsAsync<NotSupportedException>(() => p.RotateKeyAsync());
+        var method = typeof(AesGcmEncryptionProvider).GetMethod(nameof(IEncryptionProvider.RotateKeyAsync), Type.EmptyTypes)!;
+        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(p, null));
+        Assert.IsType<NotSupportedException>(ex.InnerException);
     }
 
     [Fact]

--- a/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
@@ -143,10 +143,13 @@ public class MigratingEncryptionProviderTests
     }
 
     [Fact]
-    public async Task RotateKeyAsync_AlwaysThrows()
+    public void RotateKeyAsync_AlwaysThrows()
     {
         var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
-        await Assert.ThrowsAsync<NotSupportedException>(() => migrating.RotateKeyAsync());
+
+        var method = typeof(MigratingEncryptionProvider).GetMethod(nameof(IEncryptionProvider.RotateKeyAsync), Type.EmptyTypes)!;
+        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(migrating, null));
+        Assert.IsType<NotSupportedException>(ex.InnerException);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`IEncryptionProvider.RotateKeyAsync()` and the paired `RotateKeyAsync(CancellationToken)` overload have been dead surface since they shipped — every concrete implementation throws `NotSupportedException` because the provider does not own the persisted ciphertexts. Key rotation is a storage-layer concern: decrypt under the old provider, re-encrypt under the new provider. This PR marks both interface methods and the three concrete implementations (`AesEncryptionProvider`, `AesGcmEncryptionProvider`, `MigratingEncryptionProvider`) with `[Obsolete(..., error: true)]` and queues removal for 3.0.

Closes #73.

## Changes

- `IEncryptionProvider.RotateKeyAsync()` and `IEncryptionProvider.RotateKeyAsync(CancellationToken)`: `[Obsolete(error: true)]`. The CT overload's DIM body delegates to the no-token overload — the self-referencing CS0619 inside the interface itself is suppressed via a localised pragma with an explanatory comment because both overloads ship as a coupled deprecation pair.
- `AesEncryptionProvider.RotateKeyAsync`, `AesGcmEncryptionProvider.RotateKeyAsync`, `MigratingEncryptionProvider.RotateKeyAsync`: `[Obsolete(error: true)]` with the same message so consumers who built their own provider get the same compile-time signal.
- XML docs on the interface methods rewritten to describe the deprecation and point at storage-layer rotation as the migration target.
- The two existing tests that assert `Assert.ThrowsAsync<NotSupportedException>(() => p.RotateKeyAsync())` (in `AesGcmEncryptionProviderTests` and `MigratingEncryptionProviderTests`) switch to `MethodInfo.Invoke` so the test compilation does not see the obsolete-error reference. They still exercise the runtime behaviour for the 2.x line by unwrapping `TargetInvocationException` and asserting `NotSupportedException` is the inner exception.
- `CHANGELOG.md` gains an `[Unreleased]` section with a `Deprecations` sub-entry naming both overloads and the 3.0 removal target.

No internal callers in `src/` exist; the only references were the two test methods listed above.

## SemVer judgment

This is **source-breaking but not binary-breaking**:

- **Source break:** any consumer compiling against the new 2.x interface with `-warnaserror` (or with their own `[Obsolete]` policy) will fail at the call site that previously threw at runtime.
- **Not binary-breaking:** the methods remain in metadata. Existing-built consumer assemblies load and continue to throw `NotSupportedException` exactly as they did before — the wire shape, vtable, and assembly version are unchanged.

The source break is acceptable on a 2.x line because the runtime behaviour was already broken. Anyone calling `RotateKeyAsync` was already on borrowed time; the obsolete-error simply moves the discovery from production to compile time, with a clear migration message.

Note that `#pragma warning disable CS0619` cannot suppress hard CS0619 errors emitted by `[Obsolete(error: true)]` (the language treats them as errors at the parse/bind stage, not warnings) — that is why the tests use reflection rather than the suppression pattern that works for `[Obsolete(error: false)]` (CS0618).

## Test plan

- [x] `dotnet build QuerySpec.sln -warnaserror` — clean (0 warnings, 0 errors)
- [x] `dotnet test --framework net8.0` — 379 + 87 = 466 passed
- [x] `dotnet test --framework net9.0` — 379 + 87 = 466 passed
- [x] `dotnet test --framework net10.0` — 379 + 87 = 466 passed
- [x] Both `RotateKeyAsync_Throws_NotSupported` and `RotateKeyAsync_AlwaysThrows` still verify `NotSupportedException` via the reflection path
- [x] Verified no `RotateKeyAsync(` callers in `src/` other than the three implementations being marked