### PR TITLE
feat(release): polish NuGet package metadata to first-party standard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
             --no-build --configuration Release \
             -p:Version=${{ steps.version.outputs.version }} \
             -p:ContinuousIntegrationBuild=true \
+            -p:RepositoryCommit=${{ github.sha }} \
             --output ./artifacts
         done
 
@@ -225,6 +226,25 @@ jobs:
           exit 1
         fi
         echo "All packages passed Meziantou NuGet content/metadata validation."
+
+    - name: Test SourceLink mappings
+      run: |
+        set -euo pipefail
+        dotnet tool install -g sourcelink
+        export PATH="$PATH:$HOME/.dotnet/tools"
+        failed=0
+        for pkg in ./artifacts/*.nupkg; do
+          echo "::group::SourceLink test $(basename "$pkg")"
+          if ! sourcelink test "$pkg"; then
+            echo "::error::SourceLink test failed for $(basename "$pkg")"
+            failed=$((failed + 1))
+          fi
+          echo "::endgroup::"
+        done
+        if [[ "$failed" -ne 0 ]]; then
+          exit 1
+        fi
+        echo "All packages passed SourceLink mapping verification."
 
     - name: Upload packages
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,12 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
+    <PackageReleaseNotes>https://github.com/AbongileBoja/QuerySpec/blob/main/CHANGELOG.md#$(Version.Replace('.',''))</PackageReleaseNotes>
     <Copyright>Copyright © Abongile Boja</Copyright>
+
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
   <ItemGroup>
@@ -56,6 +61,7 @@
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Shipped.$(TargetFramework).txt" Condition="Exists('$(MSBuildProjectDirectory)\PublicAPI.Shipped.$(TargetFramework).txt')" />
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Unshipped.$(TargetFramework).txt" Condition="Exists('$(MSBuildProjectDirectory)\PublicAPI.Unshipped.$(TargetFramework).txt')" />
     <None Include="icon.png" Pack="true" PackagePath="\" Condition="Exists('$(MSBuildProjectDirectory)\icon.png')" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,11 @@
 # Releasing QuerySpec to NuGet
 
-Three packages ship together at the same version:
+Four packages ship together at the same version:
 
 - [`QuerySpec.Core`](https://www.nuget.org/packages/QuerySpec.Core)
 - [`QuerySpec.EFCore`](https://www.nuget.org/packages/QuerySpec.EFCore)
 - [`QuerySpec.DependencyInjection`](https://www.nuget.org/packages/QuerySpec.DependencyInjection)
+- [`QuerySpec.Analyzers`](https://www.nuget.org/packages/QuerySpec.Analyzers)
 
 ## One-time setup
 
@@ -16,7 +17,7 @@ Three packages ship together at the same version:
    - **Key name:** `queryspec-github-actions`
    - **Package owner:** your account
    - **Scopes:** `Push new packages and package versions`
-   - **Packages:** `QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection`
+   - **Packages:** `QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection`, `QuerySpec.Analyzers`
      *(If the packages don't yet exist, use the `Glob pattern` field with `QuerySpec.*`.)*
    - **Expiration:** 365 days (rotate annually).
 4. **Copy the key once** — nuget.org won't show it again.
@@ -75,8 +76,9 @@ git push --follow-tags origin develop
    - Builds `QuerySpec.sln` with `-p:Version=<tag>` so the tag is the source of truth
      (not `Directory.Build.props`).
    - Runs the full test suite across net8/net9/net10.
-   - Packs only the three shipping `src/` projects → `artifacts/*.nupkg` + `*.snupkg`.
-   - Validates that exactly 3 nupkg + 3 snupkg exist and filenames embed the version.
+   - Packs all four shipping `src/` projects → `artifacts/*.nupkg` + `*.snupkg`.
+   - Validates that exactly 4 nupkg + 3 snupkg exist and filenames embed the version.
+     (QuerySpec.Analyzers ships with `DevelopmentDependency=true` and embedded PDB symbols; no `.snupkg`.)
 3. **Approval gate** — GitHub pauses and requests approval on the `nuget-release`
    environment. Review, then click **Approve and deploy**.
 4. **Publish** — `dotnet nuget push` uploads each `.nupkg` to nuget.org. Adjacent


### PR DESCRIPTION
## Summary

- Embeds the `LICENSE` file inside every `.nupkg` archive via a shared `None Include` in `Directory.Build.props` — enterprise procurement tooling (FOSSA, Black Duck, `dotnet validate package`) scans the physical file, not just `PackageLicenseExpression`.
- Sets `PackageReleaseNotes` to a per-version CHANGELOG anchor URL (`https://github.com/AbongileBoja/QuerySpec/blob/main/CHANGELOG.md#$(Version.Replace('.',''))`). Produces `#400` for 4.0.0, `#410` for 4.1.0, etc. — version-agnostic, no hardcoding.
- Injects `-p:RepositoryCommit=${{ github.sha }}` on every `dotnet pack` invocation in `release.yml` so nuget.org renders the source-commit link on the package page.
- Configures `NuGetAudit=true`, `NuGetAuditMode=all`, `NuGetAuditLevel=low` in `Directory.Build.props` (Microsoft defaults; SDK default for mode is `direct`, which misses transitive vulnerabilities).
- Adds a `sourcelink test` step in `release.yml` after the Meziantou validation step and before artifact upload. Installs the `sourcelink` global tool and runs it against all four `.nupkg` files. CI fails if any SourceLink mapping does not resolve.
- Fixes stale RELEASE.md prose: "Three packages" → "Four packages" (adds `QuerySpec.Analyzers`), updates the nupkg/snupkg count line, and adds Analyzers to the NuGet API key scope list.

Closes #186
Closes #205

## Verification notes

- `PackageLicenseExpression` and `PackageLicenseFile` cannot coexist (NU5033). The LICENSE file is embedded as a `None Pack=true` item; `PackageLicenseExpression` remains as the nuspec `<license type="expression">` element. Both are present in the produced archive.
- Local `dotnet restore` against develop after the NuGetAudit change surfaced zero NU1901–NU1904 warnings — no vulnerable packages in the current dependency graph.
- Local sourcelink test against a locally-packed nupkg fails (expected — the commit is unpushed and `ContinuousIntegrationBuild` is false locally). The infrastructure is wired; CI will pass once the branch commit is reachable on GitHub and built with `ContinuousIntegrationBuild=true`.
- `PackageReleaseNotes` renders as `https://github.com/AbongileBoja/QuerySpec/blob/main/CHANGELOG.md#400` in the v4.0.0 nuspec, confirmed via `unzip -p ... QuerySpec.Core.nuspec`.

## Test plan

- [ ] CI passes all checks on this branch (Build .NET 8/9/10, dotnet format, CodeQL, dep-review, NuGet vuln scan, commitlint, reproducibility)
- [ ] On the next release tag trigger: `sourcelink test` step passes for all four packages
- [ ] On the next release tag trigger: nuspec `<releaseNotes>` contains a valid CHANGELOG anchor URL
- [ ] On the next release tag trigger: each nupkg contains `LICENSE` at the archive root
- [ ] On the next release tag trigger: `<repository commit="...">` is non-empty in the nuspec