### PR TITLE
fix(ci): remove git push from mutation jobs; reports via artifacts

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,3 +1,6 @@
+# Mutation reports are emitted as workflow artifacts (per-run retention 90 days).
+# The `mutation-reports` branch is no longer used; reports are accessible via the
+# "Artifacts" section of each workflow run. `contents: read` is sufficient.
 name: Mutation testing
 
 on:
@@ -81,34 +84,6 @@ jobs:
         path: src/QuerySpec.Core/StrykerOutput/
         retention-days: 90
 
-    - name: Publish Core report to mutation-reports branch (weekly sweep only)
-      if: github.event_name == 'schedule' && success()
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        REPORT_DIR=$(ls -dt src/QuerySpec.Core/StrykerOutput/*/reports 2>/dev/null | head -1)
-        if [ -z "$REPORT_DIR" ]; then
-          echo "No report directory found; skipping publish."
-          exit 0
-        fi
-        git config user.email "actions@github.com"
-        git config user.name "github-actions"
-        git fetch origin mutation-reports 2>/dev/null || true
-        if git show-ref --verify --quiet refs/remotes/origin/mutation-reports; then
-          git checkout -b mutation-reports origin/mutation-reports
-        else
-          git checkout --orphan mutation-reports
-          git rm -rf . --quiet || true
-        fi
-        DATED=$(date -u +%Y-%m-%d)
-        mkdir -p "core/$DATED"
-        cp "$REPORT_DIR/"*.html "core/$DATED/" 2>/dev/null || true
-        cp "$REPORT_DIR/"*.json "core/$DATED/" 2>/dev/null || true
-        cp -r "core/$DATED" "core/latest"
-        git add .
-        git diff --staged --quiet || git commit -m "chore(tests): mutation report core $DATED"
-        git push origin mutation-reports
-
   stryker-efcore:
     name: Stryker.NET — QuerySpec.EFCore
     runs-on: ubuntu-latest
@@ -163,34 +138,6 @@ jobs:
         path: src/QuerySpec.EFCore/StrykerOutput/
         retention-days: 90
 
-    - name: Publish EFCore report to mutation-reports branch (weekly sweep only)
-      if: github.event_name == 'schedule' && success()
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        REPORT_DIR=$(ls -dt src/QuerySpec.EFCore/StrykerOutput/*/reports 2>/dev/null | head -1)
-        if [ -z "$REPORT_DIR" ]; then
-          echo "No report directory found; skipping publish."
-          exit 0
-        fi
-        git config user.email "actions@github.com"
-        git config user.name "github-actions"
-        git fetch origin mutation-reports 2>/dev/null || true
-        if git show-ref --verify --quiet refs/remotes/origin/mutation-reports; then
-          git checkout -b mutation-reports origin/mutation-reports
-        else
-          git checkout --orphan mutation-reports
-          git rm -rf . --quiet || true
-        fi
-        DATED=$(date -u +%Y-%m-%d)
-        mkdir -p "efcore/$DATED"
-        cp "$REPORT_DIR/"*.html "efcore/$DATED/" 2>/dev/null || true
-        cp "$REPORT_DIR/"*.json "efcore/$DATED/" 2>/dev/null || true
-        cp -r "efcore/$DATED" "efcore/latest"
-        git add .
-        git diff --staged --quiet || git commit -m "chore(tests): mutation report efcore $DATED"
-        git push origin mutation-reports
-
   stryker-di:
     name: Stryker.NET — QuerySpec.DependencyInjection
     runs-on: ubuntu-latest
@@ -244,31 +191,3 @@ jobs:
         name: stryker-report-di
         path: src/QuerySpec.DependencyInjection/StrykerOutput/
         retention-days: 90
-
-    - name: Publish DI report to mutation-reports branch (weekly sweep only)
-      if: github.event_name == 'schedule' && success()
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        REPORT_DIR=$(ls -dt src/QuerySpec.DependencyInjection/StrykerOutput/*/reports 2>/dev/null | head -1)
-        if [ -z "$REPORT_DIR" ]; then
-          echo "No report directory found; skipping publish."
-          exit 0
-        fi
-        git config user.email "actions@github.com"
-        git config user.name "github-actions"
-        git fetch origin mutation-reports 2>/dev/null || true
-        if git show-ref --verify --quiet refs/remotes/origin/mutation-reports; then
-          git checkout -b mutation-reports origin/mutation-reports
-        else
-          git checkout --orphan mutation-reports
-          git rm -rf . --quiet || true
-        fi
-        DATED=$(date -u +%Y-%m-%d)
-        mkdir -p "di/$DATED"
-        cp "$REPORT_DIR/"*.html "di/$DATED/" 2>/dev/null || true
-        cp "$REPORT_DIR/"*.json "di/$DATED/" 2>/dev/null || true
-        cp -r "di/$DATED" "di/latest"
-        git add .
-        git diff --staged --quiet || git commit -m "chore(tests): mutation report di $DATED"
-        git push origin mutation-reports


### PR DESCRIPTION
## Summary

The three Stryker mutation jobs in `mutation.yml` declared `permissions: contents: read` at the job level but then ran `git push origin mutation-reports` at the end of each weekly sweep. A read-scoped token cannot push; this created an unauditable state where the push was silently failing on every scheduled run.

Investigation results:
- The `mutation-reports` branch does not exist (HTTP 404). The push has been silently failing since the workflow was introduced.
- No file in the repository (README, docs, other workflows) references the branch — it was never consumed by anything.
- `actions/upload-artifact` steps were already wired in all three jobs, making the `git push` blocks redundant dead code on top of a working artifact upload.

## Changes

- Remove the `git push` setup blocks (`git config`, `git fetch`, `git checkout --orphan`, `git commit`, `git push`) from all three Stryker jobs (`stryker-core`, `stryker-efcore`, `stryker-di`).
- `permissions: contents: read` is preserved unchanged on all three jobs — it now correctly reflects what the jobs actually do.
- Add a three-line comment header documenting that reports are emitted as workflow artifacts (90-day retention) and that the `mutation-reports` branch is no longer used.
- The `step-security/harden-runner` step remains `steps[0]` in all three jobs.

## Risk and verification

- No functional behavior changes — artifact upload was already working; the removed steps were failing silently.
- The `mutation-reports` branch never existed, so nothing needs to be deleted post-merge.
- CI on this PR exercises the PR-mode paths (`dotnet stryker --since=origin/$base_ref`) on all three jobs; the removed steps were `schedule`-only so they do not fire on PR.
- Harden-runner audit-mode egress capture for future runs will no longer show GitHub push traffic from these jobs — consistent with issue #216's goal of a tighter allowlist.

## Acceptance criteria

- [ ] `git push origin mutation-reports` does not appear anywhere in `mutation.yml`
- [ ] `permissions: contents: read` is unchanged on all three jobs
- [ ] `step-security/harden-runner` is `steps[0]` in all three jobs
- [ ] All three Stryker CI checks pass on this PR

Closes #190