### PR TITLE
feat(release): verify SBOM in nupkg and broaden reproducibility to all shipped assemblies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,43 +669,79 @@ jobs:
 
     - name: First build
       run: |
-        dotnet build src/QuerySpec.Core/QuerySpec.Core.csproj \
-          --configuration Release \
-          -p:ContinuousIntegrationBuild=true \
-          -p:Deterministic=true \
-          -p:SignAssembly=false -p:DelaySign=false \
-          /bl:msbuild1.binlog
-        cp src/QuerySpec.Core/bin/Release/net10.0/QuerySpec.Core.dll /tmp/build1.dll
+        set -euo pipefail
+        common="-p:ContinuousIntegrationBuild=true -p:Deterministic=true -p:SignAssembly=false -p:DelaySign=false"
+        for proj in \
+          src/QuerySpec.Analyzers/QuerySpec.Analyzers.csproj \
+          src/QuerySpec.Analyzers.CodeFixes/QuerySpec.Analyzers.CodeFixes.csproj \
+          src/QuerySpec.Core/QuerySpec.Core.csproj \
+          src/QuerySpec.EFCore/QuerySpec.EFCore.csproj \
+          src/QuerySpec.DependencyInjection/QuerySpec.DependencyInjection.csproj
+        do
+          dotnet build "$proj" --configuration Release $common
+        done
+        mkdir -p /tmp/build1
+        cp src/QuerySpec.Core/bin/Release/net10.0/QuerySpec.Core.dll                                            /tmp/build1/
+        cp src/QuerySpec.EFCore/bin/Release/net10.0/QuerySpec.EFCore.dll                                        /tmp/build1/
+        cp src/QuerySpec.DependencyInjection/bin/Release/net10.0/QuerySpec.DependencyInjection.dll              /tmp/build1/
+        cp src/QuerySpec.Analyzers/bin/Release/netstandard2.0/QuerySpec.Analyzers.dll                           /tmp/build1/
+        cp src/QuerySpec.Analyzers.CodeFixes/bin/Release/netstandard2.0/QuerySpec.Analyzers.CodeFixes.dll       /tmp/build1/
 
     - name: Clean and second build
       run: |
-        dotnet clean src/QuerySpec.Core/QuerySpec.Core.csproj --configuration Release
-        rm -rf src/QuerySpec.Core/bin src/QuerySpec.Core/obj
-        dotnet build src/QuerySpec.Core/QuerySpec.Core.csproj \
-          --configuration Release \
-          -p:ContinuousIntegrationBuild=true \
-          -p:Deterministic=true \
-          -p:SignAssembly=false -p:DelaySign=false \
-          /bl:msbuild2.binlog
-        cp src/QuerySpec.Core/bin/Release/net10.0/QuerySpec.Core.dll /tmp/build2.dll
+        set -euo pipefail
+        for proj in \
+          src/QuerySpec.Analyzers \
+          src/QuerySpec.Analyzers.CodeFixes \
+          src/QuerySpec.Core \
+          src/QuerySpec.EFCore \
+          src/QuerySpec.DependencyInjection
+        do
+          rm -rf "$proj/bin" "$proj/obj"
+        done
+        common="-p:ContinuousIntegrationBuild=true -p:Deterministic=true -p:SignAssembly=false -p:DelaySign=false"
+        for proj in \
+          src/QuerySpec.Analyzers/QuerySpec.Analyzers.csproj \
+          src/QuerySpec.Analyzers.CodeFixes/QuerySpec.Analyzers.CodeFixes.csproj \
+          src/QuerySpec.Core/QuerySpec.Core.csproj \
+          src/QuerySpec.EFCore/QuerySpec.EFCore.csproj \
+          src/QuerySpec.DependencyInjection/QuerySpec.DependencyInjection.csproj
+        do
+          dotnet build "$proj" --configuration Release $common
+        done
+        mkdir -p /tmp/build2
+        cp src/QuerySpec.Core/bin/Release/net10.0/QuerySpec.Core.dll                                            /tmp/build2/
+        cp src/QuerySpec.EFCore/bin/Release/net10.0/QuerySpec.EFCore.dll                                        /tmp/build2/
+        cp src/QuerySpec.DependencyInjection/bin/Release/net10.0/QuerySpec.DependencyInjection.dll              /tmp/build2/
+        cp src/QuerySpec.Analyzers/bin/Release/netstandard2.0/QuerySpec.Analyzers.dll                           /tmp/build2/
+        cp src/QuerySpec.Analyzers.CodeFixes/bin/Release/netstandard2.0/QuerySpec.Analyzers.CodeFixes.dll       /tmp/build2/
 
     - name: Compare assembly hashes
       id: repro
       run: |
         set -euo pipefail
-        h1=$(sha256sum /tmp/build1.dll | cut -d' ' -f1)
-        h2=$(sha256sum /tmp/build2.dll | cut -d' ' -f1)
-        echo "Build 1 sha256: $h1"
-        echo "Build 2 sha256: $h2"
-        echo "h1=${h1}" >> "$GITHUB_OUTPUT"
-        echo "h2=${h2}" >> "$GITHUB_OUTPUT"
-        if [[ "$h1" != "$h2" ]]; then
-          echo "::error::Builds are not byte-identical. Deterministic build is broken."
-          echo "identical=false" >> "$GITHUB_OUTPUT"
+        failed=0
+        for asm in \
+          QuerySpec.Core.dll \
+          QuerySpec.EFCore.dll \
+          QuerySpec.DependencyInjection.dll \
+          QuerySpec.Analyzers.dll \
+          QuerySpec.Analyzers.CodeFixes.dll
+        do
+          hash1=$(sha256sum "/tmp/build1/$asm" | awk '{print $1}')
+          hash2=$(sha256sum "/tmp/build2/$asm" | awk '{print $1}')
+          if [[ "$hash1" != "$hash2" ]]; then
+            echo "::error::Non-deterministic build: $asm differs ($hash1 vs $hash2)"
+            failed=$((failed + 1))
+          else
+            echo "OK: $asm sha256=$hash1"
+          fi
+        done
+        echo "identical=$([[ $failed -eq 0 ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+        if [[ "$failed" -ne 0 ]]; then
           exit 1
         fi
-        echo "Builds are byte-identical."
-        echo "identical=true" >> "$GITHUB_OUTPUT"
+        echo "All 5 assemblies are byte-identical across both builds."
 
     - name: Emit reproducibility evidence
       if: always()
@@ -719,10 +755,8 @@ jobs:
         identical=true
         if [[ "${{ steps.repro.outcome }}" != "success" ]]; then verdict=fail; identical=false; fi
         summary=$(jq -n \
-          --arg h1 '${{ steps.repro.outputs.h1 }}' \
-          --arg h2 '${{ steps.repro.outputs.h2 }}' \
           --argjson id "$identical" \
-          '{build1_sha256:$h1, build2_sha256:$h2, identical:$id, assembly:"QuerySpec.Core.dll"}')
+          '{identical:$id, assemblies_checked:5, assemblies:["QuerySpec.Core.dll","QuerySpec.EFCore.dll","QuerySpec.DependencyInjection.dll","QuerySpec.Analyzers.dll","QuerySpec.Analyzers.CodeFixes.dll"]}')
         eng/emit-evidence.sh --gate reproducibility --verdict "$verdict" \
           --summary-json "$summary" --output-dir ./evidence
     - name: Upload reproducibility evidence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,22 @@ jobs:
         fi
         echo "All packages passed Meziantou NuGet content/metadata validation."
 
+    - name: Verify SBOM in packages
+      run: |
+        set -euo pipefail
+        failed=0
+        for pkg in ./artifacts/*.nupkg; do
+          echo "Verifying SBOM in $(basename "$pkg")"
+          if ! unzip -l "$pkg" | grep -q '_manifest/spdx_2.2/manifest.spdx.json'; then
+            echo "::error::SBOM manifest missing from $(basename "$pkg")"
+            failed=$((failed + 1))
+          fi
+        done
+        if [[ "$failed" -ne 0 ]]; then
+          exit 1
+        fi
+        echo "SBOM verified for all $(ls ./artifacts/*.nupkg | wc -l | tr -d ' ') packages"
+
     - name: Test SourceLink mappings
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary

- Adds a CI gate in `release.yml` that asserts `_manifest/spdx_2.2/manifest.spdx.json` is present inside every `.nupkg` before the SourceLink test runs. Without this check, a regression in the SBOM MSBuild target would silently ship packages without a manifest.
- Extends the `reproducibility` job in `ci.yml` from checking only `QuerySpec.Core.dll` to all five shipped assemblies: Core, EFCore, DependencyInjection, Analyzers, and Analyzers.CodeFixes. Each project is built independently to handle the mixed TFM layout (net10.0 vs netstandard2.0).

## Changes

### `release.yml` — new step "Verify SBOM in packages"

Inserted after "Validate package contents and metadata" and before "Test SourceLink mappings". Uses `unzip -l` (available by default on ubuntu-latest) to list each `.nupkg` archive and grep for the SPDX manifest path. Accumulates failures so all packages are reported before exiting.

### `ci.yml` — reproducibility job rewrite

Replaces the single-project build/copy/compare pattern with a loop over all five projects. Clean step removes bin/obj for all five before the second build. Compare step iterates all five DLL names and reports any non-deterministic assembly individually. Evidence summary updated: `assemblies_checked:5`, `assemblies:[...]`.

## Pre-flight results

Local double-build on all five assemblies — all byte-identical:

```
QuerySpec.Analyzers.CodeFixes.dll  bde3c282...  (build1 == build2)
QuerySpec.Analyzers.dll            380889619...  (build1 == build2)
QuerySpec.Core.dll                 4051ff1e...  (build1 == build2)
QuerySpec.DependencyInjection.dll  15617b07...  (build1 == build2)
QuerySpec.EFCore.dll               5ff7f7e6...  (build1 == build2)
```

Local pack of QuerySpec.Core confirmed SBOM present: `_manifest/spdx_2.2/manifest.spdx.json` (26 155 bytes) in the archive.

## Notes

`QuerySpec.Analyzers.CodeFixes` is `IsPackable=false` — it ships inside `QuerySpec.Analyzers.nupkg` via the `_IncludeAnalyzerAssembliesInPackage` target. It is still included in the reproducibility check because its DLL lands in a released package and the determinism guarantee should cover it.

Closes #187