### PR TITLE
feat(security)!: remove IEncryptionProvider.RotateKeyAsync overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
   * `PerformanceBuilder.EnableQueryCaching()` — compose the existing `WithCaching(c => c.UseMemoryCache())` configuration with your query path; QuerySpec does not own a query-result cache.
   * `PerformanceBuilder.OptimizeExpressions()` — no replacement; expression compilation is already handled by EF Core / `IQueryable` providers.
   * `SecurityBuilder.RotateKeysEvery(int)` — implement key rotation at the storage layer following the same pattern as the `RotateKeyAsync` removal in [#138](https://github.com/AbongileBoja/QuerySpec/issues/138). Closes [#139](https://github.com/AbongileBoja/QuerySpec/issues/139).
+* **security:** `IEncryptionProvider.RotateKeyAsync()` and `IEncryptionProvider.RotateKeyAsync(CancellationToken)` removed. Both overloads were `[Obsolete(error: true)]` in 3.x and every shipping implementation (`AesEncryptionProvider`, `AesGcmEncryptionProvider`, `MigratingEncryptionProvider`) threw `NotSupportedException`. ApiCompat reports `CP0001` (member removed) on both. Implement key rotation at the storage layer instead: construct a new provider with the new key, decrypt under the old provider, re-encrypt under the new provider, persist, then cut over reads. For `MigratingEncryptionProvider` specifically, the existing prefix-tag dispatch already supports this pattern — register the previous writer as a legacy reader and promote the new writer. Closes [#138](https://github.com/AbongileBoja/QuerySpec/issues/138).
 
 ### Added
 

--- a/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
@@ -110,20 +110,6 @@ public class AesEncryptionProvider : IEncryptionProvider
         return Encoding.UTF8.GetString(plainBytes);
     }
 
-    /// <summary>
-    /// Key rotation requires re-encrypting every ciphertext under the new key. This provider
-    /// does not own the persisted ciphertexts. The method previously returned silently which
-    /// gave callers a false belief that rotation had happened. Deprecated and will be removed
-    /// in 3.0; implement rotation at the storage layer.
-    /// </summary>
-    /// <exception cref="NotSupportedException">Always thrown.</exception>
-    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
-    public Task RotateKeyAsync() =>
-        throw new NotSupportedException(
-            "AesEncryptionProvider does not own the persisted ciphertexts and cannot rotate. " +
-            "Construct a new provider with the new key, decrypt with the old, re-encrypt with the new at the storage layer. " +
-            "Prefer AesGcmEncryptionProvider for new ciphertexts.");
-
     /// <summary>Generates a new 256-bit encryption key.</summary>
     /// <returns>A base64-encoded 32-byte AES key suitable for the <see cref="AesEncryptionProvider(string)"/> constructor.</returns>
     public static string GenerateKey()

--- a/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
@@ -102,20 +102,6 @@ public class AesGcmEncryptionProvider : IAuthenticatedEncryptionProvider, IEncry
         return Encoding.UTF8.GetString(plain);
     }
 
-    /// <summary>
-    /// Key rotation requires re-encrypting every ciphertext under the new key. This provider
-    /// holds a single immutable key and does not own the persisted ciphertexts; callers must
-    /// implement rotation at their storage layer (decrypt under old key, re-encrypt under new
-    /// key). The method is implemented as a throwing stub so callers cannot mistake a no-op
-    /// for a real rotation. Deprecated and will be removed in 3.0.
-    /// </summary>
-    /// <exception cref="NotSupportedException">Always thrown.</exception>
-    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
-    public Task RotateKeyAsync() =>
-        throw new NotSupportedException(
-            "AesGcmEncryptionProvider does not own the persisted ciphertexts and therefore cannot rotate. " +
-            "Construct a new instance with the new key, decrypt with the old, re-encrypt with the new at the storage layer.");
-
     /// <summary>Generates a new 256-bit AES key, base64-encoded.</summary>
     public static string GenerateKey()
     {

--- a/src/QuerySpec.Core/Security/IEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/IEncryptionProvider.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace QuerySpec.Core.Security;
 
 /// <summary>
@@ -17,25 +13,4 @@ public interface IEncryptionProvider
     /// <param name="ciphertext">Provider-defined ciphertext envelope as produced by <see cref="Encrypt"/>.</param>
     /// <returns>The recovered UTF-8 plaintext.</returns>
     string Decrypt(string ciphertext);
-
-    /// <summary>
-    /// Rotates the encryption key. Deprecated: every shipping implementation throws
-    /// <see cref="NotSupportedException"/> because the provider does not own the persisted
-    /// ciphertexts. Implement rotation at the storage layer (Azure Key Vault, AWS KMS, etc.):
-    /// decrypt under the old provider, re-encrypt under the new provider.
-    /// </summary>
-    /// <returns>A task that completes once the rotation has been performed by the implementation.</returns>
-    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
-    Task RotateKeyAsync();
-    /// <summary>
-    /// Cancellation-aware overload of <see cref="RotateKeyAsync()"/>. Deprecated alongside the
-    /// no-token overload; will be removed in 3.0. Implement key rotation at the storage layer.
-    /// </summary>
-    /// <param name="cancellationToken">Token observed by implementations that perform I/O during rotation.</param>
-    /// <returns>A task that completes once the rotation has been performed by the implementation.</returns>
-    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
-    Task RotateKeyAsync(CancellationToken cancellationToken)
-#pragma warning disable CS0619 // Obsolete-error self-reference: the DIM delegates to the CT-less overload that is itself obsolete; both ship as a coupled deprecation pair removed together in 3.0.
-        => RotateKeyAsync();
-#pragma warning restore CS0619
 }

--- a/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/MigratingEncryptionProvider.cs
@@ -128,20 +128,6 @@ public sealed class MigratingEncryptionProvider : IEncryptionProvider
     /// <summary>The tag stamped on every ciphertext written by this instance.</summary>
     public string WriteTag { get; }
 
-    /// <summary>
-    /// Migration is meaningful only at the storage layer (decrypt under reader, re-encrypt
-    /// under writer). Calling this on the wrapper is almost always a mistake — it would
-    /// rotate the inner writer's key without re-encrypting any persisted ciphertexts and
-    /// would invalidate the readers for tags pointing at the same physical provider.
-    /// Deprecated and will be removed in 3.0.
-    /// </summary>
-    /// <exception cref="NotSupportedException">Always thrown.</exception>
-    [Obsolete("Key rotation is a storage-layer concern; this method will be removed in 3.0. Implement rotation in the storage layer (Azure Key Vault, AWS KMS, etc.) rather than on IEncryptionProvider.", error: true)]
-    public Task RotateKeyAsync() =>
-        throw new NotSupportedException(
-            "MigratingEncryptionProvider does not own the inner providers' keys and cannot rotate. " +
-            "Construct a new instance with the new writer (and the previous writer demoted to a reader) and re-encrypt at the storage layer.");
-
     internal static void ValidateTag(string tag, string paramName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tag, paramName);

--- a/tests/QuerySpec.Core.Tests/Security/AesGcmEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/AesGcmEncryptionProviderTests.cs
@@ -156,16 +156,6 @@ public class AesGcmEncryptionProviderTests
     }
 
     [Fact]
-    public void RotateKeyAsync_Throws_NotSupported()
-    {
-        var p = new AesGcmEncryptionProvider(NewKey());
-
-        var method = typeof(AesGcmEncryptionProvider).GetMethod(nameof(IEncryptionProvider.RotateKeyAsync), Type.EmptyTypes)!;
-        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(p, null));
-        Assert.IsType<NotSupportedException>(ex.InnerException);
-    }
-
-    [Fact]
     public void GenerateKey_Produces_Base64_32Bytes()
     {
         var key = AesGcmEncryptionProvider.GenerateKey();

--- a/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/MigratingEncryptionProviderTests.cs
@@ -143,16 +143,6 @@ public class MigratingEncryptionProviderTests
     }
 
     [Fact]
-    public void RotateKeyAsync_AlwaysThrows()
-    {
-        var migrating = new MigratingEncryptionProvider("v2", new AesGcmEncryptionProvider(NewKeyB64()));
-
-        var method = typeof(MigratingEncryptionProvider).GetMethod(nameof(IEncryptionProvider.RotateKeyAsync), Type.EmptyTypes)!;
-        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(migrating, null));
-        Assert.IsType<NotSupportedException>(ex.InnerException);
-    }
-
-    [Fact]
     public void RegisteredTags_IncludesWriterAndReaders()
     {
         var modern = new AesGcmEncryptionProvider(NewKeyB64());


### PR DESCRIPTION
## Summary

4.0 BREAKING — Phase 3c of v4 release. Closes the 3.x deprecation shipped in #137. Both overloads were `[Obsolete(error: true)]` in 3.x and every shipping implementation (`AesEncryptionProvider`, `AesGcmEncryptionProvider`, `MigratingEncryptionProvider`) threw `NotSupportedException`. ApiCompat reports `CP0001` (member removed) on both.

## Removed

- `IEncryptionProvider.RotateKeyAsync()`
- `IEncryptionProvider.RotateKeyAsync(CancellationToken)` (the DIM that delegated to the CT-less overload)
- `AesEncryptionProvider.RotateKeyAsync` implementation
- `AesGcmEncryptionProvider.RotateKeyAsync` implementation
- `MigratingEncryptionProvider.RotateKeyAsync` implementation
- 2 reflection-based throw-asserting tests:
  - `RotateKeyAsync_Throws_NotSupported` in `AesGcmEncryptionProviderTests`
  - `RotateKeyAsync_AlwaysThrows` in `MigratingEncryptionProviderTests`

## Migration

Implement key rotation at the storage layer:
1. Construct a new provider with the new key.
2. For each persisted ciphertext: decrypt under the old provider, re-encrypt under the new provider, persist.
3. Cut over reads to the new provider once re-encryption completes.

For `MigratingEncryptionProvider` specifically, the existing prefix-tag dispatch already supports this pattern — register the previous writer as a legacy reader and promote the new writer.

## Local verification

- `dotnet build -c Release -p:QUERYSPEC_SKIP_SIGN=true` — 0 errors
- `dotnet test -c Release` — **718 unique tests green** across net8.0/9.0/10.0 (was 720; 2 removed)

## Phase context — final v4 API break

- Phase 1 ✓ #153 (Analyzers)
- Phase 2 ✓ #154 (deprecation removals)
- Phase 3a ✓ #155 (translator → static class)
- Phase 3b ✓ #156 (DI builder stubs removed)
- **Phase 3c ← this PR** (#138)
- Phase 4 release-engineer — v4.0.0 (next)

Closes #138
Refs #73