### PR TITLE
feat(tests): add public-API approval baselines via PublicApiGenerator + Verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,6 @@ FodyWeavers.xsd
 # Commitlint / husky dev-tooling artefacts
 npm-debug.log*
 .husky/_
+
+# Verify snapshot test artefacts — only .verified.txt files are committed
+*.received.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,40 @@ your PR. Local validation is strongly recommended to avoid round-trips.
 `git commit --no-verify` skips the hook. CI will still reject non-conforming commits on
 PR, so there is no production path that avoids the linter.
 
+## Public-API approval
+
+QuerySpec uses [PublicApiGenerator](https://github.com/PublicApiGenerator/PublicApiGenerator) and [Verify](https://github.com/VerifyTests/Verify) to snapshot the public surface of every shipping assembly. The baselines live in `tests/QuerySpec.PublicApi.Tests/ApprovedApi/`.
+
+### What triggers approval failure
+
+Any change to the public surface of `QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection`, or `QuerySpec.Analyzers` will cause `dotnet test` on `QuerySpec.PublicApi.Tests` to fail with a diff between the committed `.verified.txt` and the newly produced `.received.txt`.
+
+### Updating the baselines
+
+When an intentional public-API change is made, accept the new snapshot:
+
+```bash
+# From the repo root — run the approval tests once to produce .received.txt files
+dotnet test tests/QuerySpec.PublicApi.Tests/ --framework net10.0
+
+# Review every diff, then promote received → verified
+for f in tests/QuerySpec.PublicApi.Tests/ApprovedApi/*.received.txt; do
+  cp "$f" "${f/DotNet10_0.received/verified}"
+done
+
+# Stage the updated baselines alongside the API change
+git add tests/QuerySpec.PublicApi.Tests/ApprovedApi/
+```
+
+Both a `feat:` (or `fix:`) commit for the API change and the baseline update belong in the same PR so reviewers see the intended diff.
+
+### Double-gate
+
+1. `Microsoft.CodeAnalysis.PublicApiAnalyzers` (RS0016/RS0017) rejects undeclared API additions at **build time** via `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt`.
+2. The approval tests in `QuerySpec.PublicApi.Tests` catch **any surface change** (added, removed, or modified members) at **test time**.
+
+Both gates must pass for CI to be green.
+
 ## Coverage ratchet
 
 CI enforces minimum line and branch coverage on every push and PR. Thresholds are defined in `.github/workflows/ci.yml`:

--- a/QuerySpec.sln
+++ b/QuerySpec.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuerySpec.Analyzers.CodeFix
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuerySpec.Analyzers.Tests", "tests\QuerySpec.Analyzers.Tests\QuerySpec.Analyzers.Tests.csproj", "{E282FC54-B2EF-4BCC-9F18-8D68EB04DF3F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuerySpec.PublicApi.Tests", "tests\QuerySpec.PublicApi.Tests\QuerySpec.PublicApi.Tests.csproj", "{53C2D25F-28F6-4A01-92EB-37D57ECB3803}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -233,6 +235,18 @@ Global
 		{E282FC54-B2EF-4BCC-9F18-8D68EB04DF3F}.Release|x64.Build.0 = Release|Any CPU
 		{E282FC54-B2EF-4BCC-9F18-8D68EB04DF3F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E282FC54-B2EF-4BCC-9F18-8D68EB04DF3F}.Release|x86.Build.0 = Release|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Debug|x64.Build.0 = Debug|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Debug|x86.Build.0 = Debug|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Release|x64.ActiveCfg = Release|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Release|x64.Build.0 = Release|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Release|x86.ActiveCfg = Release|Any CPU
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -250,5 +264,6 @@ Global
 		{E6226DAB-342B-4E91-B9F8-FC4C7FBFFE5D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{634574EC-D5AA-4CE1-9D72-02D5AC09C10A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{E282FC54-B2EF-4BCC-9F18-8D68EB04DF3F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{53C2D25F-28F6-4A01-92EB-37D57ECB3803} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Analyzers_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Analyzers_PublicApi_HasNotChanged.verified.txt
@@ -1,0 +1,38 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/AbongileBoja/QuerySpec.git")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+namespace QuerySpec.Analyzers
+{
+    [Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer("C#", new string[0])]
+    public sealed class AdvancedFilterExpressionAnalyzer : Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer
+    {
+        public AdvancedFilterExpressionAnalyzer() { }
+        public override System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> SupportedDiagnostics { get; }
+        public override void Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext context) { }
+    }
+    [Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer("C#", new string[0])]
+    public sealed class CacheProviderInvocationAnalyzer : Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer
+    {
+        public CacheProviderInvocationAnalyzer() { }
+        public override System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> SupportedDiagnostics { get; }
+        public override void Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext context) { }
+    }
+    public static class DiagnosticDescriptors
+    {
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor AdvancedFilterExpressionUsage;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor CacheProviderInvocation;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeoLocationMemberAccess;
+    }
+    public static class DiagnosticIds
+    {
+        public const string AdvancedFilterExpressionUsage = "QSPEC0002";
+        public const string CacheProviderInvocation = "QSPEC0003";
+        public const string GeoLocationMemberAccess = "QSPEC0001";
+    }
+    [Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer("C#", new string[0])]
+    public sealed class GeoLocationMemberAccessAnalyzer : Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer
+    {
+        public GeoLocationMemberAccessAnalyzer() { }
+        public override System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor> SupportedDiagnostics { get; }
+        public override void Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext context) { }
+    }
+}

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
@@ -1,0 +1,790 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/AbongileBoja/QuerySpec.git")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"QuerySpec.Core.Tests, PublicKey=0024000004800000140100000602000000240000525341310008000001000100D915FCF575EC3FFF6560CD4D2090C44489428DB73F14E639FD23D7B05DF3670BE3C8B1D0443196D2A1C6BE5CE10A0784A799D6002014C8A667151C0063170754D3D71C2124E3960CA1C77EA352FE698C25DFB50D76D9E9F3D41FCEB71BA59763A26ECA04C1FA3AA1F9045DA9CD706333958B96763D0C836EA64A6E709CD470FFE5C144E0DF0BD317D59AB1B80856CF1B6019108B5545FA66BB25749BE658A6E5CE4822520E633CACAEC5E88441DEEE52CDC069016AFE4BE9C8730CF479E2901DEEBB38D987DDE9DB875435352F3D1473F98708E0C2F691F1E42A52AF9EC3840AFF379711B1D2373DCBD0C4B239B93CD408EF35C2FB30ED2FB10A1CE52E7615EA")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"QuerySpec.EFCore.Tests, PublicKey=0024000004800000140100000602000000240000525341310008000001000100D915FCF575EC3FFF6560CD4D2090C44489428DB73F14E639FD23D7B05DF3670BE3C8B1D0443196D2A1C6BE5CE10A0784A799D6002014C8A667151C0063170754D3D71C2124E3960CA1C77EA352FE698C25DFB50D76D9E9F3D41FCEB71BA59763A26ECA04C1FA3AA1F9045DA9CD706333958B96763D0C836EA64A6E709CD470FFE5C144E0DF0BD317D59AB1B80856CF1B6019108B5545FA66BB25749BE658A6E5CE4822520E633CACAEC5E88441DEEE52CDC069016AFE4BE9C8730CF479E2901DEEBB38D987DDE9DB875435352F3D1473F98708E0C2F691F1E42A52AF9EC3840AFF379711B1D2373DCBD0C4B239B93CD408EF35C2FB30ED2FB10A1CE52E7615EA")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace QuerySpec.Core.Advanced
+{
+    public enum AggregationOperator
+    {
+        Count = 0,
+        Sum = 1,
+        Average = 2,
+        Min = 3,
+        Max = 4,
+        Distinct = 5,
+        GroupBy = 6,
+        StdDev = 7,
+        Variance = 8,
+        Percentile = 9,
+    }
+    public class AggregationRequest
+    {
+        public AggregationRequest() { }
+        public string? Alias { get; set; }
+        public string Field { get; set; }
+        public string? GroupByField { get; set; }
+        public QuerySpec.Core.Advanced.AggregationOperator Operator { get; set; }
+        public int? Percentile { get; set; }
+    }
+    public class CustomOperatorRegistry
+    {
+        public CustomOperatorRegistry() { }
+        public QuerySpec.Core.Advanced.ICustomOperator? Get(string name) { }
+        public System.Collections.Generic.IEnumerable<QuerySpec.Core.Advanced.ICustomOperator> GetAll() { }
+        public void Register(QuerySpec.Core.Advanced.ICustomOperator op) { }
+    }
+    public enum FilterOperator
+    {
+        Equal = 0,
+        NotEqual = 1,
+        GreaterThan = 2,
+        GreaterThanOrEqual = 3,
+        LessThan = 4,
+        LessThanOrEqual = 5,
+        Contains = 10,
+        NotContains = 11,
+        StartsWith = 12,
+        EndsWith = 13,
+        StringMatchCase = 14,
+        StringMatchIgnoreCase = 15,
+        Regex = 16,
+        In = 20,
+        NotIn = 21,
+        AnyMatch = 22,
+        AllMatch = 23,
+        CountGreaterThan = 24,
+        CountLessThan = 25,
+        Between = 30,
+        NotBetween = 31,
+        IsNull = 40,
+        IsNotNull = 41,
+        IsEmpty = 50,
+        IsNotEmpty = 51,
+        [System.Obsolete("Use ContainsCaseInsensitive. Will be removed in 3.0.", false)]
+        Contains_CaseInsensitive = 52,
+        ContainsCaseInsensitive = 52,
+        FullTextSearch = 60,
+        GeoDistance = 70,
+        GeoWithin = 71,
+        DateInRange = 80,
+        DateAfter = 81,
+        DateBefore = 82,
+        DateEquals = 83,
+        RelativeDate = 84,
+        BitwiseAnd = 90,
+        BitwiseOr = 91,
+        Custom = 999,
+    }
+    public sealed class FilterSpec : System.IEquatable<QuerySpec.Core.Advanced.FilterSpec>
+    {
+        public FilterSpec() { }
+        public bool CaseSensitive { get; init; }
+        public string? CustomOperatorName { get; init; }
+        public string Field { get; init; }
+        public System.Collections.Generic.IReadOnlyList<QuerySpec.Core.Advanced.FilterSpec> Filters { get; init; }
+        public QuerySpec.Core.Advanced.GeoCoordinate? GeoLocation { get; init; }
+        public decimal? GeoRadius { get; init; }
+        public bool IncludeDeletedRecords { get; init; }
+        public QuerySpec.Core.Advanced.LogicalOperator Logic { get; init; }
+        public QuerySpec.Core.Advanced.FilterOperator Operator { get; init; }
+        public System.DateTime? TemporalEnd { get; init; }
+        public System.DateTime? TemporalStart { get; init; }
+        public bool UseRegex { get; init; }
+        public object? Value { get; init; }
+        public object? ValueTo { get; init; }
+        public long ComputeStableHash() { }
+        public bool Equals(QuerySpec.Core.Advanced.FilterSpec? other) { }
+        public override int GetHashCode() { }
+        public System.Collections.Generic.IEnumerable<string> Validate() { }
+    }
+    public readonly struct GeoCoordinate : System.IEquatable<QuerySpec.Core.Advanced.GeoCoordinate>
+    {
+        public GeoCoordinate(double latitude, double longitude) { }
+        public double Latitude { get; }
+        public double Longitude { get; }
+        public double DistanceTo(QuerySpec.Core.Advanced.GeoCoordinate other) { }
+        public override string ToString() { }
+        public static QuerySpec.Core.Advanced.GeoCoordinate Parse(string s) { }
+        public static bool TryParse(string? s, out QuerySpec.Core.Advanced.GeoCoordinate result) { }
+    }
+    public interface ICustomOperator
+    {
+        string Description { get; }
+        string Name { get; }
+        System.Type[] SupportedTypes { get; }
+        object? Execute(object value, object filterValue);
+    }
+    public enum LogicalOperator
+    {
+        And = 0,
+        Or = 1,
+        Xor = 2,
+    }
+}
+namespace QuerySpec.Core.Auditing
+{
+    public class AuditContext
+    {
+        public AuditContext() { }
+        public bool EnableAuditing { get; set; }
+        public bool EnableEncryption { get; set; }
+        public bool EnableFieldLevelTracking { get; set; }
+        public bool EnableMasking { get; set; }
+        public string Operation { get; set; }
+        public string RequestId { get; set; }
+        public string ResourceType { get; set; }
+        public System.Collections.Generic.List<string> SensitiveFields { get; set; }
+        public string TenantId { get; set; }
+        public string UserId { get; set; }
+    }
+    public class AuditLogEntry
+    {
+        public AuditLogEntry() { }
+        public System.Collections.Generic.List<string> AccessedSensitiveFields { get; init; }
+        public System.Collections.Generic.List<string> DeniedFields { get; init; }
+        public string? ErrorMessage { get; init; }
+        public long ExecutionTimeMs { get; init; }
+        public System.Collections.Generic.Dictionary<string, object> Filters { get; init; }
+        public string Hash { get; }
+        public string Id { get; init; }
+        public string Operation { get; init; }
+        public string? PreviousHash { get; }
+        public System.Collections.Generic.List<string> ProjectedFields { get; init; }
+        public int RecordsAffected { get; init; }
+        public string RequestId { get; init; }
+        public string ResourceType { get; init; }
+        public bool Success { get; init; }
+        public string TenantId { get; init; }
+        public System.DateTime Timestamp { get; init; }
+        public string UserId { get; init; }
+        public bool WasEncrypted { get; init; }
+        public bool WasMasked { get; init; }
+        [System.Obsolete("Use Seal(previousHash) instead. ComputeHash does not establish chain linkage when" +
+            " called directly.")]
+        public void ComputeHash() { }
+        public void Seal(string? previousHash) { }
+        public void Validate() { }
+        public bool VerifyIntegrity(string? expectedPreviousHash) { }
+        public static int VerifyChain(System.Collections.Generic.IReadOnlyList<QuerySpec.Core.Auditing.AuditLogEntry> entries) { }
+    }
+    public class ComplianceExporter : QuerySpec.Core.Auditing.IComplianceExporter
+    {
+        public ComplianceExporter(QuerySpec.Core.Auditing.IAuditReader auditReader) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        [System.Obsolete("Use GenerateGdprExportAsync. Will be removed in 3.0.", false)]
+        public System.Threading.Tasks.Task GenerateGDPRExportAsync(string userId, string tenantId, System.IO.Stream outputStream) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        [System.Obsolete("Use GenerateGdprExportAsync. Will be removed in 3.0.", false)]
+        public System.Threading.Tasks.Task GenerateGDPRExportAsync(string userId, string tenantId, System.IO.Stream outputStream, System.Threading.CancellationToken cancellationToken) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        public System.Threading.Tasks.Task GenerateGdprExportAsync(string userId, string tenantId, System.IO.Stream outputStream) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        public System.Threading.Tasks.Task GenerateGdprExportAsync(string userId, string tenantId, System.IO.Stream outputStream, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetUserDataAsync(string userId, string tenantId) { }
+        public System.Threading.Tasks.Task<bool> UserHasAccessedFieldAsync(string userId, string fieldName, System.DateTime since) { }
+    }
+    public class EntityAuditTrail
+    {
+        public EntityAuditTrail() { }
+        public System.Collections.Generic.List<QuerySpec.Core.Auditing.FieldChange> Changes { get; set; }
+        public System.DateTime CreatedAt { get; set; }
+        public string EntityId { get; set; }
+        public string EntityType { get; set; }
+        public System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.FieldChange> GetChangesByUser(string userId) { }
+        public System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.FieldChange> GetChangesSince(System.DateTime since) { }
+    }
+    public class FieldChange
+    {
+        public FieldChange() { }
+        public string ChangeReason { get; set; }
+        public System.DateTime ChangedAt { get; set; }
+        public string ChangedBy { get; set; }
+        public string FieldName { get; set; }
+        public object? NewValue { get; set; }
+        public object? OldValue { get; set; }
+        public void Validate() { }
+    }
+    public interface IAuditLogger : QuerySpec.Core.Auditing.IAuditMaintenance, QuerySpec.Core.Auditing.IAuditReader, QuerySpec.Core.Auditing.IAuditWriter { }
+    public interface IAuditMaintenance
+    {
+        System.Threading.Tasks.Task PurgeOldLogsAsync(System.TimeSpan olderThan);
+        System.Threading.Tasks.Task PurgeOldLogsAsync(System.TimeSpan olderThan, System.Threading.CancellationToken cancellationToken);
+    }
+    public interface IAuditReader
+    {
+        System.Threading.Tasks.Task<QuerySpec.Core.Auditing.AuditLogEntry?> GetAuditAsync(string id);
+        System.Threading.Tasks.Task<QuerySpec.Core.Auditing.AuditLogEntry?> GetAuditAsync(string id, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to, System.Threading.CancellationToken cancellationToken);
+    }
+    public interface IAuditWriter
+    {
+        System.Threading.Tasks.Task LogChangeAsync(QuerySpec.Core.Auditing.FieldChange change);
+        System.Threading.Tasks.Task LogChangeAsync(QuerySpec.Core.Auditing.FieldChange change, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task LogQueryAsync(QuerySpec.Core.Auditing.AuditLogEntry entry);
+        System.Threading.Tasks.Task LogQueryAsync(QuerySpec.Core.Auditing.AuditLogEntry entry, System.Threading.CancellationToken cancellationToken);
+    }
+    public interface IComplianceExporter
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        [System.Obsolete("Use GenerateGdprExportAsync. Will be removed in 3.0.", false)]
+        System.Threading.Tasks.Task GenerateGDPRExportAsync(string userId, string tenantId, System.IO.Stream outputStream);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        [System.Obsolete("Use GenerateGdprExportAsync. Will be removed in 3.0.", false)]
+        System.Threading.Tasks.Task GenerateGDPRExportAsync(string userId, string tenantId, System.IO.Stream outputStream, System.Threading.CancellationToken cancellationToken);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        System.Threading.Tasks.Task GenerateGdprExportAsync(string userId, string tenantId, System.IO.Stream outputStream);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
+            "ch emits IL at runtime. Use System.Text.Json source generation (JsonSerializerCo" +
+            "ntext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.")]
+        System.Threading.Tasks.Task GenerateGdprExportAsync(string userId, string tenantId, System.IO.Stream outputStream, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetUserDataAsync(string userId, string tenantId);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetUserDataAsync(string userId, string tenantId, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<bool> UserHasAccessedFieldAsync(string userId, string fieldName, System.DateTime since);
+        System.Threading.Tasks.Task<bool> UserHasAccessedFieldAsync(string userId, string fieldName, System.DateTime since, System.Threading.CancellationToken cancellationToken);
+    }
+    public class InMemoryAuditLogger : QuerySpec.Core.Auditing.IAuditLogger, QuerySpec.Core.Auditing.IAuditMaintenance, QuerySpec.Core.Auditing.IAuditReader, QuerySpec.Core.Auditing.IAuditWriter, System.IDisposable
+    {
+        public InMemoryAuditLogger() { }
+        public InMemoryAuditLogger(System.TimeProvider timeProvider) { }
+        public int Count { get; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public System.Threading.Tasks.Task<QuerySpec.Core.Auditing.AuditLogEntry?> GetAuditAsync(string id) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since = default) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since = default) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to) { }
+        public System.Threading.Tasks.Task LogChangeAsync(QuerySpec.Core.Auditing.FieldChange change) { }
+        public System.Threading.Tasks.Task LogQueryAsync(QuerySpec.Core.Auditing.AuditLogEntry entry) { }
+        public System.Threading.Tasks.Task PurgeOldLogsAsync(System.TimeSpan olderThan) { }
+    }
+}
+namespace QuerySpec.Core.Caching
+{
+    public class CacheKeyGenerator
+    {
+        public static string GenerateKey(string prefix, [System.Runtime.CompilerServices.ParamCollection] [System.Runtime.CompilerServices.ScopedRef] System.ReadOnlySpan<object?> components) { }
+        public static string GeneratePermissionCacheKey(string userId, string resourceType, string fieldName) { }
+        public static string GenerateQueryCacheKey(string tenantId, string userId, string queryHash, string sortHash, int page) { }
+        public static string GenerateSecurityPolicyCacheKey(string resourceType) { }
+    }
+    public class CachePolicy
+    {
+        public CachePolicy() { }
+        public bool CacheByPermissions { get; set; }
+        public bool CacheByTenant { get; set; }
+        public bool CacheByUser { get; set; }
+        public string? CacheKeyPrefix { get; set; }
+        public bool CompressForSize { get; set; }
+        public int CompressionThresholdBytes { get; set; }
+        public System.TimeSpan? Duration { get; set; }
+        public System.Collections.Generic.List<string> InvalidationTriggers { get; set; }
+        public static QuerySpec.Core.Caching.CachePolicy Long { get; }
+        public static QuerySpec.Core.Caching.CachePolicy Medium { get; }
+        public static QuerySpec.Core.Caching.CachePolicy None { get; }
+        public static QuerySpec.Core.Caching.CachePolicy Short { get; }
+    }
+    public readonly struct CacheResult<T> : System.IEquatable<QuerySpec.Core.Caching.CacheResult<T>>
+    {
+        public bool HasValue { get; }
+        public T Value { get; }
+        public static QuerySpec.Core.Caching.CacheResult<T> Miss { get; }
+        public bool Equals(QuerySpec.Core.Caching.CacheResult<T> other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public T GetValueOrDefault() { }
+        public T GetValueOrDefault(T fallback) { }
+        public static QuerySpec.Core.Caching.CacheResult<T> Hit(T value) { }
+        public static bool operator !=(QuerySpec.Core.Caching.CacheResult<T> left, QuerySpec.Core.Caching.CacheResult<T> right) { }
+        public static bool operator ==(QuerySpec.Core.Caching.CacheResult<T> left, QuerySpec.Core.Caching.CacheResult<T> right) { }
+    }
+    public class CacheStats
+    {
+        public CacheStats() { }
+        public double HitRate { get; }
+        public long Hits { get; set; }
+        public long Misses { get; set; }
+        public long Removes { get; set; }
+        public long Sets { get; set; }
+        public void IncrementHits() { }
+        public void IncrementMisses() { }
+        public void IncrementRemoves() { }
+        public void IncrementSets() { }
+        public void Reset() { }
+        public QuerySpec.Core.Caching.CacheStats Snapshot() { }
+        public override string ToString() { }
+    }
+    public class DistributedCacheProvider : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore
+    {
+        public DistributedCacheProvider(Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Microsoft.Extensions.Logging.ILogger<QuerySpec.Core.Caching.DistributedCacheProvider>? logger = null) { }
+        public System.Threading.Tasks.ValueTask<bool> ExistsAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask FlushAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheStats> GetStatsAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask RemoveAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        public System.Threading.Tasks.ValueTask SetValueAsync<T>(string key, T value, System.TimeSpan? ttl = default, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheResult<T>> TryGetAsync<T>(string key, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public interface ICacheInvalidationStrategy
+    {
+        System.Threading.Tasks.ValueTask InvalidateAsync(string key, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask InvalidateByTenantAsync(string tenantId, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask InvalidateByUserAsync(string userId, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask InvalidatePatternAsync(string pattern, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface ICacheProvider
+    {
+        System.Threading.Tasks.ValueTask<bool> ExistsAsync(string key, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask FlushAsync(System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheStats> GetStatsAsync(System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask RemoveAsync(string key, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface ICacheStore
+    {
+        System.Threading.Tasks.ValueTask RemoveAsync(string key, System.Threading.CancellationToken cancellationToken = default);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        System.Threading.Tasks.ValueTask SetValueAsync<T>(string key, T value, System.TimeSpan? ttl = default, System.Threading.CancellationToken cancellationToken = default);
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheResult<T>> TryGetAsync<T>(string key, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface ICacheWarmer
+    {
+        System.Threading.Tasks.ValueTask WarmCacheAsync(System.Threading.CancellationToken cancellationToken = default);
+    }
+    public class MemoryCacheProvider : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore, System.IDisposable
+    {
+        public MemoryCacheProvider() { }
+        public MemoryCacheProvider(Microsoft.Extensions.Caching.Memory.MemoryCacheOptions options) { }
+        public MemoryCacheProvider(Microsoft.Extensions.Caching.Memory.MemoryCacheOptions options, System.TimeProvider timeProvider) { }
+        public void Dispose() { }
+        public System.Threading.Tasks.ValueTask<bool> ExistsAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask FlushAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheStats> GetStatsAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask RemoveAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        public System.Threading.Tasks.ValueTask SetValueAsync<T>(string key, T value, System.TimeSpan? ttl = default, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheResult<T>> TryGetAsync<T>(string key, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public class MultiLevelCache : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore
+    {
+        public MultiLevelCache(QuerySpec.Core.Caching.MemoryCacheProvider l1, QuerySpec.Core.Caching.DistributedCacheProvider l2) { }
+        public System.Threading.Tasks.ValueTask<bool> ExistsAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask FlushAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheStats> GetStatsAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask RemoveAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        public System.Threading.Tasks.ValueTask SetValueAsync<T>(string key, T value, System.TimeSpan? ttl = default, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Cache store reads and writes serialise T. Distributed implementations use System." +
+            "Text.Json reflection-based serialisation, which emits IL at runtime. Use System." +
+            "Text.Json source generation (JsonSerializerContext) for AOT scenarios.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
+        public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheResult<T>> TryGetAsync<T>(string key, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+}
+namespace QuerySpec.Core.Monitoring
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class HealthStatus
+    {
+        public HealthStatus() { }
+        public string Component { get; set; }
+        public bool IsHealthy { get; set; }
+        public string? Message { get; set; }
+        public long ResponseTimeMs { get; set; }
+    }
+    public interface IHealthCheckProvider
+    {
+        System.Threading.Tasks.Task<QuerySpec.Core.Monitoring.HealthStatus> CheckAuditAsync();
+        System.Threading.Tasks.Task<QuerySpec.Core.Monitoring.HealthStatus> CheckCacheAsync();
+        System.Threading.Tasks.Task<QuerySpec.Core.Monitoring.HealthStatus> CheckDatabaseAsync();
+        System.Threading.Tasks.Task<QuerySpec.Core.Monitoring.HealthStatus> CheckSecurityAsync();
+    }
+    public class MetricsCollector
+    {
+        public const int DefaultMaxRetainedQueries = 10000;
+        public MetricsCollector() { }
+        public MetricsCollector(int maxRetainedQueries) { }
+        public MetricsCollector(int maxRetainedQueries, System.TimeProvider timeProvider) { }
+        public QuerySpec.Core.Monitoring.QueryMetricsReport GetReport(System.TimeSpan? period = default) { }
+        public void Record(QuerySpec.Core.Monitoring.QueryMetrics metrics) { }
+    }
+    public class N1DetectionEngine
+    {
+        public const int MaxTrackedPatterns = 1024;
+        public N1DetectionEngine() { }
+        public int MaxStackFrames { get; set; }
+        public int StackPreviewChars { get; set; }
+        public int SuspicionThreshold { get; set; }
+        public QuerySpec.Core.Monitoring.N1DetectionReport GetReport() { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"RecordQuery walks the managed stack via System.Diagnostics.StackFrame.GetMethod() to build a call-site fingerprint. Under trimming, method metadata may be incomplete and patterns will collapse to '?' segments, reducing N+1 detection precision. Consider disabling N+1 detection in trimmed deployments or use a structured logging approach upstream of QuerySpec.")]
+        public void RecordQuery(string sql, long executionTimeMs) { }
+        public void Reset() { }
+    }
+    public class N1DetectionReport
+    {
+        public N1DetectionReport() { }
+        public bool HasSuspiciousPatterns { get; set; }
+        public System.Collections.Generic.List<QuerySpec.Core.Monitoring.SuspiciousPattern> Patterns { get; set; }
+        public int TotalPatterns { get; set; }
+    }
+    public class QueryMetrics
+    {
+        public QueryMetrics() { }
+        public long? CacheExtractionTimeMs { get; set; }
+        public bool CacheHit { get; set; }
+        public int ComplexityScore { get; set; }
+        public long? DatabaseRoundTrips { get; set; }
+        public long? DatabaseTimeMs { get; set; }
+        public double EstimatedComplexity { get; }
+        public System.DateTime ExecutedAt { get; set; }
+        public long ExecutionTimeMs { get; set; }
+        public int FilterCount { get; set; }
+        public System.Collections.Generic.List<string> OptimizationApplied { get; set; }
+        public string QueryId { get; set; }
+        public int RecordsReturned { get; set; }
+        public string ResourceType { get; set; }
+        public int SortCount { get; set; }
+        public bool WasOptimized { get; set; }
+    }
+    public class QueryMetricsReport
+    {
+        public QueryMetricsReport() { }
+        public double AverageComplexityScore { get; set; }
+        public double AverageExecutionTimeMs { get; set; }
+        public double CacheHitRate { get; set; }
+        public QuerySpec.Core.Monitoring.QueryMetrics? MostExpensiveQuery { get; set; }
+        public int OptimizedQueriesCount { get; set; }
+        public int SlowQueries { get; set; }
+        public int TotalQueries { get; set; }
+    }
+    public class SuspiciousPattern
+    {
+        public SuspiciousPattern() { }
+        public double AverageTime { get; set; }
+        public int ExecutionCount { get; set; }
+        public string StackTrace { get; set; }
+        public long TotalTime { get; set; }
+    }
+}
+namespace QuerySpec.Core.Resilience
+{
+    public class BulkheadException : System.Exception
+    {
+        public BulkheadException() { }
+        public BulkheadException(string message) { }
+        public BulkheadException(string message, System.Exception innerException) { }
+    }
+    public class BulkheadPolicy : System.IDisposable
+    {
+        public BulkheadPolicy(int maxConcurrentRequests) { }
+        public int MaxConcurrentRequests { get; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation) { }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public class CircuitBreaker
+    {
+        public CircuitBreaker(System.TimeProvider? timeProvider = null) { }
+        public int FailureThreshold { get; set; }
+        public System.TimeSpan HalfOpenTestInterval { get; set; }
+        public System.TimeSpan OpenTimeout { get; set; }
+        public QuerySpec.Core.Resilience.CircuitState State { get; }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation) { }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, System.Threading.CancellationToken cancellationToken) { }
+        public void Reset() { }
+    }
+    public class CircuitBreakerOpenException : System.Exception
+    {
+        public CircuitBreakerOpenException() { }
+        public CircuitBreakerOpenException(string message) { }
+        public CircuitBreakerOpenException(string message, System.Exception innerException) { }
+        public CircuitBreakerOpenException(string message, int failureCount, int failureThreshold, System.DateTime lastFailureTime, System.TimeSpan retryAfter) { }
+        public int FailureCount { get; }
+        public int FailureThreshold { get; }
+        public System.DateTime LastFailureTime { get; }
+        public System.TimeSpan RetryAfter { get; }
+    }
+    public enum CircuitState
+    {
+        Closed = 0,
+        Open = 1,
+        HalfOpen = 2,
+    }
+    public class RateLimitedException : System.Exception
+    {
+        public RateLimitedException() { }
+        public RateLimitedException(string message) { }
+        public RateLimitedException(string message, System.Exception innerException) { }
+    }
+    public class RateLimiter
+    {
+        public RateLimiter(System.TimeProvider? timeProvider = null) { }
+        public int BurstSize { get; set; }
+        public int TokensPerSecond { get; set; }
+        public System.TimeSpan? GetRetryAfter(string key, int tokensRequired = 1) { }
+        public bool TryAcquire(string key, int tokensRequired = 1) { }
+    }
+    public class ResiliencePolicy
+    {
+        public ResiliencePolicy() { }
+        public QuerySpec.Core.Resilience.BulkheadPolicy? Bulkhead { get; set; }
+        public QuerySpec.Core.Resilience.CircuitBreaker? CircuitBreaker { get; set; }
+        public QuerySpec.Core.Resilience.RateLimiter? RateLimiter { get; set; }
+        public QuerySpec.Core.Resilience.RetryPolicy? RetryPolicy { get; set; }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, string key = "default") { }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, string key, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public class RetryPolicy
+    {
+        public RetryPolicy() { }
+        public double BackoffMultiplier { get; set; }
+        public System.TimeSpan InitialDelay { get; set; }
+        public System.TimeSpan MaxDelay { get; set; }
+        public int MaxRetries { get; set; }
+        public bool UseExponentialBackoff { get; set; }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation) { }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, System.Threading.CancellationToken cancellationToken) { }
+    }
+}
+namespace QuerySpec.Core.Security
+{
+    [System.Obsolete("CBC without authentication is malleable. Use AesGcmEncryptionProvider for new cip" +
+        "hertexts; this class remains only to decrypt legacy data.")]
+    public class AesEncryptionProvider : QuerySpec.Core.Security.IEncryptionProvider
+    {
+        public AesEncryptionProvider(string keyBase64) { }
+        public string Decrypt(string ciphertext) { }
+        public string Encrypt(string plaintext) { }
+        public static string GenerateKey() { }
+    }
+    public class AesGcmEncryptionProvider : QuerySpec.Core.Security.IAuthenticatedEncryptionProvider, QuerySpec.Core.Security.IEncryptionProvider
+    {
+        public AesGcmEncryptionProvider(byte[] key) { }
+        public AesGcmEncryptionProvider(string keyBase64) { }
+        public string Decrypt(string ciphertext) { }
+        public string Decrypt(string ciphertext, System.ReadOnlySpan<byte> associatedData) { }
+        public string Encrypt(string plaintext) { }
+        public string Encrypt(string plaintext, System.ReadOnlySpan<byte> associatedData) { }
+        public static string GenerateKey() { }
+    }
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("AttributePiiClassifier reflects over caller-supplied entity types. Under trimming" +
+        ", [Pii]-annotated members may be removed and the classifier will silently return" +
+        " None. Use ConfiguredPiiClassifier in trimmed/AOT scenarios.")]
+    public sealed class AttributePiiClassifier : QuerySpec.Core.Security.IPiiClassifier
+    {
+        public AttributePiiClassifier() { }
+        public QuerySpec.Core.Security.PiiCategory Classify([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName) { }
+    }
+    public sealed class CompositePiiClassifier : QuerySpec.Core.Security.IPiiClassifier
+    {
+        public CompositePiiClassifier(params QuerySpec.Core.Security.IPiiClassifier[] classifiers) { }
+        public CompositePiiClassifier(System.Collections.Generic.IEnumerable<QuerySpec.Core.Security.IPiiClassifier> classifiers) { }
+        public QuerySpec.Core.Security.PiiCategory Classify([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName) { }
+    }
+    public sealed class ConfiguredPiiClassifier : QuerySpec.Core.Security.IPiiClassifier
+    {
+        public ConfiguredPiiClassifier([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "DeclaringType",
+                "FieldName",
+                "Category"})] System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type, string, QuerySpec.Core.Security.PiiCategory>> registrations) { }
+        public QuerySpec.Core.Security.PiiCategory Classify([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName) { }
+    }
+    public sealed class DataMaskingEngine
+    {
+        public DataMaskingEngine() { }
+        public DataMaskingEngine(byte[]? hashKey) { }
+        public DataMaskingEngine(byte[]? hashKey, QuerySpec.Core.Security.IPiiClassifier? classifier) { }
+        public QuerySpec.Core.Security.PiiCategory Classify([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName) { }
+        public bool IsPii([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName) { }
+        [System.Obsolete("Field-name + value-regex heuristics produce false negatives that leak PII. Annota" +
+            "te fields with [Pii(...)] and use IsPii(Type, string) backed by IPiiClassifier i" +
+            "nstead. Promoted to a build error in 2.0.1; scheduled for removal in 3.0.0.", true)]
+        public bool IsPii(string fieldName, object? value) { }
+        public string Mask(string fieldName, object? value, string? tenantId = null) { }
+        public string Mask([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName, object? value, string? tenantId = null) { }
+        public void RegisterFieldMask(string fieldName, QuerySpec.Core.Security.MaskingStrategy strategy) { }
+    }
+    public class DynamicContext
+    {
+        public DynamicContext() { }
+        public System.DateTime AccessTime { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> CustomData { get; set; }
+        public string? FieldName { get; set; }
+        public string ResourceType { get; set; }
+        public System.Collections.Generic.List<string> Roles { get; set; }
+        public string UserId { get; set; }
+    }
+    public class DynamicPermissionEvaluator
+    {
+        public DynamicPermissionEvaluator() { }
+        public bool HasPermission(QuerySpec.Core.Security.DynamicContext context, QuerySpec.Core.Security.PermissionType type) { }
+        public void RegisterPermission(string role, QuerySpec.Core.Security.PermissionType type, System.Func<QuerySpec.Core.Security.DynamicContext, bool> evaluator) { }
+    }
+    public interface IAuthenticatedEncryptionProvider
+    {
+        string Decrypt(string ciphertext, System.ReadOnlySpan<byte> associatedData);
+        string Encrypt(string plaintext, System.ReadOnlySpan<byte> associatedData);
+    }
+    public interface IEncryptionProvider
+    {
+        string Decrypt(string ciphertext);
+        string Encrypt(string plaintext);
+    }
+    public interface IPiiClassifier
+    {
+        QuerySpec.Core.Security.PiiCategory Classify([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName);
+    }
+    public enum MaskingStrategy
+    {
+        FullMask = 0,
+        PartialMask = 1,
+        LastFourOnly = 2,
+        EmailMask = 3,
+        HashMask = 4,
+    }
+    public sealed class MigratingAuthenticatedEncryptionProvider : QuerySpec.Core.Security.IAuthenticatedEncryptionProvider
+    {
+        public MigratingAuthenticatedEncryptionProvider(string writeTag, QuerySpec.Core.Security.IAuthenticatedEncryptionProvider writer, System.Collections.Generic.IReadOnlyDictionary<string, QuerySpec.Core.Security.IAuthenticatedEncryptionProvider>? legacyReaders = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<string> RegisteredTags { get; }
+        public string WriteTag { get; }
+        public string Decrypt(string ciphertext, System.ReadOnlySpan<byte> associatedData) { }
+        public string Encrypt(string plaintext, System.ReadOnlySpan<byte> associatedData) { }
+    }
+    public sealed class MigratingEncryptionProvider : QuerySpec.Core.Security.IEncryptionProvider
+    {
+        public MigratingEncryptionProvider(string writeTag, QuerySpec.Core.Security.IEncryptionProvider writer, System.Collections.Generic.IReadOnlyDictionary<string, QuerySpec.Core.Security.IEncryptionProvider>? legacyReaders = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<string> RegisteredTags { get; }
+        public string WriteTag { get; }
+        public string Decrypt(string ciphertext) { }
+        public string Encrypt(string plaintext) { }
+    }
+    public sealed class NameOnlyPiiClassifier : QuerySpec.Core.Security.IPiiClassifier
+    {
+        public NameOnlyPiiClassifier(System.Collections.Generic.IReadOnlyDictionary<string, QuerySpec.Core.Security.PiiCategory> byFieldName) { }
+        public QuerySpec.Core.Security.PiiCategory Classify([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName) { }
+    }
+    public enum PermissionType
+    {
+        Read = 0,
+        Write = 1,
+        Delete = 2,
+        Export = 3,
+        ViewSensitive = 4,
+    }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple=false, Inherited=true)]
+    public sealed class PiiAttribute : System.Attribute
+    {
+        public PiiAttribute(QuerySpec.Core.Security.PiiCategory category) { }
+        public QuerySpec.Core.Security.PiiCategory Category { get; }
+    }
+    public enum PiiCategory
+    {
+        None = 0,
+        DirectIdentifier = 1,
+        Contact = 2,
+        Financial = 3,
+        Health = 4,
+        Location = 5,
+        Sensitive = 6,
+    }
+    public class RLSContext
+    {
+        public RLSContext() { }
+        public System.Collections.Generic.List<string> AllowedTenants { get; set; }
+        public System.Collections.Generic.Dictionary<string, object> CustomAttributes { get; set; }
+        public string Department { get; set; }
+        public string Region { get; set; }
+        public string UserId { get; set; }
+    }
+    public enum RLSDefaultBehavior
+    {
+        Throw = 0,
+        DenyAll = 1,
+        AllowAll = 2,
+    }
+    public sealed class RLSFilter
+    {
+        public static readonly QuerySpec.Core.Security.RLSFilter AllowAll;
+        public static readonly QuerySpec.Core.Security.RLSFilter DenyAll;
+        public RLSFilter(string sql, System.Collections.Generic.IReadOnlyDictionary<string, object?>? parameters = null) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Parameters { get; }
+        public string Sql { get; }
+    }
+    public class RLSPolicy
+    {
+        public RLSPolicy() { }
+        public bool ApplyHierarchically { get; set; }
+        public System.Func<QuerySpec.Core.Security.RLSContext, QuerySpec.Core.Security.RLSFilter> FilterGenerator { get; set; }
+        public System.Delegate? PredicateFactory { get; set; }
+        public string ResourceType { get; set; }
+        public QuerySpec.Core.Security.RLSPolicy SetPredicate<T>(System.Func<QuerySpec.Core.Security.RLSContext, System.Linq.Expressions.Expression<System.Func<T, bool>>> factory) { }
+    }
+    public class RowLevelSecurityEngine
+    {
+        public RowLevelSecurityEngine(QuerySpec.Core.Security.RLSDefaultBehavior defaultBehavior = 0) { }
+        public QuerySpec.Core.Security.RLSFilter GenerateFilter(string resourceType, QuerySpec.Core.Security.RLSContext context) { }
+        public System.Linq.Expressions.Expression<System.Func<T, bool>>? GetPredicate<T>(string resourceType, QuerySpec.Core.Security.RLSContext context) { }
+        public void RegisterPolicy(QuerySpec.Core.Security.RLSPolicy policy) { }
+        public void RegisterUnrestricted<T>(string resourceType) { }
+        public static QuerySpec.Core.Security.RLSPolicy CreateDepartmentBased(string deptFieldName) { }
+        public static QuerySpec.Core.Security.RLSPolicy CreateOwnerBased(string ownerFieldName) { }
+        public static QuerySpec.Core.Security.RLSPolicy CreateTenantBased(string tenantFieldName) { }
+        public static string EscapeSqlLiteral(string? value) { }
+        public static string ValidateIdentifier(string identifier) { }
+    }
+}

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.DependencyInjection_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.DependencyInjection_PublicApi_HasNotChanged.verified.txt
@@ -1,0 +1,71 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/AbongileBoja/QuerySpec.git")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace QuerySpec.DependencyInjection
+{
+    public class AuditingBuilder
+    {
+        public AuditingBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+    }
+    public class CachingBuilder
+    {
+        public CachingBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        public QuerySpec.DependencyInjection.CachingBuilder UseDistributedRedis(string connectionString) { }
+        public QuerySpec.DependencyInjection.CachingBuilder UseMemoryCache() { }
+        public QuerySpec.DependencyInjection.CachingBuilder UseMultiLevel() { }
+    }
+    public class MonitoringBuilder
+    {
+        public MonitoringBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+    }
+    public class PerformanceBuilder
+    {
+        public PerformanceBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        public QuerySpec.DependencyInjection.PerformanceBuilder EnableMetrics() { }
+        public QuerySpec.DependencyInjection.PerformanceBuilder EnableN1Detection() { }
+    }
+    public class QuerySpecBuilder
+    {
+        public QuerySpecBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        public QuerySpec.DependencyInjection.QuerySpecBuilder WithAuditing(System.Action<QuerySpec.DependencyInjection.AuditingBuilder> configure) { }
+        public QuerySpec.DependencyInjection.QuerySpecBuilder WithCaching(System.Action<QuerySpec.DependencyInjection.CachingBuilder> configure) { }
+        public QuerySpec.DependencyInjection.QuerySpecBuilder WithMonitoring(System.Action<QuerySpec.DependencyInjection.MonitoringBuilder> configure) { }
+        public QuerySpec.DependencyInjection.QuerySpecBuilder WithPerformance(System.Action<QuerySpec.DependencyInjection.PerformanceBuilder> configure) { }
+        public QuerySpec.DependencyInjection.QuerySpecBuilder WithResilience(System.Action<QuerySpec.DependencyInjection.ResilienceBuilder> configure) { }
+        public QuerySpec.DependencyInjection.QuerySpecBuilder WithSecurity(System.Action<QuerySpec.DependencyInjection.SecurityBuilder> configure) { }
+    }
+    public class ResilienceBuilder
+    {
+        public ResilienceBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        public QuerySpec.DependencyInjection.ResilienceBuilder UseBulkhead(int maxConcurrentRequests) { }
+        public QuerySpec.DependencyInjection.ResilienceBuilder UseCircuitBreaker(int failureThreshold, System.TimeSpan openTimeout) { }
+        public QuerySpec.DependencyInjection.ResilienceBuilder UseRateLimiting(int tokensPerSecond, System.TimeSpan? window = default) { }
+        public QuerySpec.DependencyInjection.ResilienceBuilder UseRetryPolicy(int maxRetries, bool exponentialBackoff = true) { }
+    }
+    public class SecurityBuilder
+    {
+        public SecurityBuilder(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
+        public QuerySpec.DependencyInjection.SecurityBuilder EnableDataMasking() { }
+        public QuerySpec.DependencyInjection.SecurityBuilder EnableDynamicPermissions() { }
+        public QuerySpec.DependencyInjection.SecurityBuilder EnableFieldEncryption(string encryptionKey) { }
+        public QuerySpec.DependencyInjection.SecurityBuilder EnableRowLevelSecurity() { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("AttributePiiClassifier reflects over caller-supplied entity types. Under trimming" +
+            ", [Pii]-annotated members may be removed and the classifier will silently return" +
+            " None. Use UsePiiClassifier with a ConfiguredPiiClassifier in trimmed/AOT scenar" +
+            "ios.")]
+        public QuerySpec.DependencyInjection.SecurityBuilder UseAttributePiiClassifier() { }
+        public QuerySpec.DependencyInjection.SecurityBuilder UsePiiClassifier(QuerySpec.Core.Security.IPiiClassifier classifier) { }
+    }
+    public static class ServiceCollectionExtensions
+    {
+        public static QuerySpec.DependencyInjection.QuerySpecBuilder AddQuerySpec(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<QuerySpec.DependencyInjection.QuerySpecBuilder> configure) { }
+    }
+}

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.EFCore_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.EFCore_PublicApi_HasNotChanged.verified.txt
@@ -1,0 +1,32 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/AbongileBoja/QuerySpec.git")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace QuerySpec.EFCore
+{
+    public static class QuerySpecExpressionTranslator
+    {
+        [System.Obsolete("Aggregation translation is not implemented. The method now throws when an aggrega" +
+            "tion is supplied; previously it silently returned the unmodified query.", false)]
+        public static System.Linq.IQueryable<T> ApplyAggregation<T>(System.Linq.IQueryable<T> query, QuerySpec.Core.Advanced.AggregationRequest? aggregation)
+            where T :  class { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(@"QuerySpec filter translation builds an Enumerable.Contains<T> call via MethodInfo.MakeGenericMethod / Array.CreateInstance for In/NotIn operators. These APIs emit IL at runtime and are not supported under Native AOT. Avoid In/NotIn in AOT-published applications, or pre-translate to a Contains-call against a strongly-typed array at the call site.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"QuerySpec filter translation resolves entity properties by name via reflection (Type.GetProperty), navigates nested property paths whose intermediate types are not statically annotated, and reads Nullable<T>.HasValue/Value via reflected PropertyInfo. Under PublishTrimmed the trimmer cannot prove these members are preserved for arbitrary entity types, so callers must either annotate T with [DynamicallyAccessedMembers(PublicProperties)] for the entire entity graph or opt out of trimming for the call site.")]
+        public static System.Linq.IQueryable<T> ApplyFilter<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(System.Linq.IQueryable<T> query, QuerySpec.Core.Advanced.FilterSpec? filter)
+            where T :  class { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(@"QuerySpec filter translation builds an Enumerable.Contains<T> call via MethodInfo.MakeGenericMethod / Array.CreateInstance for In/NotIn operators. These APIs emit IL at runtime and are not supported under Native AOT. Avoid In/NotIn in AOT-published applications, or pre-translate to a Contains-call against a strongly-typed array at the call site.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"QuerySpec filter translation resolves entity properties by name via reflection (Type.GetProperty), navigates nested property paths whose intermediate types are not statically annotated, and reads Nullable<T>.HasValue/Value via reflected PropertyInfo. Under PublishTrimmed the trimmer cannot prove these members are preserved for arbitrary entity types, so callers must either annotate T with [DynamicallyAccessedMembers(PublicProperties)] for the entire entity graph or opt out of trimming for the call site.")]
+        public static System.Linq.IQueryable<T> ApplyFilterCached<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(System.Linq.IQueryable<T> query, QuerySpec.Core.Advanced.FilterSpec? filter)
+            where T :  class { }
+        public static void ClearPredicateCache() { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(@"QuerySpec filter translation builds an Enumerable.Contains<T> call via MethodInfo.MakeGenericMethod / Array.CreateInstance for In/NotIn operators. These APIs emit IL at runtime and are not supported under Native AOT. Avoid In/NotIn in AOT-published applications, or pre-translate to a Contains-call against a strongly-typed array at the call site.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"QuerySpec filter translation resolves entity properties by name via reflection (Type.GetProperty), navigates nested property paths whose intermediate types are not statically annotated, and reads Nullable<T>.HasValue/Value via reflected PropertyInfo. Under PublishTrimmed the trimmer cannot prove these members are preserved for arbitrary entity types, so callers must either annotate T with [DynamicallyAccessedMembers(PublicProperties)] for the entire entity graph or opt out of trimming for the call site.")]
+        public static System.Linq.Expressions.Expression<System.Func<T, bool>> GetOrBuildCachedPredicate<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)]  T>(QuerySpec.Core.Advanced.FilterSpec filter)
+            where T :  class { }
+        public static class RegexHelper
+        {
+            public static void ClearRegexCache() { }
+            public static bool IsMatch(string? input, string pattern) { }
+        }
+    }
+}

--- a/tests/QuerySpec.PublicApi.Tests/PublicApiApprovalTests.cs
+++ b/tests/QuerySpec.PublicApi.Tests/PublicApiApprovalTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using PublicApiGenerator;
 using QuerySpec.Analyzers;
@@ -15,35 +17,42 @@ namespace QuerySpec.PublicApi.Tests;
 [RequiresDynamicCode("Public API approval tests use reflection to enumerate assembly members.")]
 public sealed class PublicApiApprovalTests
 {
-    private static readonly string SourceFile = GetSourceFile();
+    private static readonly string ApprovedApiDirectory = GetApprovedApiDirectory();
 
-    private static string GetSourceFile([CallerFilePath] string path = "") => path;
+    private static string GetApprovedApiDirectory()
+    {
+        var projectDir = typeof(PublicApiApprovalTests).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .First(a => a.Key == "Verify.ProjectDirectory")
+            .Value!;
+        return Path.Combine(projectDir, "ApprovedApi");
+    }
 
     [Fact]
     public Task Core_PublicApi_HasNotChanged()
     {
         var api = typeof(FilterSpec).Assembly.GeneratePublicApi();
-        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+        return Verifier.Verify(api).UseDirectory(ApprovedApiDirectory);
     }
 
     [Fact]
     public Task EFCore_PublicApi_HasNotChanged()
     {
         var api = typeof(QuerySpecExpressionTranslator).Assembly.GeneratePublicApi();
-        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+        return Verifier.Verify(api).UseDirectory(ApprovedApiDirectory);
     }
 
     [Fact]
     public Task DependencyInjection_PublicApi_HasNotChanged()
     {
         var api = typeof(QuerySpecBuilder).Assembly.GeneratePublicApi();
-        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+        return Verifier.Verify(api).UseDirectory(ApprovedApiDirectory);
     }
 
     [Fact]
     public Task Analyzers_PublicApi_HasNotChanged()
     {
         var api = typeof(DiagnosticIds).Assembly.GeneratePublicApi();
-        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+        return Verifier.Verify(api).UseDirectory(ApprovedApiDirectory);
     }
 }

--- a/tests/QuerySpec.PublicApi.Tests/PublicApiApprovalTests.cs
+++ b/tests/QuerySpec.PublicApi.Tests/PublicApiApprovalTests.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using PublicApiGenerator;
+using QuerySpec.Analyzers;
+using QuerySpec.Core.Advanced;
+using QuerySpec.DependencyInjection;
+using QuerySpec.EFCore;
+using VerifyXunit;
+using Xunit;
+
+namespace QuerySpec.PublicApi.Tests;
+
+[RequiresUnreferencedCode("Public API approval tests use reflection to enumerate assembly members.")]
+[RequiresDynamicCode("Public API approval tests use reflection to enumerate assembly members.")]
+public sealed class PublicApiApprovalTests
+{
+    private static readonly string SourceFile = GetSourceFile();
+
+    private static string GetSourceFile([CallerFilePath] string path = "") => path;
+
+    [Fact]
+    public Task Core_PublicApi_HasNotChanged()
+    {
+        var api = typeof(FilterSpec).Assembly.GeneratePublicApi();
+        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+    }
+
+    [Fact]
+    public Task EFCore_PublicApi_HasNotChanged()
+    {
+        var api = typeof(QuerySpecExpressionTranslator).Assembly.GeneratePublicApi();
+        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+    }
+
+    [Fact]
+    public Task DependencyInjection_PublicApi_HasNotChanged()
+    {
+        var api = typeof(QuerySpecBuilder).Assembly.GeneratePublicApi();
+        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+    }
+
+    [Fact]
+    public Task Analyzers_PublicApi_HasNotChanged()
+    {
+        var api = typeof(DiagnosticIds).Assembly.GeneratePublicApi();
+        return Verifier.Verify(api, sourceFile: SourceFile).UseDirectory("ApprovedApi");
+    }
+}

--- a/tests/QuerySpec.PublicApi.Tests/QuerySpec.PublicApi.Tests.csproj
+++ b/tests/QuerySpec.PublicApi.Tests/QuerySpec.PublicApi.Tests.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
+    <PackageReference Include="Verify.XunitV3" Version="31.16.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(NuGetPackageRoot)xunit.runner.visualstudio\3.1.5\build\net8.0\xunit.runner.visualstudio.testadapter.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          Link="xunit.runner.visualstudio.testadapter.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\QuerySpec.Core\QuerySpec.Core.csproj" />
+    <ProjectReference Include="..\..\src\QuerySpec.EFCore\QuerySpec.EFCore.csproj" />
+    <ProjectReference Include="..\..\src\QuerySpec.DependencyInjection\QuerySpec.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\src\QuerySpec.Analyzers\QuerySpec.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/QuerySpec.PublicApi.Tests/QuerySpec.PublicApi.Tests.csproj
+++ b/tests/QuerySpec.PublicApi.Tests/QuerySpec.PublicApi.Tests.csproj
@@ -26,6 +26,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Verify.SourceGenerators" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -44,6 +48,17 @@
     <ProjectReference Include="..\..\src\QuerySpec.EFCore\QuerySpec.EFCore.csproj" />
     <ProjectReference Include="..\..\src\QuerySpec.DependencyInjection\QuerySpec.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\QuerySpec.Analyzers\QuerySpec.Analyzers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>Verify.ProjectDirectory</_Parameter1>
+      <_Parameter2>$(MSBuildProjectDirectory)\</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>Verify.TargetFrameworks</_Parameter1>
+      <_Parameter2></_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Closes #182. Adds `tests/QuerySpec.PublicApi.Tests/` with one Verify snapshot approval test per shipping assembly: `QuerySpec.Core`, `QuerySpec.EFCore`, `QuerySpec.DependencyInjection`, and `QuerySpec.Analyzers`.
- Initial `.verified.txt` baselines committed under `tests/QuerySpec.PublicApi.Tests/ApprovedApi/`.
- `*.received.txt` added to `.gitignore`; updating baselines documented in `CONTRIBUTING.md`.

## Double-gate

1. `RS0016/RS0017` (PublicApiAnalyzers) rejects undeclared additions at **build time** via `PublicAPI.Shipped.txt`.
2. Approval tests catch any surface change at **test time** — gate fails on both additions and removals.

## Technical notes

- `QuerySpec.Analyzers` targets `netstandard2.0`; PublicApiGenerator uses Mono.Cecil and needs `Microsoft.CodeAnalysis` DLLs in the test output. Added `Microsoft.CodeAnalysis.CSharp 4.8.0` to the test project (no `PrivateAssets="all"`) to satisfy the resolver.
- `GenerateTestingPlatformEntryPoint=false` + `GenerateProgramFile=false` both required to suppress the CS8892 duplicate entry-point conflict between `xunit.v3` and `Microsoft.Testing.Platform.MSBuild` (pulled transitively by Verify.XunitV3).
- `xunit.runner.visualstudio.testadapter.dll` copied explicitly via a `None` item because the runner's `build/` directory only contains a `net8.0/` subfolder, and TFM fallback does not fire for `net10.0` test output directories in the current SDK.
- Tests are scoped to `net10.0` only (single-TFM project) to avoid generating separate baselines per framework.

## Test plan

- [x] `dotnet test tests/QuerySpec.PublicApi.Tests/ --framework net10.0` — 4/4 pass
- [x] Adding `public sealed class SanityCheckApprovalGate {}` to `QuerySpec.EFCore` triggers RS0016 at build time
- [x] 0 suppressions added in diff (`NoWarn`, `SuppressMessage`, `pragma warning disable`)
- [x] 0 warnings in `QuerySpec.PublicApi.Tests.csproj` under Release build