### PR TITLE
fix(security): use fixed-time compare for audit chain-link verification

### DIFF
--- a/src/QuerySpec.Core/Auditing/AuditLogEntry.cs
+++ b/src/QuerySpec.Core/Auditing/AuditLogEntry.cs
@@ -135,12 +135,26 @@ public class AuditLogEntry
         for (var i = 0; i < entries.Count; i++)
         {
             var expectedPrevious = i == 0 ? null : entries[i - 1].Hash;
-            if (entries[i].PreviousHash != expectedPrevious)
+            if (!ChainLinkMatches(entries[i].PreviousHash, expectedPrevious))
                 return i;
             if (!entries[i].VerifyIntegrity(expectedPrevious))
                 return i;
         }
         return -1;
+    }
+
+    private static bool ChainLinkMatches(string? actual, string? expected)
+    {
+        if (actual is null && expected is null) return true;
+        if (actual is null || expected is null) return false;
+
+        Span<byte> actualBuf = stackalloc byte[64];
+        Span<byte> expectedBuf = stackalloc byte[64];
+        if (!Convert.TryFromBase64String(actual, actualBuf, out var actualLen)) return false;
+        if (!Convert.TryFromBase64String(expected, expectedBuf, out var expectedLen)) return false;
+        if (actualLen != expectedLen) return false;
+
+        return CryptographicOperations.FixedTimeEquals(actualBuf[..actualLen], expectedBuf[..expectedLen]);
     }
 
     private static string ComputeHashCore(AuditLogEntry e, string? previousHash)

--- a/tests/QuerySpec.Core.Tests/Auditing/AuditLogEntryTests.cs
+++ b/tests/QuerySpec.Core.Tests/Auditing/AuditLogEntryTests.cs
@@ -147,4 +147,37 @@ public class AuditLogEntryTests
     {
         Assert.Throws<ArgumentNullException>(() => AuditLogEntry.VerifyChain(null!));
     }
+
+    [Fact]
+    public void VerifyChain_Detects_PreviousHash_Mismatch_Against_Valid_Base64()
+    {
+        var entries = new List<AuditLogEntry>();
+        string? prev = null;
+        for (var i = 0; i < 4; i++)
+        {
+            var e = NewValidEntry(user: $"user{i}");
+            e.Seal(prev);
+            prev = e.Hash;
+            entries.Add(e);
+        }
+
+        var pristine = NewValidEntry(user: "userValidB64");
+        pristine.Seal(previousHash: null);
+        var validButWrongBase64 = pristine.Hash;
+
+        var replacement = NewValidEntry(user: "userX");
+        replacement.Seal(validButWrongBase64);
+        entries[2] = replacement;
+
+        Assert.Equal(2, AuditLogEntry.VerifyChain(entries));
+    }
+
+    [Fact]
+    public void VerifyChain_Detects_Genesis_PreviousHash_Mismatch()
+    {
+        var first = NewValidEntry();
+        first.Seal(previousHash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+
+        Assert.Equal(0, AuditLogEntry.VerifyChain(new[] { first }));
+    }
 }


### PR DESCRIPTION
## Summary

`AuditLogEntry.VerifyChain` had two adjacent equality checks operating on cryptographic comparison data: the integrity-hash compare correctly used `CryptographicOperations.FixedTimeEquals` (line 120), while the chain-link compare on the very next code path used a plain `!=` string compare (line 138). Make the two consistent by routing the chain-link compare through a fixed-time byte-array comparison.

## Change

`VerifyChain` now delegates the `PreviousHash` vs `entries[i-1].Hash` comparison to a private `ChainLinkMatches` helper that:

- Returns `true` for the genesis case (both `null`).
- Returns `false` when exactly one side is `null`.
- Decodes both Base64 strings via `Convert.TryFromBase64String` into stack buffers (hashes are stored Base64-encoded — `Convert.ToBase64String(hash)` in `ComputeHashCore`, not hex).
- Returns `false` if either side fails to decode (preserves the old behaviour on malformed/forged input — the existing `VerifyChain_Detects_Hash_Mutation` test seals with the literal `"forged-prev"` which is invalid Base64).
- Returns `false` on length mismatch.
- Otherwise calls `CryptographicOperations.FixedTimeEquals` on the decoded bytes.

## Public API

No change. `VerifyChain`, `VerifyIntegrity`, and the `PreviousHash` property already shipped (in `PublicAPI.Shipped.txt`); only the body of `VerifyChain` is touched. ApiCompat / PublicAPI tracking will not flag this.

## Tests

- All 44 existing `AuditLog*` tests pass on net8 / net9 / net10.
- 2 new regression tests:
  - `VerifyChain_Detects_PreviousHash_Mismatch_Against_Valid_Base64` — exercises the comparison path with a valid-Base64 PreviousHash that does not match the prior entry's Hash. The old `!=` check would have caught this; under the new code the same break is detected via `FixedTimeEquals` returning `false`.
  - `VerifyChain_Detects_Genesis_PreviousHash_Mismatch` — first entry sealed with a non-null PreviousHash; expected to break at index 0.

Total: 46/46 pass on all three TFMs.

## Behaviour preservation

Same correctness; slightly slower on the verification path (one Base64 decode per entry). Verification is offline and bounded by `entries.Count`, so the cost is acceptable — chain integrity is the priority over a few microseconds.

Closes #188