### PR TITLE
docs(security): add SECURITY.md vulnerability-disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are issued for the versions below. Older majors do not receive backports.
+
+| Version | Status              |
+| ------- | ------------------- |
+| 4.x     | Supported           |
+| < 4.0   | End of life         |
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately. Do not open a public issue or pull request that describes the flaw.
+
+- Preferred: [GitHub Private Vulnerability Reporting](https://github.com/AbongileBoja/QuerySpec/security/advisories/new). This routes the report into a private advisory thread that only the maintainers can read.
+- Fallback: email `bojaabongile0@gmail.com` if the GitHub flow is unavailable for you.
+
+Please include affected version(s), a minimal reproduction, the impact you observed, and any proposed mitigation.
+
+## Triage SLA
+
+- Acknowledgement of the report: within 72 hours.
+- Initial assessment (severity, scope, affected versions): within 7 days.
+- Fix or mitigation:
+  - High and Critical: within 90 days.
+  - Medium and Low: within 180 days.
+- Coordinated disclosure window: 90 days from acknowledgement, or upon fix release, whichever comes first.
+
+We will keep the reporter informed at each step and credit them in the advisory unless they request otherwise.
+
+## Scope
+
+In scope:
+
+- `src/QuerySpec.Core`
+- `src/QuerySpec.EFCore`
+- `src/QuerySpec.DependencyInjection`
+- `src/QuerySpec.Analyzers`
+
+Out of scope (please do not file private reports against these; use a regular GitHub issue or the appropriate upstream channel):
+
+- Sample applications under `samples/`
+- Benchmark project under `benchmarks/`
+- Test fixtures and test-only assemblies
+- CI infrastructure under `.github/workflows/` (report via a GitHub Security Advisory if a finding is genuinely security-relevant)
+
+## Disclosure Process
+
+Reports are received privately, acknowledged within the SLA above, triaged for severity and affected versions, and patched on a private branch. A coordinated release publishes the fix together with a public GitHub Security Advisory and, where applicable, a CVE identifier. The advisory is the canonical record of what was fixed, which versions are affected, and how to upgrade.
+
+---
+
+Past advisories and currently open reports are tracked under [Security Advisories](https://github.com/AbongileBoja/QuerySpec/security/advisories).


### PR DESCRIPTION
## Summary

Adds `SECURITY.md` at the repository root so GitHub auto-detects it and renders the policy in the repository Security tab. Enterprise procurement and SOC 2 supplier-risk reviews look for this file as a baseline checklist item; without it the Security tab shows the default placeholder.

## What is in the file

- **Supported Versions** table: `4.x` supported, `< 4.0` end of life. No speculative versions listed.
- **Reporting** channel: GitHub Private Vulnerability Reporting (primary), `bojaabongile0@gmail.com` (fallback).
- **Triage SLA**: 72h acknowledgement, 7d initial assessment, 90d fix for high/critical, 180d for medium/low, 90-day coordinated-disclosure window.
- **Scope**: explicit in-scope (`QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection`, `QuerySpec.Analyzers`) and out-of-scope (samples, benchmarks, tests, CI).
- **Disclosure process**: report → ack → triage → private patch → coordinated release with public GHSA/CVE.

The PGP-key section is intentionally omitted rather than populated with a placeholder. A real key can be added later if a reporter requires one.

## File stats

- Path: `SECURITY.md` (repo root, not `.github/`, for maximum discoverability).
- 54 lines.
- Markdown headings only (`##`), no bold-as-heading.

## Manual settings required after merge

These cannot be flipped via `gh api` without admin scope and must be done in the GitHub web UI by the repository owner:

1. Enable "Private vulnerability reporting" at https://github.com/AbongileBoja/QuerySpec/settings/security_analysis — toggle "Private vulnerability reporting" to ON. This activates the link in `SECURITY.md` (`/security/advisories/new`) and lets reporters open private advisory threads directly from the Security tab.

## Test plan

- [ ] After merge, visit https://github.com/AbongileBoja/QuerySpec/security/policy and confirm the policy renders.
- [ ] After enabling private vulnerability reporting, confirm https://github.com/AbongileBoja/QuerySpec/security/advisories/new is reachable and shows the "Report a vulnerability" form.
- [ ] Confirm `gh repo view AbongileBoja/QuerySpec --json securityPolicyUrl` returns a non-null URL.

Closes #161