### PR TITLE
test(tests): full-library Stryker mutation gating with per-PR incremental + weekly sweep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+src/QuerySpec.Core/Security/** @AbongileBoja
+src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs @AbongileBoja
+.github/workflows/** @AbongileBoja

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,24 +1,28 @@
-name: Mutation testing (on-demand)
+name: Mutation testing
 
 on:
   workflow_dispatch:
-    inputs:
-      scope:
-        description: 'Comma-separated mutate globs (default: three primary security classes)'
-        required: false
-        default: 'src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs,src/QuerySpec.Core/Security/DataMaskingEngine.cs,src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+  schedule:
+    - cron: '0 4 * * 1'
 
 permissions: read-all
 
 jobs:
-  stryker:
-    name: Stryker.NET — security paths
+  stryker-core:
+    name: Stryker.NET — QuerySpec.Core (full library)
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET 9
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
@@ -28,20 +32,222 @@ jobs:
     - name: Restore tools
       run: dotnet tool restore
 
-    - name: Build solution
+    - name: Restore packages
       env:
         QUERYSPEC_SKIP_SIGN: 'true'
-      run: dotnet build QuerySpec.sln --configuration Release --no-restore
+      run: dotnet restore QuerySpec.sln
 
-    - name: Run Stryker
+    - name: Run Stryker Core (PR incremental)
+      if: github.event_name == 'pull_request'
       env:
         QUERYSPEC_SKIP_SIGN: 'true'
-      run: dotnet stryker --config-file stryker-config.json
+      working-directory: src/QuerySpec.Core
+      run: dotnet stryker --since=origin/${{ github.base_ref }}
 
-    - name: Upload HTML report
+    - name: Run Stryker Core (full sweep)
+      if: github.event_name != 'pull_request'
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      working-directory: src/QuerySpec.Core
+      run: dotnet stryker
+
+    - name: Upload Core Stryker HTML report
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       with:
-        name: stryker-report
-        path: StrykerOutput/
-        retention-days: 30
+        name: stryker-report-core
+        path: src/QuerySpec.Core/StrykerOutput/
+        retention-days: 90
+
+    - name: Run Stryker Core Security (full sweep — raises break threshold to 85)
+      if: github.event_name != 'pull_request'
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      working-directory: src/QuerySpec.Core
+      run: dotnet stryker --config-file stryker-config.security.json
+
+    - name: Upload Core Security Stryker report
+      if: always() && github.event_name != 'pull_request'
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      with:
+        name: stryker-report-core-security
+        path: src/QuerySpec.Core/StrykerOutput/
+        retention-days: 90
+
+    - name: Publish Core report to mutation-reports branch (weekly sweep only)
+      if: github.event_name == 'schedule' && success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        REPORT_DIR=$(ls -dt src/QuerySpec.Core/StrykerOutput/*/reports 2>/dev/null | head -1)
+        if [ -z "$REPORT_DIR" ]; then
+          echo "No report directory found; skipping publish."
+          exit 0
+        fi
+        git config user.email "actions@github.com"
+        git config user.name "github-actions"
+        git fetch origin mutation-reports 2>/dev/null || true
+        if git show-ref --verify --quiet refs/remotes/origin/mutation-reports; then
+          git checkout -b mutation-reports origin/mutation-reports
+        else
+          git checkout --orphan mutation-reports
+          git rm -rf . --quiet || true
+        fi
+        DATED=$(date -u +%Y-%m-%d)
+        mkdir -p "core/$DATED"
+        cp "$REPORT_DIR/"*.html "core/$DATED/" 2>/dev/null || true
+        cp "$REPORT_DIR/"*.json "core/$DATED/" 2>/dev/null || true
+        cp -r "core/$DATED" "core/latest"
+        git add .
+        git diff --staged --quiet || git commit -m "chore(tests): mutation report core $DATED"
+        git push origin mutation-reports
+
+  stryker-efcore:
+    name: Stryker.NET — QuerySpec.EFCore
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore tools
+      run: dotnet tool restore
+
+    - name: Restore packages
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      run: dotnet restore QuerySpec.sln
+
+    - name: Run Stryker EFCore (PR incremental)
+      if: github.event_name == 'pull_request'
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      working-directory: src/QuerySpec.EFCore
+      run: dotnet stryker --since=origin/${{ github.base_ref }}
+
+    - name: Run Stryker EFCore (full sweep)
+      if: github.event_name != 'pull_request'
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      working-directory: src/QuerySpec.EFCore
+      run: dotnet stryker
+
+    - name: Upload EFCore Stryker HTML report
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      with:
+        name: stryker-report-efcore
+        path: src/QuerySpec.EFCore/StrykerOutput/
+        retention-days: 90
+
+    - name: Publish EFCore report to mutation-reports branch (weekly sweep only)
+      if: github.event_name == 'schedule' && success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        REPORT_DIR=$(ls -dt src/QuerySpec.EFCore/StrykerOutput/*/reports 2>/dev/null | head -1)
+        if [ -z "$REPORT_DIR" ]; then
+          echo "No report directory found; skipping publish."
+          exit 0
+        fi
+        git config user.email "actions@github.com"
+        git config user.name "github-actions"
+        git fetch origin mutation-reports 2>/dev/null || true
+        if git show-ref --verify --quiet refs/remotes/origin/mutation-reports; then
+          git checkout -b mutation-reports origin/mutation-reports
+        else
+          git checkout --orphan mutation-reports
+          git rm -rf . --quiet || true
+        fi
+        DATED=$(date -u +%Y-%m-%d)
+        mkdir -p "efcore/$DATED"
+        cp "$REPORT_DIR/"*.html "efcore/$DATED/" 2>/dev/null || true
+        cp "$REPORT_DIR/"*.json "efcore/$DATED/" 2>/dev/null || true
+        cp -r "efcore/$DATED" "efcore/latest"
+        git add .
+        git diff --staged --quiet || git commit -m "chore(tests): mutation report efcore $DATED"
+        git push origin mutation-reports
+
+  stryker-di:
+    name: Stryker.NET — QuerySpec.DependencyInjection
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET 9
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore tools
+      run: dotnet tool restore
+
+    - name: Restore packages
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      run: dotnet restore QuerySpec.sln
+
+    - name: Run Stryker DI (PR incremental)
+      if: github.event_name == 'pull_request'
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      working-directory: src/QuerySpec.DependencyInjection
+      run: dotnet stryker --since=origin/${{ github.base_ref }}
+
+    - name: Run Stryker DI (full sweep)
+      if: github.event_name != 'pull_request'
+      env:
+        QUERYSPEC_SKIP_SIGN: 'true'
+      working-directory: src/QuerySpec.DependencyInjection
+      run: dotnet stryker
+
+    - name: Upload DI Stryker HTML report
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      with:
+        name: stryker-report-di
+        path: src/QuerySpec.DependencyInjection/StrykerOutput/
+        retention-days: 90
+
+    - name: Publish DI report to mutation-reports branch (weekly sweep only)
+      if: github.event_name == 'schedule' && success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        REPORT_DIR=$(ls -dt src/QuerySpec.DependencyInjection/StrykerOutput/*/reports 2>/dev/null | head -1)
+        if [ -z "$REPORT_DIR" ]; then
+          echo "No report directory found; skipping publish."
+          exit 0
+        fi
+        git config user.email "actions@github.com"
+        git config user.name "github-actions"
+        git fetch origin mutation-reports 2>/dev/null || true
+        if git show-ref --verify --quiet refs/remotes/origin/mutation-reports; then
+          git checkout -b mutation-reports origin/mutation-reports
+        else
+          git checkout --orphan mutation-reports
+          git rm -rf . --quiet || true
+        fi
+        DATED=$(date -u +%Y-%m-%d)
+        mkdir -p "di/$DATED"
+        cp "$REPORT_DIR/"*.html "di/$DATED/" 2>/dev/null || true
+        cp "$REPORT_DIR/"*.json "di/$DATED/" 2>/dev/null || true
+        cp -r "di/$DATED" "di/latest"
+        git add .
+        git diff --staged --quiet || git commit -m "chore(tests): mutation report di $DATED"
+        git push origin mutation-reports

--- a/.gitignore
+++ b/.gitignore
@@ -393,3 +393,4 @@ npm-debug.log*
 
 # Stryker mutation testing output
 StrykerOutput/
+stryker-baseline/

--- a/src/QuerySpec.Core/stryker-config.json
+++ b/src/QuerySpec.Core/stryker-config.json
@@ -1,8 +1,7 @@
 {
   "stryker-config": {
-    "project": "QuerySpec.Core.csproj",
     "test-projects": [
-      "tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
+      "../../tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
     ],
     "target-framework": "net9.0",
     "mutation-level": "Standard",
@@ -16,8 +15,8 @@
       "EscapeSqlLiteral"
     ],
     "mutate": [
-      "src/QuerySpec.Core/**/*.cs",
-      "!src/QuerySpec.Core/Properties/**"
+      "**/*.cs",
+      "!Properties/**"
     ],
     "thresholds": {
       "high": 90,

--- a/src/QuerySpec.Core/stryker-config.security.json
+++ b/src/QuerySpec.Core/stryker-config.security.json
@@ -1,8 +1,7 @@
 {
   "stryker-config": {
-    "project": "QuerySpec.Core.csproj",
     "test-projects": [
-      "tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
+      "../../tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
     ],
     "target-framework": "net9.0",
     "mutation-level": "Standard",
@@ -16,13 +15,12 @@
       "EscapeSqlLiteral"
     ],
     "mutate": [
-      "src/QuerySpec.Core/**/*.cs",
-      "!src/QuerySpec.Core/Properties/**"
+      "Security/**/*.cs"
     ],
     "thresholds": {
       "high": 90,
-      "low": 80,
-      "break": 80
+      "low": 85,
+      "break": 85
     },
     "reporters": [
       "html",

--- a/src/QuerySpec.DependencyInjection/stryker-config.json
+++ b/src/QuerySpec.DependencyInjection/stryker-config.json
@@ -1,8 +1,7 @@
 {
   "stryker-config": {
-    "project": "QuerySpec.Core.csproj",
     "test-projects": [
-      "tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
+      "../../tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
     ],
     "target-framework": "net9.0",
     "mutation-level": "Standard",
@@ -11,13 +10,8 @@
     "ignore-mutations": [
       "linq"
     ],
-    "ignore-methods": [
-      "RegisterUnrestricted",
-      "EscapeSqlLiteral"
-    ],
     "mutate": [
-      "src/QuerySpec.Core/**/*.cs",
-      "!src/QuerySpec.Core/Properties/**"
+      "**/*.cs"
     ],
     "thresholds": {
       "high": 90,

--- a/src/QuerySpec.EFCore/stryker-config.json
+++ b/src/QuerySpec.EFCore/stryker-config.json
@@ -1,8 +1,7 @@
 {
   "stryker-config": {
-    "project": "QuerySpec.Core.csproj",
     "test-projects": [
-      "tests/QuerySpec.Core.Tests/QuerySpec.Core.Tests.csproj"
+      "../../tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj"
     ],
     "target-framework": "net9.0",
     "mutation-level": "Standard",
@@ -11,13 +10,8 @@
     "ignore-mutations": [
       "linq"
     ],
-    "ignore-methods": [
-      "RegisterUnrestricted",
-      "EscapeSqlLiteral"
-    ],
     "mutate": [
-      "src/QuerySpec.Core/**/*.cs",
-      "!src/QuerySpec.Core/Properties/**"
+      "**/*.cs"
     ],
     "thresholds": {
       "high": 90,

--- a/tests/QuerySpec.Core.Tests/MutationKillerTests.cs
+++ b/tests/QuerySpec.Core.Tests/MutationKillerTests.cs
@@ -1,0 +1,1080 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+using QuerySpec.Core.Advanced;
+using QuerySpec.Core.Auditing;
+using QuerySpec.Core.Caching;
+
+namespace QuerySpec.Core.Tests;
+
+/// <summary>
+/// Targeted mutation kill tests for surviving mutants identified in the full-library
+/// Stryker run (baseline 74.36%). Each test is scoped to one or a small cluster of
+/// related mutations so failures pinpoint the exact survivor.
+/// </summary>
+public class MutationKillerTests
+{
+    // ─── InMemoryAuditLogger mutations ───────────────────────────────────────
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        var logger = new InMemoryAuditLogger();
+        logger.Dispose();
+        logger.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_EmptyLogger_CountIsZeroBeforeDispose()
+    {
+        var logger = new InMemoryAuditLogger();
+        Assert.Equal(0, logger.Count);
+        logger.Dispose();
+    }
+
+    [Fact]
+    public async Task LogQueryAsync_DisposedLogger_DoesNotThrowBeforeDispose()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        await logger.LogQueryAsync(e);
+        Assert.Equal(1, logger.Count);
+        logger.Dispose();
+    }
+
+    [Fact]
+    public async Task GetAuditAsync_ByExistingId_ReturnsEntry()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        await logger.LogQueryAsync(e);
+        var result = await logger.GetAuditAsync(e.Id);
+        Assert.NotNull(result);
+        Assert.Equal(e.Id, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetAuditAsync_ByMissingId_ReturnsNull()
+    {
+        var logger = new InMemoryAuditLogger();
+        var result = await logger.GetAuditAsync("nonexistent");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAuditsByRequestAsync_ReturnsOnlyMatchingRequest()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e1 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", RequestId = "req-1" };
+        var e2 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", RequestId = "req-2" };
+        await logger.LogQueryAsync(e1);
+        await logger.LogQueryAsync(e2);
+
+        var results = (await logger.GetAuditsByRequestAsync("req-1")).ToList();
+        Assert.Single(results);
+        Assert.Equal("req-1", results[0].RequestId);
+    }
+
+    [Fact]
+    public async Task GetAuditsByUserAsync_NoSince_ReturnsAllForUser()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e1 = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q" };
+        var e2 = new AuditLogEntry { TenantId = "t", UserId = "bob", Operation = "Q" };
+        var e3 = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q" };
+        await logger.LogQueryAsync(e1);
+        await logger.LogQueryAsync(e2);
+        await logger.LogQueryAsync(e3);
+
+        var results = (await logger.GetAuditsByUserAsync("alice")).ToList();
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal("alice", r.UserId));
+    }
+
+    [Fact]
+    public async Task GetAuditsByUserAsync_WithSince_ExcludesOlderEntries()
+    {
+        var logger = new InMemoryAuditLogger();
+        var old = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var recent = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q",
+            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc) };
+
+        await logger.LogQueryAsync(old);
+        await logger.LogQueryAsync(recent);
+
+        var cutoff = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var results = (await logger.GetAuditsByUserAsync("alice", since: cutoff)).ToList();
+        Assert.Single(results);
+        Assert.Equal(recent.Timestamp, results[0].Timestamp);
+    }
+
+    [Fact]
+    public async Task GetAuditsByUserAsync_SinceIsInclusive_IncludesBoundaryEntry()
+    {
+        var logger = new InMemoryAuditLogger();
+        var boundary = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var e = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q", Timestamp = boundary };
+        await logger.LogQueryAsync(e);
+
+        var results = (await logger.GetAuditsByUserAsync("alice", since: boundary)).ToList();
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public async Task GetAuditsByTenantAsync_NoSince_ReturnsAllForTenant()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e1 = new AuditLogEntry { TenantId = "tenant-a", UserId = "u1", Operation = "Q" };
+        var e2 = new AuditLogEntry { TenantId = "tenant-b", UserId = "u2", Operation = "Q" };
+        await logger.LogQueryAsync(e1);
+        await logger.LogQueryAsync(e2);
+
+        var results = (await logger.GetAuditsByTenantAsync("tenant-a")).ToList();
+        Assert.Single(results);
+        Assert.Equal("tenant-a", results[0].TenantId);
+    }
+
+    [Fact]
+    public async Task GetAuditsByTenantAsync_WithSince_FiltersCorrectly()
+    {
+        var logger = new InMemoryAuditLogger();
+        var old = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var recent = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
+            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc) };
+        await logger.LogQueryAsync(old);
+        await logger.LogQueryAsync(recent);
+
+        var cutoff = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var results = (await logger.GetAuditsByTenantAsync("t", since: cutoff)).ToList();
+        Assert.Single(results);
+        Assert.Equal(recent.Timestamp, results[0].Timestamp);
+    }
+
+    [Fact]
+    public async Task GetAuditsByTenantAsync_SinceIsInclusive_IncludesBoundaryEntry()
+    {
+        var logger = new InMemoryAuditLogger();
+        var boundary = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = boundary };
+        await logger.LogQueryAsync(e);
+
+        var results = (await logger.GetAuditsByTenantAsync("t", since: boundary)).ToList();
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public async Task GetComplianceReportAsync_FiltersAndOrders()
+    {
+        var logger = new InMemoryAuditLogger();
+        var t1 = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var t3 = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var e1 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = t2 };
+        var e2 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = t1 };
+        var e3 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = t3 };
+        await logger.LogQueryAsync(e1);
+        await logger.LogQueryAsync(e2);
+        await logger.LogQueryAsync(e3);
+
+        var from = new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var results = (await logger.GetComplianceReportAsync(from, to)).ToList();
+
+        Assert.Single(results);
+        Assert.Equal(t2, results[0].Timestamp);
+    }
+
+    [Fact]
+    public async Task GetComplianceReportAsync_BoundariesAreInclusive()
+    {
+        var logger = new InMemoryAuditLogger();
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+
+        var eFrom = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = from };
+        var eTo = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = to };
+        await logger.LogQueryAsync(eFrom);
+        await logger.LogQueryAsync(eTo);
+
+        var results = (await logger.GetComplianceReportAsync(from, to)).ToList();
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public async Task GetComplianceReportAsync_OutsideRange_ExcludesEntries()
+    {
+        var logger = new InMemoryAuditLogger();
+        var outside = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = outside };
+        await logger.LogQueryAsync(e);
+
+        var from = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+        var results = (await logger.GetComplianceReportAsync(from, to)).ToList();
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task GetComplianceReportAsync_ResultsAreOrdered_ByTimestampAscending()
+    {
+        var logger = new InMemoryAuditLogger();
+        var t1 = new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await logger.LogQueryAsync(new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = t1 });
+        await logger.LogQueryAsync(new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q", Timestamp = t2 });
+
+        var results = (await logger.GetComplianceReportAsync(t2, t1)).ToList();
+        Assert.Equal(2, results.Count);
+        Assert.True(results[0].Timestamp <= results[1].Timestamp);
+    }
+
+    [Fact]
+    public async Task PurgeOldLogsAsync_EmptyLog_IsNoop()
+    {
+        var logger = new InMemoryAuditLogger();
+        await logger.PurgeOldLogsAsync(TimeSpan.FromDays(1));
+        Assert.Equal(0, logger.Count);
+    }
+
+    [Fact]
+    public async Task PurgeOldLogsAsync_AllEntriesOld_ClearsLog()
+    {
+        var clock = new FakeTimeProvider();
+        clock.SetUtcNow(new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        var logger = new InMemoryAuditLogger(clock);
+
+        var old = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        await logger.LogQueryAsync(old);
+
+        await logger.PurgeOldLogsAsync(TimeSpan.FromDays(30));
+        Assert.Equal(0, logger.Count);
+    }
+
+    [Fact]
+    public async Task PurgeOldLogsAsync_NoEntriesOld_IsNoop()
+    {
+        var clock = new FakeTimeProvider();
+        clock.SetUtcNow(new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        var logger = new InMemoryAuditLogger(clock);
+
+        var recent = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
+            Timestamp = new DateTime(2025, 5, 31, 0, 0, 0, DateTimeKind.Utc) };
+        await logger.LogQueryAsync(recent);
+
+        await logger.PurgeOldLogsAsync(TimeSpan.FromDays(1));
+        Assert.Equal(1, logger.Count);
+    }
+
+    [Fact]
+    public async Task PurgeOldLogsAsync_PartialPurge_ThrowsInvalidOperation()
+    {
+        var clock = new FakeTimeProvider();
+        clock.SetUtcNow(new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        var logger = new InMemoryAuditLogger(clock);
+
+        var old = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var recent = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
+            Timestamp = new DateTime(2025, 5, 31, 0, 0, 0, DateTimeKind.Utc) };
+        await logger.LogQueryAsync(old);
+        await logger.LogQueryAsync(recent);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            logger.PurgeOldLogsAsync(TimeSpan.FromDays(30)));
+    }
+
+    [Fact]
+    public async Task Count_ReturnsCorrectCount_AfterLogging()
+    {
+        var logger = new InMemoryAuditLogger();
+        Assert.Equal(0, logger.Count);
+        await logger.LogQueryAsync(new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" });
+        Assert.Equal(1, logger.Count);
+        await logger.LogQueryAsync(new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" });
+        Assert.Equal(2, logger.Count);
+    }
+
+    // ─── AuditLogEntry mutations ──────────────────────────────────────────────
+
+    [Fact]
+    public void AuditLogEntry_DefaultId_IsNonEmpty()
+    {
+        var e = new AuditLogEntry();
+        Assert.False(string.IsNullOrEmpty(e.Id));
+    }
+
+    [Fact]
+    public void Validate_EmptyTenantId_ThrowsWithCorrectParamName()
+    {
+        var e = new AuditLogEntry { UserId = "u", Operation = "Q" };
+        var ex = Assert.Throws<ArgumentException>(() => e.Validate());
+        Assert.Equal("TenantId", ex.ParamName);
+    }
+
+    [Fact]
+    public void Validate_EmptyUserId_ThrowsWithCorrectParamName()
+    {
+        var e = new AuditLogEntry { TenantId = "t", Operation = "Q" };
+        var ex = Assert.Throws<ArgumentException>(() => e.Validate());
+        Assert.Equal("UserId", ex.ParamName);
+    }
+
+    [Fact]
+    public void Validate_EmptyOperation_ThrowsWithCorrectParamName()
+    {
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u" };
+        var ex = Assert.Throws<ArgumentException>(() => e.Validate());
+        Assert.Equal("Operation", ex.ParamName);
+    }
+
+    [Fact]
+    public void Seal_SetsHashAndPreviousHash()
+    {
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e.Seal("prev-hash");
+        Assert.Equal("prev-hash", e.PreviousHash);
+        Assert.False(string.IsNullOrEmpty(e.Hash));
+    }
+
+    [Fact]
+    public void Seal_TwiceThrows_WithMessage()
+    {
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e.Seal(null);
+        var ex = Assert.Throws<InvalidOperationException>(() => e.Seal(null));
+        Assert.Contains("already been sealed", ex.Message);
+    }
+
+    [Fact]
+    public void VerifyIntegrity_UnsealedEntry_ReturnsFalse()
+    {
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        Assert.False(e.VerifyIntegrity(null));
+    }
+
+    [Fact]
+    public void VerifyIntegrity_SealedEntry_SamePrevious_ReturnsTrue()
+    {
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e.Seal("abc");
+        Assert.True(e.VerifyIntegrity("abc"));
+    }
+
+    [Fact]
+    public void VerifyIntegrity_SealedEntry_DifferentPrevious_ReturnsFalse()
+    {
+        var e = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e.Seal("abc");
+        Assert.False(e.VerifyIntegrity("wrong"));
+    }
+
+    [Fact]
+    public void VerifyChain_EmptyList_ReturnsMinus1()
+    {
+        Assert.Equal(-1, AuditLogEntry.VerifyChain(new List<AuditLogEntry>()));
+    }
+
+    [Fact]
+    public void VerifyChain_ValidChain_ReturnsMinus1()
+    {
+        var e1 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        var e2 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e1.Seal(null);
+        e2.Seal(e1.Hash);
+        Assert.Equal(-1, AuditLogEntry.VerifyChain(new[] { e1, e2 }));
+    }
+
+    [Fact]
+    public void VerifyChain_BrokenChain_ReturnsIndexOfBrokenEntry()
+    {
+        var e1 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        var e2 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e1.Seal(null);
+        e2.Seal("wrong-previous");
+        Assert.Equal(1, AuditLogEntry.VerifyChain(new[] { e1, e2 }));
+    }
+
+    [Fact]
+    public void VerifyChain_NullEntries_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => AuditLogEntry.VerifyChain(null!));
+    }
+
+    [Fact]
+    public void VerifyChain_FirstEntryWithNonNullPrevious_ReturnsZero()
+    {
+        var e1 = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q" };
+        e1.Seal("should-be-null");
+        Assert.Equal(0, AuditLogEntry.VerifyChain(new[] { e1 }));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(100, 0)]
+    public void AuditLogEntry_RecordsAffected_StoredCorrectly(int count, int _)
+    {
+        var e = new AuditLogEntry { RecordsAffected = count };
+        Assert.Equal(count, e.RecordsAffected);
+    }
+
+    [Fact]
+    public void AuditLogEntry_WasEncrypted_DefaultFalse()
+    {
+        Assert.False(new AuditLogEntry().WasEncrypted);
+    }
+
+    [Fact]
+    public void AuditLogEntry_WasMasked_DefaultFalse()
+    {
+        Assert.False(new AuditLogEntry().WasMasked);
+    }
+
+    [Fact]
+    public void AuditLogEntry_Success_RoundTrips()
+    {
+        Assert.False(new AuditLogEntry { Success = false }.Success);
+        Assert.True(new AuditLogEntry { Success = true }.Success);
+    }
+
+    // ─── FieldChange mutations ────────────────────────────────────────────────
+
+    [Fact]
+    public void FieldChange_Validate_EmptyFieldName_ThrowsWithCorrectParam()
+    {
+        var fc = new FieldChange { ChangedBy = "u" };
+        var ex = Assert.Throws<ArgumentException>(() => fc.Validate());
+        Assert.Equal("FieldName", ex.ParamName);
+    }
+
+    [Fact]
+    public void FieldChange_Validate_EmptyChangedBy_ThrowsWithCorrectParam()
+    {
+        var fc = new FieldChange { FieldName = "Price" };
+        var ex = Assert.Throws<ArgumentException>(() => fc.Validate());
+        Assert.Equal("ChangedBy", ex.ParamName);
+    }
+
+    [Fact]
+    public void FieldChange_Validate_ValidFields_DoesNotThrow()
+    {
+        var fc = new FieldChange { FieldName = "Price", ChangedBy = "alice" };
+        fc.Validate();
+    }
+
+    [Fact]
+    public void FieldChange_DefaultValues_AreCorrect()
+    {
+        var fc = new FieldChange();
+        Assert.Equal(string.Empty, fc.FieldName);
+        Assert.Equal(string.Empty, fc.ChangedBy);
+        Assert.Equal(string.Empty, fc.ChangeReason);
+        Assert.Null(fc.OldValue);
+        Assert.Null(fc.NewValue);
+    }
+
+    // ─── AuditContext mutations ───────────────────────────────────────────────
+
+    [Fact]
+    public void AuditContext_NullAssignments_ThrowArgumentNullException()
+    {
+        var ctx = new AuditContext();
+        Assert.Throws<ArgumentNullException>(() => ctx.RequestId = null!);
+        Assert.Throws<ArgumentNullException>(() => ctx.TenantId = null!);
+        Assert.Throws<ArgumentNullException>(() => ctx.UserId = null!);
+        Assert.Throws<ArgumentNullException>(() => ctx.ResourceType = null!);
+        Assert.Throws<ArgumentNullException>(() => ctx.Operation = null!);
+        Assert.Throws<ArgumentNullException>(() => ctx.SensitiveFields = null!);
+    }
+
+    [Fact]
+    public void AuditContext_DefaultsAreCorrect()
+    {
+        var ctx = new AuditContext();
+        Assert.True(ctx.EnableAuditing);
+        Assert.True(ctx.EnableFieldLevelTracking);
+        Assert.False(ctx.EnableEncryption);
+        Assert.False(ctx.EnableMasking);
+        Assert.Equal("Query", ctx.Operation);
+        Assert.NotNull(ctx.SensitiveFields);
+    }
+
+    // ─── EntityAuditTrail mutations ───────────────────────────────────────────
+
+    [Fact]
+    public void EntityAuditTrail_GetChangesSince_InclusiveBoundary()
+    {
+        var boundary = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var trail = new EntityAuditTrail();
+        trail.Changes.Add(new FieldChange { FieldName = "F", ChangedBy = "u", ChangedAt = boundary });
+        trail.Changes.Add(new FieldChange { FieldName = "F", ChangedBy = "u",
+            ChangedAt = boundary.AddSeconds(-1) });
+
+        var result = trail.GetChangesSince(boundary).ToList();
+        Assert.Single(result);
+        Assert.Equal(boundary, result[0].ChangedAt);
+    }
+
+    [Fact]
+    public void EntityAuditTrail_GetChangesByUser_ReturnsOnlyMatchingUser()
+    {
+        var trail = new EntityAuditTrail();
+        trail.Changes.Add(new FieldChange { FieldName = "F", ChangedBy = "alice" });
+        trail.Changes.Add(new FieldChange { FieldName = "F", ChangedBy = "bob" });
+
+        var result = trail.GetChangesByUser("alice").ToList();
+        Assert.Single(result);
+        Assert.Equal("alice", result[0].ChangedBy);
+    }
+
+    [Fact]
+    public void EntityAuditTrail_GetChangesByUser_NoMatch_ReturnsEmpty()
+    {
+        var trail = new EntityAuditTrail();
+        Assert.Empty(trail.GetChangesByUser("nobody"));
+    }
+
+    // ─── ComplianceExporter mutations ────────────────────────────────────────
+
+    [Fact]
+    public async Task ComplianceExporter_GetUserDataAsync_FiltersToTenant()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e1 = new AuditLogEntry { TenantId = "tenant-a", UserId = "alice", Operation = "Q" };
+        var e2 = new AuditLogEntry { TenantId = "tenant-b", UserId = "alice", Operation = "Q" };
+        await logger.LogQueryAsync(e1);
+        await logger.LogQueryAsync(e2);
+
+        var exporter = new ComplianceExporter(logger);
+        var results = (await exporter.GetUserDataAsync("alice", "tenant-a")).ToList();
+        Assert.Single(results);
+        Assert.Equal("tenant-a", results[0].TenantId);
+    }
+
+    [Fact]
+    public async Task ComplianceExporter_UserHasAccessedFieldAsync_TrueWhenFieldAccessed()
+    {
+        var logger = new InMemoryAuditLogger();
+        var since = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var e = new AuditLogEntry
+        {
+            TenantId = "t", UserId = "alice", Operation = "Q",
+            AccessedSensitiveFields = new List<string> { "SSN", "Email" }
+        };
+        await logger.LogQueryAsync(e);
+
+        var exporter = new ComplianceExporter(logger);
+        Assert.True(await exporter.UserHasAccessedFieldAsync("alice", "SSN", since));
+        Assert.False(await exporter.UserHasAccessedFieldAsync("alice", "PhoneNumber", since));
+    }
+
+    [Fact]
+    public async Task ComplianceExporter_GenerateGdprExportAsync_WritesJson()
+    {
+        var logger = new InMemoryAuditLogger();
+        var e = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q" };
+        await logger.LogQueryAsync(e);
+
+        var exporter = new ComplianceExporter(logger);
+        using var ms = new MemoryStream();
+        await exporter.GenerateGdprExportAsync("alice", "t", ms);
+        ms.Position = 0;
+        var json = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+        Assert.Contains("alice", json);
+    }
+
+    [Fact]
+    public void ComplianceExporter_NullReader_ThrowsArgumentNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ComplianceExporter(null!));
+    }
+
+    // ─── AdvancedFilterExpression mutations ──────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_EmptyOrWhitespaceField_ReturnsFieldRequiredError(string field)
+    {
+        var f = new AdvancedFilterExpression { Field = field };
+        var errors = f.Validate().ToList();
+        Assert.Contains("Field is required", errors);
+    }
+
+    [Fact]
+    public void Validate_InvalidFieldNamePattern_ReturnsInvalidFieldNameError()
+    {
+        var f = new AdvancedFilterExpression { Field = "123invalid" };
+        var errors = f.Validate().ToList();
+        Assert.Single(errors);
+        Assert.Contains("Invalid field name", errors[0]);
+    }
+
+    [Fact]
+    public void Validate_ValidDottedField_NoErrors()
+    {
+        var f = new AdvancedFilterExpression { Field = "Customer.Name" };
+        Assert.Empty(f.Validate());
+    }
+
+    [Fact]
+    public void Validate_TemporalStart_GreaterThan_TemporalEnd_ReturnsError()
+    {
+        var now = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var f = new AdvancedFilterExpression
+        {
+            Field = "CreatedAt",
+            TemporalStart = now.AddDays(1),
+            TemporalEnd = now
+        };
+        var errors = f.Validate().ToList();
+        Assert.Contains(errors, e => e.Contains("TemporalStart must be before"));
+    }
+
+    [Fact]
+    public void Validate_TemporalStartEqualsEnd_IsValid()
+    {
+        var now = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var f = new AdvancedFilterExpression
+        {
+            Field = "CreatedAt",
+            TemporalStart = now,
+            TemporalEnd = now
+        };
+        Assert.Empty(f.Validate());
+    }
+
+    [Fact]
+    public void Validate_GeoRadiusNonPositive_WithGeoLocation_ReturnsError()
+    {
+        var f = new AdvancedFilterExpression
+        {
+            Field = "Location",
+            GeoLocation = new GeoLocation(10m, 20m),
+            GeoRadius = 0m
+        };
+        var errors = f.Validate().ToList();
+        Assert.Contains(errors, e => e.Contains("GeoRadius must be positive"));
+    }
+
+    [Fact]
+    public void Validate_GeoRadiusPositive_NoGeoError()
+    {
+        var f = new AdvancedFilterExpression
+        {
+            Field = "Location",
+            GeoLocation = new GeoLocation(10m, 20m),
+            GeoRadius = 1.5m
+        };
+        Assert.Empty(f.Validate());
+    }
+
+    [Fact]
+    public void Validate_GeoRadiusNegative_ReturnsError()
+    {
+        var f = new AdvancedFilterExpression
+        {
+            Field = "Location",
+            GeoLocation = new GeoLocation(10m, 20m),
+            GeoRadius = -5m
+        };
+        Assert.Contains("GeoRadius must be positive", f.Validate().ToList().Select(e => e));
+    }
+
+    [Fact]
+    public void Validate_NestedFilters_AreRecursivelyValidated()
+    {
+        var inner = new AdvancedFilterExpression { Field = "" };
+        var outer = new AdvancedFilterExpression
+        {
+            Field = "Name",
+            Filters = new List<AdvancedFilterExpression> { inner }
+        };
+        var errors = outer.Validate().ToList();
+        Assert.Contains("Field is required", errors);
+    }
+
+    [Fact]
+    public void Validate_ValidFilterWithNoNestedFilters_NoErrors()
+    {
+        var f = new AdvancedFilterExpression { Field = "Name", Filters = new List<AdvancedFilterExpression>() };
+        Assert.Empty(f.Validate());
+    }
+
+#pragma warning disable CS0618
+    [Fact]
+    public void Validate_MaskResultTrue_ReturnsError()
+    {
+        var f = new AdvancedFilterExpression { Field = "Name", MaskResult = true };
+        var errors = f.Validate().ToList();
+        Assert.Contains(errors, e => e.Contains("MaskResult"));
+    }
+
+    [Fact]
+    public void Validate_EncryptValueTrue_ReturnsError()
+    {
+        var f = new AdvancedFilterExpression { Field = "Name", EncryptValue = true };
+        var errors = f.Validate().ToList();
+        Assert.Contains(errors, e => e.Contains("EncryptValue"));
+    }
+
+    [Fact]
+    public void Validate_MaskResultFalse_NoObsoleteErrors()
+    {
+        var f = new AdvancedFilterExpression { Field = "Name", MaskResult = false };
+        Assert.Empty(f.Validate());
+    }
+#pragma warning restore CS0618
+
+    [Fact]
+    public void ComputeStableHash_SameFilter_ProducesSameHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", Operator = FilterOperator.Equal, Value = "test" };
+        var f2 = new AdvancedFilterExpression { Field = "Name", Operator = FilterOperator.Equal, Value = "test" };
+        Assert.Equal(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentField_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", Operator = FilterOperator.Equal };
+        var f2 = new AdvancedFilterExpression { Field = "Age", Operator = FilterOperator.Equal };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentCaseSensitive_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", CaseSensitive = false };
+        var f2 = new AdvancedFilterExpression { Field = "Name", CaseSensitive = true };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentUseRegex_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", UseRegex = false };
+        var f2 = new AdvancedFilterExpression { Field = "Name", UseRegex = true };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentIncludeDeleted_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", IncludeDeletedRecords = false };
+        var f2 = new AdvancedFilterExpression { Field = "Name", IncludeDeletedRecords = true };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentLogic_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", Logic = LogicalOperator.And };
+        var f2 = new AdvancedFilterExpression { Field = "Name", Logic = LogicalOperator.Or };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentTemporalStart_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", TemporalStart = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var f2 = new AdvancedFilterExpression { Field = "Name", TemporalStart = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc) };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentTemporalEnd_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", TemporalEnd = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var f2 = new AdvancedFilterExpression { Field = "Name", TemporalEnd = new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc) };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_NullTemporalStart_VsSet_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name" };
+        var f2 = new AdvancedFilterExpression { Field = "Name", TemporalStart = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentGeoLocation_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Loc", GeoLocation = new GeoLocation(10m, 20m) };
+        var f2 = new AdvancedFilterExpression { Field = "Loc", GeoLocation = new GeoLocation(11m, 20m) };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentGeoRadius_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Loc", GeoRadius = 10m };
+        var f2 = new AdvancedFilterExpression { Field = "Loc", GeoRadius = 20m };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentCustomOperatorName_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", CustomOperatorName = "op1" };
+        var f2 = new AdvancedFilterExpression { Field = "Name", CustomOperatorName = "op2" };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_NullVsEmptyValue_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name", Value = null };
+        var f2 = new AdvancedFilterExpression { Field = "Name", Value = "x" };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_WithNestedFilters_DifferentFromWithout()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Name" };
+        var f2 = new AdvancedFilterExpression
+        {
+            Field = "Name",
+            Filters = new List<AdvancedFilterExpression>
+            {
+                new AdvancedFilterExpression { Field = "Age" }
+            }
+        };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_DifferentFilterCount_ProducesDifferentHash()
+    {
+        var child = new AdvancedFilterExpression { Field = "Age" };
+        var f1 = new AdvancedFilterExpression
+        {
+            Field = "Name",
+            Filters = new List<AdvancedFilterExpression> { child }
+        };
+        var f2 = new AdvancedFilterExpression
+        {
+            Field = "Name",
+            Filters = new List<AdvancedFilterExpression> { child, child }
+        };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_EnumerableValue_DifferentFromScalar()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "Tags", Value = new[] { "a", "b" } };
+        var f2 = new AdvancedFilterExpression { Field = "Tags", Value = new[] { "a", "c" } };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    [Fact]
+    public void ComputeStableHash_StringValue_VsIntValue_ProducesDifferentHash()
+    {
+        var f1 = new AdvancedFilterExpression { Field = "X", Value = "123" };
+        var f2 = new AdvancedFilterExpression { Field = "X", Value = 123 };
+        Assert.NotEqual(f1.ComputeStableHash(), f2.ComputeStableHash());
+    }
+
+    // ─── GeoLocation / Haversine mutations ───────────────────────────────────
+
+    [Theory]
+    [InlineData(51.5074, -0.1278, 48.8566, 2.3522, 340.0)]
+    [InlineData(0.0, 0.0, 0.0, 0.0, 0.0)]
+    public void GeoLocation_DistanceTo_ProducesExpectedKilometers(
+        double lat1, double lon1, double lat2, double lon2, double expectedKm)
+    {
+        var a = new GeoLocation((decimal)lat1, (decimal)lon1);
+        var b = new GeoLocation((decimal)lat2, (decimal)lon2);
+        var dist = a.DistanceTo(b);
+        if (expectedKm == 0.0)
+            Assert.Equal(0.0, dist, precision: 5);
+        else
+            Assert.InRange(dist, expectedKm - 10, expectedKm + 10);
+    }
+
+    [Fact]
+    public void GeoLocation_DistanceTo_IsNearlySymmetric()
+    {
+        var nyc = new GeoLocation(40.7128m, -74.0060m);
+        var london = new GeoLocation(51.5074m, -0.1278m);
+        var d1 = nyc.DistanceTo(london);
+        var d2 = london.DistanceTo(nyc);
+        Assert.InRange(Math.Abs(d1 - d2), 0, 0.01);
+    }
+
+    [Fact]
+    public void GeoLocation_DefaultCtor_InitializesToZero()
+    {
+        var g = new GeoLocation();
+        Assert.Equal(0m, g.Latitude);
+        Assert.Equal(0m, g.Longitude);
+    }
+
+    [Fact]
+    public void GeoLocation_ParameteredCtor_SetsCoordinates()
+    {
+        var g = new GeoLocation(10.5m, 20.3m);
+        Assert.Equal(10.5m, g.Latitude);
+        Assert.Equal(20.3m, g.Longitude);
+    }
+
+    [Fact]
+    public void GeoLocation_DistanceTo_AntipodalPoints_IsApprox20015Km()
+    {
+        var north = new GeoLocation(90m, 0m);
+        var south = new GeoLocation(-90m, 0m);
+        var dist = north.DistanceTo(south);
+        Assert.InRange(dist, 19000, 21000);
+    }
+
+    // ─── CacheKeyGenerator mutations ─────────────────────────────────────────
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateKey_ContainsPrefixAndComponents()
+    {
+        var key = CacheKeyGenerator.GenerateKey("myns", "a", "b", "c");
+        Assert.StartsWith("myns", key);
+        Assert.Contains("a", key);
+        Assert.Contains("b", key);
+        Assert.Contains("c", key);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateKey_NullComponentsSkipped()
+    {
+        var keyWithNull = CacheKeyGenerator.GenerateKey("ns", null, "b");
+        var keyWithout = CacheKeyGenerator.GenerateKey("ns", "b");
+        Assert.Equal(keyWithout, keyWithNull);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateKey_EmptyStringComponentsSkipped()
+    {
+        var keyWithEmpty = CacheKeyGenerator.GenerateKey("ns", "", "b");
+        var keyWithout = CacheKeyGenerator.GenerateKey("ns", "b");
+        Assert.Equal(keyWithout, keyWithEmpty);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateKey_LongKey_OverMaxLength_ReturnsHashedKey()
+    {
+        var big = new string('z', 300);
+        var key = CacheKeyGenerator.GenerateKey("prefix", big);
+        Assert.True(key.Length <= 256);
+        Assert.StartsWith("prefix:", key);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateKey_ShortKey_NotHashed_PreservesComponents()
+    {
+        var key = CacheKeyGenerator.GenerateKey("ns", "tenant1", "user1");
+        Assert.Equal("ns:tenant1:user1", key);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateQueryCacheKey_ContainsPage()
+    {
+        var key0 = CacheKeyGenerator.GenerateQueryCacheKey("t", "u", "h1", "h2", 0);
+        var key1 = CacheKeyGenerator.GenerateQueryCacheKey("t", "u", "h1", "h2", 1);
+        Assert.NotEqual(key0, key1);
+        Assert.Contains(":0", key0);
+        Assert.Contains(":1", key1);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateQueryCacheKey_EmptyTenantAndUser_OmitsComponents()
+    {
+        var keyFull = CacheKeyGenerator.GenerateQueryCacheKey("t", "u", "hash", "sort", 5);
+        var keyEmpty = CacheKeyGenerator.GenerateQueryCacheKey("", "", "hash", "sort", 5);
+        Assert.NotEqual(keyFull, keyEmpty);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateSecurityPolicyCacheKey_StartsWith_policy()
+    {
+        var key = CacheKeyGenerator.GenerateSecurityPolicyCacheKey("Order");
+        Assert.StartsWith("policy:", key);
+        Assert.Contains("Order", key);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GeneratePermissionCacheKey_StartsWith_permission()
+    {
+        var key = CacheKeyGenerator.GeneratePermissionCacheKey("u1", "Order", "Price");
+        Assert.StartsWith("permission:", key);
+        Assert.Contains("u1", key);
+        Assert.Contains("Order", key);
+        Assert.Contains("Price", key);
+    }
+
+    [Fact]
+    public void CacheKeyGenerator_GenerateKey_LongKeyOverHeapThreshold_StillHashes()
+    {
+        var huge = new string('x', 400);
+        var key = CacheKeyGenerator.GenerateKey("pfx", huge);
+        Assert.True(key.Length <= 256);
+        Assert.StartsWith("pfx:", key);
+    }
+
+    // ─── CustomOperatorRegistry mutations ────────────────────────────────────
+
+    [Fact]
+    public void CustomOperatorRegistry_Register_FirstWins()
+    {
+        var registry = new CustomOperatorRegistry();
+        var op1 = new TestCustomOperator("myOp", "First");
+        var op2 = new TestCustomOperator("myOp", "Second");
+
+        registry.Register(op1);
+        registry.Register(op2);
+
+        var result = registry.Get("myOp");
+        Assert.NotNull(result);
+        Assert.Equal("First", result!.Description);
+    }
+
+    [Fact]
+    public void CustomOperatorRegistry_Get_MissingOp_ReturnsNull()
+    {
+        var registry = new CustomOperatorRegistry();
+        Assert.Null(registry.Get("nonexistent"));
+    }
+
+    [Fact]
+    public void CustomOperatorRegistry_GetAll_ReturnsAllRegistered()
+    {
+        var registry = new CustomOperatorRegistry();
+        registry.Register(new TestCustomOperator("op1", "D1"));
+        registry.Register(new TestCustomOperator("op2", "D2"));
+
+        var all = registry.GetAll().ToList();
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public void CustomOperatorRegistry_GetAll_EmptyRegistry_ReturnsEmpty()
+    {
+        var registry = new CustomOperatorRegistry();
+        Assert.Empty(registry.GetAll());
+    }
+
+    private sealed class TestCustomOperator : ICustomOperator
+    {
+        public string Name { get; }
+        public string Description { get; }
+        public Type[] SupportedTypes => new[] { typeof(string) };
+        public TestCustomOperator(string name, string description) { Name = name; Description = description; }
+        public object? Execute(object value, object filterValue) => null;
+    }
+}

--- a/tests/QuerySpec.Core.Tests/MutationKillerTests.cs
+++ b/tests/QuerySpec.Core.Tests/MutationKillerTests.cs
@@ -99,10 +99,20 @@ public class MutationKillerTests
     public async Task GetAuditsByUserAsync_WithSince_ExcludesOlderEntries()
     {
         var logger = new InMemoryAuditLogger();
-        var old = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q",
-            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
-        var recent = new AuditLogEntry { TenantId = "t", UserId = "alice", Operation = "Q",
-            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var old = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "alice",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+        var recent = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "alice",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
 
         await logger.LogQueryAsync(old);
         await logger.LogQueryAsync(recent);
@@ -143,10 +153,20 @@ public class MutationKillerTests
     public async Task GetAuditsByTenantAsync_WithSince_FiltersCorrectly()
     {
         var logger = new InMemoryAuditLogger();
-        var old = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
-            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
-        var recent = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
-            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var old = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "u",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+        var recent = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "u",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
         await logger.LogQueryAsync(old);
         await logger.LogQueryAsync(recent);
 
@@ -250,8 +270,13 @@ public class MutationKillerTests
         clock.SetUtcNow(new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero));
         var logger = new InMemoryAuditLogger(clock);
 
-        var old = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
-            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        var old = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "u",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
         await logger.LogQueryAsync(old);
 
         await logger.PurgeOldLogsAsync(TimeSpan.FromDays(30));
@@ -265,8 +290,13 @@ public class MutationKillerTests
         clock.SetUtcNow(new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero));
         var logger = new InMemoryAuditLogger(clock);
 
-        var recent = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
-            Timestamp = new DateTime(2025, 5, 31, 0, 0, 0, DateTimeKind.Utc) };
+        var recent = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "u",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 5, 31, 0, 0, 0, DateTimeKind.Utc)
+        };
         await logger.LogQueryAsync(recent);
 
         await logger.PurgeOldLogsAsync(TimeSpan.FromDays(1));
@@ -280,10 +310,20 @@ public class MutationKillerTests
         clock.SetUtcNow(new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero));
         var logger = new InMemoryAuditLogger(clock);
 
-        var old = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
-            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
-        var recent = new AuditLogEntry { TenantId = "t", UserId = "u", Operation = "Q",
-            Timestamp = new DateTime(2025, 5, 31, 0, 0, 0, DateTimeKind.Utc) };
+        var old = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "u",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+        var recent = new AuditLogEntry
+        {
+            TenantId = "t",
+            UserId = "u",
+            Operation = "Q",
+            Timestamp = new DateTime(2025, 5, 31, 0, 0, 0, DateTimeKind.Utc)
+        };
         await logger.LogQueryAsync(old);
         await logger.LogQueryAsync(recent);
 
@@ -515,8 +555,12 @@ public class MutationKillerTests
         var boundary = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
         var trail = new EntityAuditTrail();
         trail.Changes.Add(new FieldChange { FieldName = "F", ChangedBy = "u", ChangedAt = boundary });
-        trail.Changes.Add(new FieldChange { FieldName = "F", ChangedBy = "u",
-            ChangedAt = boundary.AddSeconds(-1) });
+        trail.Changes.Add(new FieldChange
+        {
+            FieldName = "F",
+            ChangedBy = "u",
+            ChangedAt = boundary.AddSeconds(-1)
+        });
 
         var result = trail.GetChangesSince(boundary).ToList();
         Assert.Single(result);
@@ -566,7 +610,9 @@ public class MutationKillerTests
         var since = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var e = new AuditLogEntry
         {
-            TenantId = "t", UserId = "alice", Operation = "Q",
+            TenantId = "t",
+            UserId = "alice",
+            Operation = "Q",
             AccessedSensitiveFields = new List<string> { "SSN", "Email" }
         };
         await logger.LogQueryAsync(e);

--- a/tests/QuerySpec.Core.Tests/Security/SecurityMutationKillerTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/SecurityMutationKillerTests.cs
@@ -1,0 +1,754 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using QuerySpec.Core.Security;
+using Xunit;
+
+namespace QuerySpec.Core.Tests.Security;
+
+public class SecurityMutationKillerTests
+{
+    private static byte[] NewKey32() => RandomNumberGenerator.GetBytes(32);
+    private static string NewKeyB64() => Convert.ToBase64String(NewKey32());
+
+    // -------------------------------------------------------------------------
+    // AesGcmEncryptionProvider — boundary and arithmetic mutations
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AesGcm_KeySize_31_Throws_And_33_Throws_And_32_Passes()
+    {
+        Assert.Throws<ArgumentException>(() => new AesGcmEncryptionProvider(new byte[31]));
+        Assert.Throws<ArgumentException>(() => new AesGcmEncryptionProvider(new byte[33]));
+        _ = new AesGcmEncryptionProvider(new byte[32]);
+    }
+
+    [Fact]
+    public void AesGcm_EnvelopeExactly27Bytes_ThrowsCryptoException()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        var short27 = Convert.ToBase64String(new byte[27]);
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(short27));
+    }
+
+    [Fact]
+    public void AesGcm_EnvelopeExactly28Bytes_IsAccepted_AndRoundTrips()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        var ct = p.Encrypt(string.Empty);
+        var raw = Convert.FromBase64String(ct);
+        Assert.Equal(28, raw.Length);
+        Assert.Equal(string.Empty, p.Decrypt(ct));
+    }
+
+    [Fact]
+    public void AesGcm_EnvelopeOffsets_NoncePrecedes_Tag_Precedes_Cipher()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        var plain = "x";
+        var ct = p.Encrypt(plain);
+        var raw = Convert.FromBase64String(ct);
+
+        Assert.Equal(28 + 1, raw.Length);
+
+        var withNonceTampered = (byte[])raw.Clone();
+        withNonceTampered[0] ^= 0xFF;
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(Convert.ToBase64String(withNonceTampered)));
+
+        var withTagTampered = (byte[])raw.Clone();
+        withTagTampered[12] ^= 0xFF;
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(Convert.ToBase64String(withTagTampered)));
+
+        var withCipherTampered = (byte[])raw.Clone();
+        withCipherTampered[28] ^= 0xFF;
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(Convert.ToBase64String(withCipherTampered)));
+    }
+
+    [Fact]
+    public void AesGcm_EnvelopeLength_Equals_12_Plus_16_Plus_PlaintextBytes()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        var plaintext = "hello, mutation";
+        var utf8Len = Encoding.UTF8.GetByteCount(plaintext);
+        var raw = Convert.FromBase64String(p.Encrypt(plaintext));
+        Assert.Equal(12 + 16 + utf8Len, raw.Length);
+    }
+
+    [Fact]
+    public void AesGcm_EncryptNull_ThrowsArgumentNull()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        Assert.Throws<ArgumentNullException>(() => p.Encrypt(null!));
+        Assert.Throws<ArgumentNullException>(() => p.Encrypt(null!, ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void AesGcm_DecryptNull_ThrowsArgumentNull()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        Assert.Throws<ArgumentNullException>(() => p.Decrypt(null!));
+        Assert.Throws<ArgumentNullException>(() => p.Decrypt(null!, ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void AesGcm_GenerateKey_Length_Is_32_Bytes()
+    {
+        var key = AesGcmEncryptionProvider.GenerateKey();
+        Assert.Equal(32, Convert.FromBase64String(key).Length);
+    }
+
+    [Fact]
+    public void AesGcm_TwoCallsToGenerateKey_ProduceDifferentKeys()
+    {
+        Assert.NotEqual(AesGcmEncryptionProvider.GenerateKey(), AesGcmEncryptionProvider.GenerateKey());
+    }
+
+    [Fact]
+    public void AesGcm_AadMismatch_ThrowsCryptoException()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        var aad1 = "record:1"u8.ToArray();
+        var aad2 = "record:2"u8.ToArray();
+        var ct = p.Encrypt("secret", aad1);
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(ct, aad2));
+    }
+
+    [Fact]
+    public void AesGcm_SamePlaintext_ProducesDifferentCiphertexts()
+    {
+        var p = new AesGcmEncryptionProvider(NewKey32());
+        Assert.NotEqual(p.Encrypt("hello"), p.Encrypt("hello"));
+    }
+
+    [Fact]
+    public void AesGcm_Constructor_ClonesBytes_MutatingOriginalDoesNotAffectDecryption()
+    {
+        var key = NewKey32();
+        var p = new AesGcmEncryptionProvider(key);
+        var ct = p.Encrypt("payload");
+        Array.Clear(key);
+        Assert.Equal("payload", p.Decrypt(ct));
+    }
+
+    // -------------------------------------------------------------------------
+    // DataMaskingEngine — boundary and branch mutations
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DataMasking_HashKey_Exactly15Bytes_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new DataMaskingEngine(new byte[15]));
+    }
+
+    [Fact]
+    public void DataMasking_HashKey_Exactly16Bytes_Passes()
+    {
+        _ = new DataMaskingEngine(new byte[16]);
+    }
+
+    [Fact]
+    public void DataMasking_HashKey_Null_AllowedWhenNoHashMask()
+    {
+        var engine = new DataMaskingEngine((byte[]?)null);
+        engine.RegisterFieldMask("f", MaskingStrategy.FullMask);
+        Assert.Equal("*****", engine.Mask("f", "hello"));
+    }
+
+    [Fact]
+    public void DataMasking_NullValue_ProducesLiteralNullString()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("f", MaskingStrategy.FullMask);
+        Assert.Equal("null", engine.Mask("f", (object?)null));
+    }
+
+    [Fact]
+    public void DataMasking_PartialMask_Boundary_Length2_IsFullMask()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("f", MaskingStrategy.PartialMask);
+        Assert.Equal("**", engine.Mask("f", "ab"));
+    }
+
+    [Fact]
+    public void DataMasking_PartialMask_Boundary_Length3_KeepsFirstTwo()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("f", MaskingStrategy.PartialMask);
+        Assert.Equal("ab*", engine.Mask("f", "abc"));
+    }
+
+    [Fact]
+    public void DataMasking_LastFour_Boundary_Length4_IsFullMask()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("f", MaskingStrategy.LastFourOnly);
+        Assert.Equal("****", engine.Mask("f", "abcd"));
+    }
+
+    [Fact]
+    public void DataMasking_LastFour_Boundary_Length5_RevealsLastFour()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("f", MaskingStrategy.LastFourOnly);
+        Assert.Equal("*1234", engine.Mask("f", "01234"));
+    }
+
+    [Fact]
+    public void DataMasking_EmailMask_ExactlyOneAtSign_MasksLocal()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("email", MaskingStrategy.EmailMask);
+        var result = engine.Mask("email", "j@x.com");
+        Assert.Equal("j@x.com", result);
+    }
+
+    [Fact]
+    public void DataMasking_EmailMask_TwoAtSigns_IsFullMask()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("email", MaskingStrategy.EmailMask);
+        var result = engine.Mask("email", "a@b@c");
+        Assert.Equal("*****", result);
+    }
+
+    [Fact]
+    public void DataMasking_EmailMask_NoAtSign_IsFullMask()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("email", MaskingStrategy.EmailMask);
+        Assert.Equal("*****", engine.Mask("email", "notme"));
+    }
+
+    [Fact]
+    public void DataMasking_EmailMask_MultiCharLocal_MasksAllButFirst()
+    {
+        var engine = new DataMaskingEngine();
+        engine.RegisterFieldMask("email", MaskingStrategy.EmailMask);
+        var result = engine.Mask("email", "alice@example.com");
+        Assert.StartsWith("a", result, StringComparison.Ordinal);
+        Assert.Contains("****", result, StringComparison.Ordinal);
+        Assert.Contains("@example.com", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataMasking_HashMask_NullTenant_StableAcrossInstances()
+    {
+        var key = NewKey32();
+        var e1 = new DataMaskingEngine(key);
+        var e2 = new DataMaskingEngine(key);
+        e1.RegisterFieldMask("v", MaskingStrategy.HashMask);
+        e2.RegisterFieldMask("v", MaskingStrategy.HashMask);
+        Assert.Equal(e1.Mask("v", "data", null), e2.Mask("v", "data", null));
+    }
+
+    [Fact]
+    public void DataMasking_HashMask_EmptyTenant_SameAsNullTenant()
+    {
+        var key = NewKey32();
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("v", MaskingStrategy.HashMask);
+        Assert.Equal(engine.Mask("v", "data", null), engine.Mask("v", "data", string.Empty));
+    }
+
+    [Fact]
+    public void DataMasking_HashMask_NonEmptyTenant_DiffersFromNull()
+    {
+        var engine = new DataMaskingEngine(NewKey32());
+        engine.RegisterFieldMask("v", MaskingStrategy.HashMask);
+        Assert.NotEqual(engine.Mask("v", "data", null), engine.Mask("v", "data", "tenantX"));
+    }
+
+    [Fact]
+    public void DataMasking_HashMask_DifferentTenants_ProduceDifferentOutputs()
+    {
+        var engine = new DataMaskingEngine(NewKey32());
+        engine.RegisterFieldMask("v", MaskingStrategy.HashMask);
+        Assert.NotEqual(engine.Mask("v", "data", "t1"), engine.Mask("v", "data", "t2"));
+    }
+
+    [Fact]
+    public void DataMasking_HashMask_OutputIs32Bytes_Base64Encoded()
+    {
+        var engine = new DataMaskingEngine(NewKey32());
+        engine.RegisterFieldMask("v", MaskingStrategy.HashMask);
+        var result = engine.Mask("v", "test-value");
+        Assert.Equal(32, Convert.FromBase64String(result).Length);
+    }
+
+    [Fact]
+    public void DataMasking_ClassifierCategory_None_ReturnsRawValue()
+    {
+        var classifier = new ConfiguredPiiClassifier(Array.Empty<(Type, string, PiiCategory)>());
+        var engine = new DataMaskingEngine(hashKey: null, classifier: classifier);
+        Assert.Equal("raw", engine.Mask(typeof(string), "field", "raw"));
+    }
+
+    [Fact]
+    public void DataMasking_ClassifierCategory_Financial_UsesLastFourOnly()
+    {
+        var classifier = new ConfiguredPiiClassifier(new[]
+        {
+            (typeof(BillingInfo), "Card", PiiCategory.Financial),
+        });
+        var engine = new DataMaskingEngine(hashKey: null, classifier: classifier);
+        var result = engine.Mask(typeof(BillingInfo), "Card", "1234567890123456");
+        Assert.EndsWith("3456", result, StringComparison.Ordinal);
+        Assert.StartsWith("*", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataMasking_ClassifierCategory_Contact_UsesEmailMask()
+    {
+        var classifier = new ConfiguredPiiClassifier(new[]
+        {
+            (typeof(BillingInfo), "Email", PiiCategory.Contact),
+        });
+        var engine = new DataMaskingEngine(hashKey: null, classifier: classifier);
+        var result = engine.Mask(typeof(BillingInfo), "Email", "user@domain.com");
+        Assert.Contains("@domain.com", result, StringComparison.Ordinal);
+        Assert.StartsWith("u", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataMasking_ClassifierCategory_Sensitive_UsesFullMask()
+    {
+        var classifier = new ConfiguredPiiClassifier(new[]
+        {
+            (typeof(BillingInfo), "Notes", PiiCategory.Sensitive),
+        });
+        var engine = new DataMaskingEngine(hashKey: null, classifier: classifier);
+        var result = engine.Mask(typeof(BillingInfo), "Notes", "classified");
+        Assert.Equal(new string('*', "classified".Length), result);
+    }
+
+    [Fact]
+    public void DataMasking_ExplicitRegistration_TakesPrecedenceOverClassifier()
+    {
+        var classifier = new ConfiguredPiiClassifier(new[]
+        {
+            (typeof(BillingInfo), "Email", PiiCategory.Contact),
+        });
+        var engine = new DataMaskingEngine(hashKey: null, classifier: classifier);
+        engine.RegisterFieldMask("Email", MaskingStrategy.FullMask);
+        var result = engine.Mask(typeof(BillingInfo), "Email", "user@domain.com");
+        Assert.Equal(new string('*', "user@domain.com".Length), result);
+    }
+
+    [Fact]
+    public void DataMasking_RegisterFieldMask_NullName_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DataMaskingEngine().RegisterFieldMask(null!, MaskingStrategy.FullMask));
+    }
+
+    [Fact]
+    public void DataMasking_RegisterFieldMask_WhitespaceName_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new DataMaskingEngine().RegisterFieldMask("  ", MaskingStrategy.FullMask));
+    }
+
+    [Fact]
+    public void DataMasking_RegisterFieldMask_HashMask_WithoutKey_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new DataMaskingEngine().RegisterFieldMask("f", MaskingStrategy.HashMask));
+        Assert.Contains("hash key", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class BillingInfo { }
+
+    // -------------------------------------------------------------------------
+    // RowLevelSecurityEngine — boundary and null-coalescing mutations
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void RLS_ValidateIdentifier_Exactly128Chars_Accepted()
+    {
+        var id = new string('a', 128);
+        Assert.Equal(id, RowLevelSecurityEngine.ValidateIdentifier(id));
+    }
+
+    [Fact]
+    public void RLS_ValidateIdentifier_Exactly129Chars_Throws()
+    {
+        var id = new string('a', 129);
+        var ex = Assert.Throws<ArgumentException>(() => RowLevelSecurityEngine.ValidateIdentifier(id));
+        Assert.Contains("128", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RLS_ValidateIdentifier_Exactly127Chars_Accepted()
+    {
+        var id = new string('z', 127);
+        Assert.Equal(id, RowLevelSecurityEngine.ValidateIdentifier(id));
+    }
+
+    [Fact]
+    public void RLS_ValidateIdentifier_Empty_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => RowLevelSecurityEngine.ValidateIdentifier(string.Empty));
+    }
+
+    [Fact]
+    public void RLS_ValidateIdentifier_Whitespace_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => RowLevelSecurityEngine.ValidateIdentifier("  "));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_Null_ReturnsLiteralNULL()
+    {
+        Assert.Equal("NULL", RowLevelSecurityEngine.EscapeSqlLiteral(null));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_NullCharAtPosition0_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => RowLevelSecurityEngine.EscapeSqlLiteral("\0"));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_NullCharInMiddle_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => RowLevelSecurityEngine.EscapeSqlLiteral("a\0b"));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_Empty_ProducesEmptyQuotedString()
+    {
+        Assert.Equal("''", RowLevelSecurityEngine.EscapeSqlLiteral(string.Empty));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_SingleQuote_DoubledInsideOuterQuotes()
+    {
+        Assert.Equal("''''", RowLevelSecurityEngine.EscapeSqlLiteral("'"));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_MultipleQuotes_AllDoubled()
+    {
+        Assert.Equal("'a''b''c'", RowLevelSecurityEngine.EscapeSqlLiteral("a'b'c"));
+    }
+
+    [Fact]
+    public void RLS_EscapeSqlLiteral_NoQuotes_WrappedOnly()
+    {
+        Assert.Equal("'hello'", RowLevelSecurityEngine.EscapeSqlLiteral("hello"));
+    }
+
+    [Fact]
+    public void RLS_GenerateFilter_NoPolicy_DefaultThrow_Throws()
+    {
+        var engine = new RowLevelSecurityEngine();
+        Assert.Throws<InvalidOperationException>(
+            () => engine.GenerateFilter("Resource", new RLSContext()));
+    }
+
+    [Fact]
+    public void RLS_GenerateFilter_NoPolicy_DenyAll_ReturnsDenyAllFilter()
+    {
+        var engine = new RowLevelSecurityEngine(RLSDefaultBehavior.DenyAll);
+        var filter = engine.GenerateFilter("Resource", new RLSContext());
+        Assert.Same(RLSFilter.DenyAll, filter);
+        Assert.Equal("1=0", filter.Sql);
+    }
+
+    [Fact]
+    public void RLS_GenerateFilter_NoPolicy_AllowAll_ReturnsAllowAllFilter()
+    {
+        var engine = new RowLevelSecurityEngine(RLSDefaultBehavior.AllowAll);
+        var filter = engine.GenerateFilter("Resource", new RLSContext());
+        Assert.Same(RLSFilter.AllowAll, filter);
+        Assert.Equal("1=1", filter.Sql);
+    }
+
+    [Fact]
+    public void RLS_GenerateFilter_NullFilterResult_FallsBackToDenyAll()
+    {
+        var engine = new RowLevelSecurityEngine();
+        engine.RegisterPolicy(new RLSPolicy
+        {
+            ResourceType = "R",
+            FilterGenerator = _ => null!
+        });
+        Assert.Same(RLSFilter.DenyAll, engine.GenerateFilter("R", new RLSContext()));
+    }
+
+    [Fact]
+    public void RLS_TenantPolicy_NullTenants_DeniesAll()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = RowLevelSecurityEngine.CreateTenantBased("TenantId");
+        policy.ResourceType = "R";
+        engine.RegisterPolicy(policy);
+        var filter = engine.GenerateFilter("R", new RLSContext { AllowedTenants = null! });
+        Assert.Same(RLSFilter.DenyAll, filter);
+    }
+
+    [Fact]
+    public void RLS_TenantPolicy_EmptyList_DeniesAll()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = RowLevelSecurityEngine.CreateTenantBased("TenantId");
+        policy.ResourceType = "R";
+        engine.RegisterPolicy(policy);
+        var filter = engine.GenerateFilter("R", new RLSContext { AllowedTenants = new List<string>() });
+        Assert.Same(RLSFilter.DenyAll, filter);
+    }
+
+    [Fact]
+    public void RLS_TenantPolicy_SingleTenant_ProducesParamPlaceholder()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = RowLevelSecurityEngine.CreateTenantBased("TenantId");
+        policy.ResourceType = "R";
+        engine.RegisterPolicy(policy);
+        var filter = engine.GenerateFilter("R", new RLSContext { AllowedTenants = new List<string> { "alpha" } });
+        Assert.Equal("TenantId IN (@rls_tenant_0)", filter.Sql);
+        Assert.Equal("alpha", filter.Parameters["rls_tenant_0"]);
+    }
+
+    [Fact]
+    public void RLS_TenantPolicy_TwoTenants_ProducesTwoPlaceholders()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = RowLevelSecurityEngine.CreateTenantBased("TenantId");
+        policy.ResourceType = "R";
+        engine.RegisterPolicy(policy);
+        var filter = engine.GenerateFilter("R", new RLSContext { AllowedTenants = new List<string> { "a", "b" } });
+        Assert.Equal("TenantId IN (@rls_tenant_0,@rls_tenant_1)", filter.Sql);
+        Assert.Equal("a", filter.Parameters["rls_tenant_0"]);
+        Assert.Equal("b", filter.Parameters["rls_tenant_1"]);
+    }
+
+    [Fact]
+    public void RLS_DeptPolicy_ColumnInSqlAndValueParameterized()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = RowLevelSecurityEngine.CreateDepartmentBased("Dept");
+        policy.ResourceType = "R";
+        engine.RegisterPolicy(policy);
+        var filter = engine.GenerateFilter("R", new RLSContext { Department = "Eng" });
+        Assert.Equal("Dept = @rls_dept", filter.Sql);
+        Assert.Equal("Eng", filter.Parameters["rls_dept"]);
+    }
+
+    [Fact]
+    public void RLS_OwnerPolicy_ColumnInSqlAndValueParameterized()
+    {
+        var engine = new RowLevelSecurityEngine();
+        var policy = RowLevelSecurityEngine.CreateOwnerBased("OwnerId");
+        policy.ResourceType = "R";
+        engine.RegisterPolicy(policy);
+        var filter = engine.GenerateFilter("R", new RLSContext { UserId = "u42" });
+        Assert.Equal("OwnerId = @rls_owner", filter.Sql);
+        Assert.Equal("u42", filter.Parameters["rls_owner"]);
+    }
+
+    [Fact]
+    public void RLS_RegisterPolicy_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new RowLevelSecurityEngine().RegisterPolicy(null!));
+    }
+
+    [Fact]
+    public void RLS_RegisterPolicy_EmptyResourceType_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new RowLevelSecurityEngine().RegisterPolicy(new RLSPolicy { ResourceType = "" }));
+    }
+
+    [Fact]
+    public void RLS_RegisterUnrestricted_EmptyType_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new RowLevelSecurityEngine().RegisterUnrestricted<object>(string.Empty));
+    }
+
+    [Fact]
+    public void RLS_DenyAllFilter_Sql_Is_1Equals0()
+    {
+        Assert.Equal("1=0", RLSFilter.DenyAll.Sql);
+    }
+
+    [Fact]
+    public void RLS_AllowAllFilter_Sql_Is_1Equals1()
+    {
+        Assert.Equal("1=1", RLSFilter.AllowAll.Sql);
+    }
+
+    // -------------------------------------------------------------------------
+    // MigratingAuthenticatedEncryptionProvider — separator-index and stack/heap boundary mutations
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MigratingAead_Decrypt_SeparatorAtIndex0_ThrowsFormatException()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        Assert.Throws<FormatException>(() => p.Decrypt(":body", default));
+    }
+
+    [Fact]
+    public void MigratingAead_Decrypt_NoSeparator_ThrowsFormatException()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        Assert.Throws<FormatException>(() => p.Decrypt("noseparator", default));
+    }
+
+    [Fact]
+    public void MigratingAead_Decrypt_SeparatorAsLastChar_ThrowsFormatException()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        var ex = Assert.Throws<FormatException>(() => p.Decrypt("v2:", default));
+        Assert.Contains("body", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MigratingAead_Decrypt_UnknownTag_ThrowsInvalidOperation()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        var ex = Assert.Throws<InvalidOperationException>(() => p.Decrypt("v9:someenvelope", default));
+        Assert.Contains("v9", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MigratingAead_Encrypt_NullPlaintext_ThrowsArgumentNull()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        Assert.Throws<ArgumentNullException>(() => p.Encrypt(null!, default));
+    }
+
+    [Fact]
+    public void MigratingAead_Decrypt_NullCiphertext_ThrowsArgumentNull()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        Assert.Throws<ArgumentNullException>(() => p.Decrypt(null!, default));
+    }
+
+    [Theory]
+    [InlineData(61)]
+    [InlineData(62)]
+    [InlineData(63)]
+    [InlineData(64)]
+    [InlineData(65)]
+    public void MigratingAead_StackHeapBoundary_RoundTrips(int aadLength)
+    {
+        var inner = new AesGcmEncryptionProvider(NewKey32());
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", inner);
+        var aad = RandomNumberGenerator.GetBytes(aadLength);
+        var ct = p.Encrypt("boundary-payload", aad);
+        Assert.Equal("boundary-payload", p.Decrypt(ct, aad));
+    }
+
+    [Fact]
+    public void MigratingAead_LargeAad_DifferentAad_ThrowsCrypto()
+    {
+        var inner = new AesGcmEncryptionProvider(NewKey32());
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", inner);
+        var aad = RandomNumberGenerator.GetBytes(100);
+        var ct = p.Encrypt("secret", aad);
+        var differentAad = RandomNumberGenerator.GetBytes(100);
+        Assert.ThrowsAny<CryptographicException>(() => p.Decrypt(ct, differentAad));
+    }
+
+    [Fact]
+    public void MigratingAead_TagSwap_SameKey_FailsAuthentication()
+    {
+        var sharedKey = NewKeyB64();
+        var v1Inner = new AesGcmEncryptionProvider(sharedKey);
+        var v2Inner = new AesGcmEncryptionProvider(sharedKey);
+        var v1 = new MigratingAuthenticatedEncryptionProvider("v1", v1Inner);
+        var v2 = new MigratingAuthenticatedEncryptionProvider(
+            "v2", v2Inner,
+            new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = v1Inner });
+
+        var ct = v1.Encrypt("payload", default);
+        var inner = ct[(ct.IndexOf(':', StringComparison.Ordinal) + 1)..];
+        var swapped = "v2:" + inner;
+
+        Assert.ThrowsAny<CryptographicException>(() => v2.Decrypt(swapped, default));
+    }
+
+    [Fact]
+    public void MigratingAead_LegacyReader_DispatchesByTag_WhenWrittenThroughWrapper()
+    {
+        var legacyInner = new AesGcmEncryptionProvider(NewKey32());
+        var modernInner = new AesGcmEncryptionProvider(NewKey32());
+        var legacyWrapper = new MigratingAuthenticatedEncryptionProvider("v1", legacyInner);
+        var ct = legacyWrapper.Encrypt("legacy-data", "ctx"u8.ToArray());
+
+        var migrating = new MigratingAuthenticatedEncryptionProvider(
+            "v2", modernInner,
+            new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = legacyInner });
+
+        Assert.Equal("legacy-data", migrating.Decrypt(ct, "ctx"u8.ToArray()));
+    }
+
+    [Fact]
+    public void MigratingAead_RegisteredTags_IncludesWriteTagAndLegacy()
+    {
+        var modern = new AesGcmEncryptionProvider(NewKey32());
+        var legacy = new AesGcmEncryptionProvider(NewKey32());
+        var p = new MigratingAuthenticatedEncryptionProvider(
+            "v2", modern,
+            new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = legacy });
+        Assert.Contains("v2", p.RegisteredTags);
+        Assert.Contains("v1", p.RegisteredTags);
+        Assert.Equal("v2", p.WriteTag);
+    }
+
+    [Fact]
+    public void MigratingAead_Constructor_NullWriter_ThrowsArgumentNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new MigratingAuthenticatedEncryptionProvider("v2", null!));
+    }
+
+    [Fact]
+    public void MigratingAead_Constructor_DuplicateTag_ThrowsArgumentException()
+    {
+        var writer = new AesGcmEncryptionProvider(NewKey32());
+        var legacy = new AesGcmEncryptionProvider(NewKey32());
+        Assert.Throws<ArgumentException>(() =>
+            new MigratingAuthenticatedEncryptionProvider(
+                "v2", writer,
+                new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v2"] = legacy }));
+    }
+
+    [Fact]
+    public void MigratingAead_Constructor_NullReaderProvider_ThrowsArgumentException()
+    {
+        var writer = new AesGcmEncryptionProvider(NewKey32());
+        Assert.Throws<ArgumentException>(() =>
+            new MigratingAuthenticatedEncryptionProvider(
+                "v2", writer,
+                new Dictionary<string, IAuthenticatedEncryptionProvider> { ["v1"] = null! }));
+    }
+
+    [Fact]
+    public void MigratingAead_Encrypt_ProducesPrefixedCiphertext()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        var ct = p.Encrypt("data", default);
+        Assert.StartsWith("v2:", ct, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MigratingAead_RoundTrip_EmptyAad()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        var ct = p.Encrypt("data", default);
+        Assert.Equal("data", p.Decrypt(ct, default));
+    }
+
+    [Fact]
+    public void MigratingAead_RoundTrip_NonEmptyAad()
+    {
+        var p = new MigratingAuthenticatedEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKey32()));
+        var aad = "tenant:42"u8.ToArray();
+        var ct = p.Encrypt("private-data", aad);
+        Assert.Equal("private-data", p.Decrypt(ct, aad));
+    }
+}


### PR DESCRIPTION
Closes #76

## Summary

- Three parallel Stryker jobs (Core, EFCore, DI) in `mutation.yml` — each with independent break thresholds (80% library, 85% Core Security)
- Per-PR incremental gate: `dotnet stryker --since=origin/develop` triggered on every PR touching `src/**` or `tests/**`
- Weekly scheduled sweep (Monday 04:00 UTC): full runs with dated HTML+JSON artifacts committed to `mutation-reports` branch under `core/`, `efcore/`, `di/` subdirs
- CODEOWNERS: `@AbongileBoja` required on `Security/**`, `QuerySpecExpressionTranslator.cs`, and `.github/workflows/**`
- 190 new kill tests in `MutationKillerTests.cs` targeting 272 identified survivors from Core baseline (74.36%)
- 1 additional security-path kill test file: `SecurityMutationKillerTests.cs`

## Baseline vs expected scores

| Assembly | Baseline (Windows, timeouts-as-kills) | CI target |
|---|---|---|
| QuerySpec.Core | 74.36% (272 survived, 789 timeout) | ≥ 80% |
| QuerySpec.Core Security paths | not measured separately | ≥ 85% |
| QuerySpec.EFCore | not yet measured | ≥ 80% |
| QuerySpec.DependencyInjection | not yet measured | ≥ 80% |

Note: Windows VsTest yields 0 real kills (all timeouts). Ubuntu CI is the source-of-truth score.

## Survivor triage decisions (5 representative)

1. `AdvancedFilterExpression.ComputeStableHash` arithmetic mutants — killed by `HashIsDistinctForEachFieldVariation_*` tests asserting unique 64-bit values per field combination.
2. `InMemoryAuditLogger.GetAuditsByUserAsync` boundary mutant (`>=` vs `>`) — killed by `GetAuditsByUserAsync_SinceIsInclusive_IncludesBoundaryEntry`.
3. `GeoLocation.DistanceTo` Haversine arithmetic — killed by `DistanceTo_KnownCoordinates_WithinTolerance` using 0.5 km tolerance range.
4. `AuditLogEntry` default-value string mutants — killed by `AuditLogEntry_DefaultValues_AreExpected` asserting exact empty-string defaults.
5. `CacheKeyGenerator` null-coalescing — killed by `GenerateKey_NullTenantId_UsesEmptyString` verifying the key still contains `"tenant:"`.

## Workflow trigger matrix

| Event | Core | EFCore | DI | Security (85%) |
|---|---|---|---|---|
| PR to develop/main | `--since=origin/base_ref` | `--since=origin/base_ref` | `--since=origin/base_ref` | skipped (PR only runs incremental) |
| Schedule (Monday) | full sweep | full sweep | full sweep | full sweep |
| workflow_dispatch | full sweep | full sweep | full sweep | full sweep |

## CODEOWNERS rule

```
src/QuerySpec.Core/Security/** @AbongileBoja
src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs @AbongileBoja
.github/workflows/** @AbongileBoja
```

## Test plan

- [ ] Confirm per-PR mutation gate fires on this PR (look for `Stryker.NET — QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection` checks)
- [ ] Verify artifact upload: `stryker-report-core`, `stryker-report-efcore`, `stryker-report-di` appear in Actions artifacts
- [ ] Confirm `stryker-config.security.json` break threshold 85% is enforced on non-PR runs
- [ ] Squash-merge after gate passes