### PR TITLE
feat(ci): fail CI on CodeQL high-severity alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,9 +430,6 @@ jobs:
         echo "alerts_medium=${med}"    >> "$GITHUB_OUTPUT"
         echo "alerts_low=${low}"       >> "$GITHUB_OUTPUT"
         echo "CodeQL open alerts: critical=${crit} high=${high} medium=${med} low=${low}"
-        if [[ "${high}" -gt 0 ]]; then
-          echo "::warning::CodeQL reports ${high} open high-severity alert(s). Currently warn-only; ratchet to fail tracked in #200."
-        fi
 
     - name: Emit CodeQL evidence
       if: always()
@@ -452,13 +449,14 @@ jobs:
         if [[ "${{ steps.codeql.outcome }}" != "success" ]]; then verdict=fail; fi
         if [[ "${{ steps.codeql_alerts.outcome }}" != "success" ]]; then verdict=fail; fi
         if [[ "${crit}" -gt 0 ]]; then verdict=fail; fi
+        if [[ "${high}" -gt 0 ]]; then verdict=fail; fi
         summary=$(jq -n \
           --argjson c "$crit" --argjson h "$high" --argjson m "$med" --argjson l "$low" \
           '{language:"csharp", queries:"security-and-quality",
             alerts_critical:$c, alerts_high:$h, alerts_medium:$m, alerts_low:$l}')
         eng/emit-evidence.sh --gate codeql --verdict "$verdict" \
           --summary-json "$summary" --output-dir ./evidence \
-          --notes "Parsed from GitHub Code Scanning API for ref ${REF}, tool=CodeQL. critical>0 fails the gate; high>0 is warn-only (ratchet tracked in #200)."
+          --notes "Parsed from GitHub Code Scanning API for ref ${REF}, tool=CodeQL. critical>0 and high>0 fail the gate; medium/low remain emit-only."
     - name: Upload codeql evidence
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Summary

Ratchet the CodeQL evidence gate in `.github/workflows/ci.yml` so high-severity alerts now fail the build alongside critical. medium/low remain emit-only.

## Baseline verification

Queried Code Scanning API for `ref=develop`, `state=open`, `tool_name=CodeQL` per severity bucket (matches the workflow's own counter):

```
critical=0
high=0
medium=0
low=0
```

Baseline is clean, so flipping the gate does not retroactively fail develop.

## Diff summary

`.github/workflows/ci.yml` — 1 file changed, 2 insertions(+), 4 deletions(-)

- `Emit CodeQL evidence` step: add `if [[ "${high}" -gt 0 ]]; then verdict=fail; fi` immediately after the existing critical check.
- `Emit CodeQL evidence` step: update `--notes` to `"... critical>0 and high>0 fail the gate; medium/low remain emit-only."`
- `Read CodeQL alert counts` step: drop the `::warning::` emission for `high > 0` (the hard fail in the next step makes it redundant).

## Behavior

- `high == 0` (today): gate still passes (the new `if` only fires when `high > 0`).
- `high >= 1` (future): `verdict=fail`, evidence emitter exits non-zero, the codeql job fails, the aggregate-evidence job fails the run.

## Test plan

- [ ] CI green on this PR (verifies clean-baseline path still passes).
- [ ] No suppressions introduced — `git diff` audited against `NoWarn|SuppressMessage|pragma warning disable|TreatWarningsAsErrors|WarningsNotAsErrors|continue-on-error: true`, output empty.

## Related

- Issue #202 (gate CodeQL **quality** findings) is orthogonal — this PR only changes the security-severity threshold (`alerts_high`). Quality findings come from the `security-and-quality` query suite but are surfaced separately and are not gated by this change.

Closes #200