### PR TITLE
docs(efcore): mark QuerySpecExpressionTranslator for 3.0 static-class conversion

### DIFF
--- a/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
+++ b/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
@@ -15,6 +15,12 @@ namespace QuerySpec.EFCore;
 /// Optimized for enterprise use: cached reflection, EF Core SQL-compatible expressions,
 /// null-safe comparisons, and depth-limited recursion.
 /// </summary>
+/// <remarks>
+/// This class will be marked <c>static</c> in v3.0. Every public member is already static and
+/// the type carries no instance state, so deriving from it or constructing an instance has no
+/// purpose. Do not derive from this class; call the static members directly. Tracked at
+/// <see href="https://github.com/AbongileBoja/QuerySpec/issues/141">#141</see>.
+/// </remarks>
 public class QuerySpecExpressionTranslator
 {
     private const int MaxFilterDepth = 10;


### PR DESCRIPTION
## Summary

`QuerySpec.EFCore.QuerySpecExpressionTranslator` is `public class` with all members `static`, no instance state, and no inheritance hook. The right shape is `public static class`, but flipping that on the 2.x line is a binary-breaking change (`abstract sealed` metadata bits change), so the conversion is locked in until 3.0.

This PR is the lightweight 2.x remediation: a `<remarks>` block on the class telegraphing the planned 3.0 change to consumers reading IntelliSense. No code change. No SemVer impact. Source-compatible and binary-compatible.

The 3.0 conversion itself is tracked at #141 alongside the existing 3.0 trackers (#138 for `RotateKeyAsync` removal, #139 for DI-builder stub removal).

## Changes

- `src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs` — new `<remarks>` block on the type:

  > This class will be marked `static` in v3.0. Every public member is already static and the type carries no instance state, so deriving from it or constructing an instance has no purpose. Do not derive from this class; call the static members directly. Tracked at #141.

## Verification

- `dotnet build src/QuerySpec.EFCore/QuerySpec.EFCore.csproj -warnaserror` — 0 errors across net8.0/net9.0/net10.0. The new XML doc compiles cleanly under the CS1591/1573/1572/1574/1734 promotion landed in #136.
- `dotnet test tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj` — 87/87 passed on each of net8.0, net9.0, net10.0.

Closes #79.

Tracking: #141.