### PR TITLE
docs(release): document supported TFM policy and netstandard2.0 stance

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Supported TFM policy: net8.0 (LTS), net9.0 (STS), net10.0 (LTS). netstandard2.0 is intentionally excluded — see README "Supported frameworks". -->
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Version>0.0.0-local</Version>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ dotnet add package QuerySpec.DependencyInjection
 
 Most apps want all three. Core alone is fine if you're not using EF Core or DI.
 
+## Supported frameworks
+
+QuerySpec targets `net8.0` (LTS, supported through November 2026), `net9.0` (STS, supported through May 2026), and `net10.0` (LTS). These are the only supported TFMs. `netstandard2.0` is not targeted.
+
+The library relies on APIs that are unavailable on `netstandard2.0`: `System.Threading.Lock`, `params ReadOnlySpan<T>`, `TimeProvider`, async `JsonSerializer` overloads, and related BCL surface. Adding a `netstandard2.0` target would require either reverting those improvements or shipping a parallel conditional-compilation codebase — a cost that does not make sense for an enterprise data-access library targeting modern .NET.
+
+Consumers on .NET Framework 4.x or older runtimes should use [Ardalis.Specification](https://github.com/ardalis/Specification) or another `netstandard2.0`-compatible alternative.
+
+For the .NET support lifecycle see https://dotnet.microsoft.com/platform/support/policy/dotnet-core.
+
 ## Applying a filter to an EF Core query
 
 ```csharp


### PR DESCRIPTION
## Summary

Closes #66

Option 2 taken: document the explicit TFM policy rather than adding a `netstandard2.0` target.

The library relies on `System.Threading.Lock`, `params ReadOnlySpan<T>`, `TimeProvider`, and async `JsonSerializer` overloads — all unavailable on `netstandard2.0`. Adding that target would require either reverting those improvements or shipping a parallel conditional-compilation codebase. For an enterprise data-access library whose entire consumer base is on modern .NET, the cost/benefit is wrong. Documenting the policy costs nothing and answers procurement reviewers' question definitively.

## Changes

- `README.md`: new "Supported frameworks" section after the install block — lists the three TFMs with lifecycle dates, states the `netstandard2.0` exclusion with rationale, recommends Ardalis.Specification for .NET Framework consumers, links to the .NET support lifecycle page.
- `Directory.Build.props`: one-line comment on `<TargetFrameworks>` pointing at the README section, so the intent is visible to any engineer reading the props file.