### PR TITLE
feat(security): add step-security/harden-runner in audit mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
         dotnet-version: ['8.0.x', '9.0.x', '10.0.x']
 
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Record start time
@@ -318,6 +325,12 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -363,6 +376,12 @@ jobs:
       contents: read
       security-events: write
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -456,6 +475,12 @@ jobs:
       pull-requests: read
     if: github.event_name == 'pull_request'
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -493,6 +518,12 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -560,6 +591,12 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0
@@ -617,6 +654,12 @@ jobs:
     name: Reproducibility check (deterministic build)
     runs-on: ubuntu-latest
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -698,6 +741,12 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Download all per-gate evidence

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,6 +20,13 @@ jobs:
       contents: read
 
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0
@@ -110,6 +117,13 @@ jobs:
       contents: read
 
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0
@@ -185,6 +199,13 @@ jobs:
       contents: read
 
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,13 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - name: Reject non-tag refs
       run: |
         set -euo pipefail
@@ -60,6 +67,13 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - name: Checkout
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
@@ -361,6 +375,13 @@ jobs:
       id-token: write
       attestations: write
     steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+
     - name: Download packages
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
       with:


### PR DESCRIPTION
## Summary

Phase 1 of #164. Adds `step-security/harden-runner` as the first step of every job in the three GitHub Actions workflows so runner egress is observed (not yet blocked). Phase 2 will flip to `egress-policy: block` with an explicit allowlist after at least one full CI cycle has produced audit data.

- Pinned to commit `8d3c67de8e2fe68ef647c8db1e6a09f647780f40` (v2.19.0).
- 14 jobs hardened: ci.yml (8), release.yml (3), mutation.yml (3).
- `disable-sudo: true` on every job — none of these workloads need sudo for build/test/pack/publish.
- `disable-file-monitoring: false` keeps file-write events in the audit signal.

## Coverage

| Workflow | Jobs hardened |
|---|---|
| `.github/workflows/ci.yml` | `build` (matrix x3), `format`, `codeql`, `dependency-review`, `vulnerability-scan`, `commitlint`, `reproducibility`, `aggregate-evidence` |
| `.github/workflows/release.yml` | `guard`, `pack`, `publish` |
| `.github/workflows/mutation.yml` | `stryker-core`, `stryker-efcore`, `stryker-di` |

In every job the harden-runner step precedes `actions/checkout` (or in the `guard` and `publish` jobs, the first non-checkout step) so it intercepts egress from the very first step.

## Behaviour change

None at runtime. Audit mode does not fail the job on egress — it only records observed endpoints in the harden-runner job summary. CI verdicts on this PR will reflect the existing gates only.

## Phase 2 follow-up

Tracked separately so the audit data from this PR can inform the allowlist. The two phases will not be combined.

Refs #164