### PR TITLE
fix(ci): switch dependabot to chore(deps) prefix and add deps-dev scope

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -38,6 +38,7 @@
         "tests",
         "ci",
         "deps",
+        "deps-dev",
         "docs",
         "release"
       ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,9 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
     groups:
       microsoft-extensions:
         patterns:
@@ -42,8 +43,9 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
     groups:
       actions-core:
         patterns:
@@ -57,5 +59,6 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Dependabot was emitting `deps:` / `deps-dev:` as commit-message type prefixes
- commitlint rejects those — only the standard Conventional Commits types are in `type-enum`
- Result: every Dependabot PR fails the "Commit message lint" check, blocking all 17 currently open dependabot PRs (#237, #231, #227, #225, #224, #223, #222, #221, #219, #218, #217, #214, #213, #212, #211, #210, #209)

## Fix

- `.github/dependabot.yml`: all three ecosystems (nuget, github-actions, npm) switched to `prefix: chore` + `include: scope`. Dependabot will now emit `chore(deps): ...` and `chore(deps-dev): ...`
- `.commitlintrc.json`: added `deps-dev` to `scope-enum` (we already had `deps`)
- Validated both messages pass `npx commitlint` locally; the old `deps:` form correctly fails

## Why structural

Editing PR titles wouldn't help — the lint job (`.github/workflows/ci.yml:614-617`) runs `commitlint --from=base.sha --to=head.sha`, validating every commit in the range. Closing and reopening 17 PRs by hand is wasteful churn.

## Test plan

- [x] `npx commitlint` accepts `chore(deps): bump xunit from 2.9.2 to 2.9.3`
- [x] `npx commitlint` accepts `chore(deps-dev): bump @commitlint/cli from 19.8.1 to 20.5.2`
- [x] `npx commitlint` rejects the legacy `deps: bump xunit ...` form
- [x] Dependabot YAML parses cleanly via `js-yaml`
- [ ] After merge: comment `@dependabot recreate` on each of the 17 open PRs to regenerate them

Closes #238