### PR TITLE
chore(deps): add Dependabot configuration for nuget, actions, and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      microsoft-efcore:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
+      analyzers:
+        patterns:
+          - "Microsoft.CodeAnalysis.*"
+          - "Roslynator.*"
+          - "StyleCop.*"
+          - "SonarAnalyzer.*"
+          - "Meziantou.Analyzer"
+          - "Microsoft.VisualStudio.Threading.Analyzers"
+      xunit:
+        patterns:
+          - "xunit*"
+      benchmark:
+        patterns:
+          - "BenchmarkDotNet*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+    groups:
+      actions-core:
+        patterns:
+          - "actions/*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so transitive vulnerabilities, action drift, and dev-tooling staleness get automated bump PRs — closing the gap between the existing CI vulnerability scan (which detects) and an actual remediation path (which it didn't have).

Three ecosystems:

| Ecosystem | Cadence | PR limit | Directory |
|---|---|---|---|
| `nuget` | weekly | 10 | `/` (recursive `.csproj` discovery) |
| `github-actions` | weekly | 5 | `/` |
| `npm` | monthly | 5 | `/` |

Bump PRs target `develop` (the default branch and the project's working branch). Commit prefixes are `deps` / `deps-dev` so they pass the project's commitlint scope-enum and slot into the `standard-version` changelog cleanly.

## Grouping (to avoid PR spam)

NuGet bumps cluster into one PR per family rather than one PR per package:

- `microsoft-extensions` — `Microsoft.Extensions.*`
- `microsoft-efcore` — `Microsoft.EntityFrameworkCore*`
- `analyzers` — `Microsoft.CodeAnalysis.*`, `Roslynator.*`, `StyleCop.*`, `SonarAnalyzer.*`, `Meziantou.Analyzer`, `Microsoft.VisualStudio.Threading.Analyzers`
- `xunit` — `xunit*`
- `benchmark` — `BenchmarkDotNet*`

GitHub Actions:

- `actions-core` — `actions/*` (covers `actions/checkout`, `actions/setup-dotnet`, etc.)

npm is left flat — the dev-tooling surface is just commitlint + husky + standard-version, low volume.

## Why these patterns

- **CPM not enabled** in this repo (no `Directory.Packages.props`), so Dependabot will discover versions per `.csproj` recursively under `/`. Confirmed by `find . -name 'Directory.Packages.props'` returning empty.
- **`package.json` is at repo root**, so `npm` directory `/` is correct.
- **Default branch is `develop`**, so `target-branch: develop` on the nuget block is technically redundant but explicit per the issue requirement; github-actions and npm rely on the same default.

## Manual settings required after merge

Two follow-ups the repository owner does in the GitHub UI (cannot be flipped via `gh api` without admin scope, and orthogonal to this PR's file):

1. Visit https://github.com/AbongileBoja/QuerySpec/network/updates and confirm Dependabot has parsed the config and scheduled the first run for each ecosystem.
2. Confirm the existing branch-protection rule on `develop` still requires CI green before any PR (including Dependabot's) can merge. The rule predates this change and should be untouched, but worth a one-click verify.

## Out of scope (intentionally)

- Branch-protection rule changes (separate concern + repo-admin scope)
- PR templates
- CODEOWNERS edits

## Risk and verification

Configuration only. No runtime code touched. The file is parsed by GitHub on push to the default branch; if the YAML is malformed Dependabot surfaces an error in the repo's "Dependabot" tab rather than failing CI. Local YAML parse via PyYAML returned the expected structure (3 ecosystems, 6 group sets, all required keys present).

## Acceptance criteria

- [x] `.github/dependabot.yml` exists with `nuget`, `github-actions`, and `npm` ecosystems
- [x] Grouped updates configured for `Microsoft.Extensions.*` / `Microsoft.EntityFrameworkCore*` / analyzers / xunit / benchmark to avoid PR spam
- [ ] Initial Dependabot PRs land on the configured cadence (post-merge verification)

Closes #162