### PR TITLE
feat(tests): add SQL Server and PostgreSQL provider matrix via Testcontainers

### DIFF
--- a/tests/QuerySpec.EFCore.Tests/Fixtures/PostgresFixture.cs
+++ b/tests/QuerySpec.EFCore.Tests/Fixtures/PostgresFixture.cs
@@ -36,10 +36,10 @@ public sealed class PostgresFixture : IAsyncLifetime
         using var ctx = new PostgresWidgetContext(Options);
         await ctx.Database.EnsureCreatedAsync();
         ctx.Widgets.AddRange(
-            new PostgresWidget { Id = 1, Name = "Alpha",    Quantity = 10, Price = 99.50m, CreatedAt = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc) },
-            new PostgresWidget { Id = 2, Name = "Beta",     Quantity = 5,  Price = null,   CreatedAt = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc)  },
+            new PostgresWidget { Id = 1, Name = "Alpha", Quantity = 10, Price = 99.50m, CreatedAt = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc) },
+            new PostgresWidget { Id = 2, Name = "Beta", Quantity = 5, Price = null, CreatedAt = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc) },
             new PostgresWidget { Id = 3, Name = "alphabet", Quantity = 25, Price = 49.99m, CreatedAt = new DateTime(2024, 9, 20, 0, 0, 0, DateTimeKind.Utc) },
-            new PostgresWidget { Id = 4, Name = "Gamma",    Quantity = 0,  Price = 0m,     CreatedAt = new DateTime(2023, 12, 31, 0, 0, 0, DateTimeKind.Utc) });
+            new PostgresWidget { Id = 4, Name = "Gamma", Quantity = 0, Price = 0m, CreatedAt = new DateTime(2023, 12, 31, 0, 0, 0, DateTimeKind.Utc) });
         await ctx.SaveChangesAsync();
     }
 
@@ -62,6 +62,7 @@ public sealed class PostgresWidgetContext : DbContext
         modelBuilder.Entity<PostgresWidget>(e =>
         {
             e.HasKey(w => w.Id);
+            e.Property(w => w.Id).ValueGeneratedNever();
             e.Property(w => w.Price).HasPrecision(18, 4);
         });
     }

--- a/tests/QuerySpec.EFCore.Tests/Fixtures/PostgresFixture.cs
+++ b/tests/QuerySpec.EFCore.Tests/Fixtures/PostgresFixture.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace QuerySpec.EFCore.Tests.Fixtures;
+
+[CollectionDefinition("Postgres")]
+public sealed class PostgresCollection : ICollectionFixture<PostgresFixture> { }
+
+/// <summary>
+/// Starts a PostgreSQL 16 container once per test assembly run and exposes a
+/// <see cref="DbContextOptions{TContext}"/> factory for the Widget entity.  The container
+/// is not restarted between tests; each test creates its own <see cref="DbContext"/> instance
+/// keeping container start overhead to one pay-once cost.
+/// </summary>
+[RequiresUnreferencedCode("Fixture creates EF Core DbContext which requires reflection metadata.")]
+[RequiresDynamicCode("Fixture creates EF Core DbContext which compiles expression trees at runtime.")]
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:16-alpine")
+        .Build();
+
+    public DbContextOptions<PostgresWidgetContext> Options { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        Options = new DbContextOptionsBuilder<PostgresWidgetContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .Options;
+
+        using var ctx = new PostgresWidgetContext(Options);
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Widgets.AddRange(
+            new PostgresWidget { Id = 1, Name = "Alpha",    Quantity = 10, Price = 99.50m, CreatedAt = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc) },
+            new PostgresWidget { Id = 2, Name = "Beta",     Quantity = 5,  Price = null,   CreatedAt = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc)  },
+            new PostgresWidget { Id = 3, Name = "alphabet", Quantity = 25, Price = 49.99m, CreatedAt = new DateTime(2024, 9, 20, 0, 0, 0, DateTimeKind.Utc) },
+            new PostgresWidget { Id = 4, Name = "Gamma",    Quantity = 0,  Price = 0m,     CreatedAt = new DateTime(2023, 12, 31, 0, 0, 0, DateTimeKind.Utc) });
+        await ctx.SaveChangesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+}
+
+[RequiresUnreferencedCode("EF Core DbContext is not fully compatible with trimming.")]
+[RequiresDynamicCode("EF Core DbContext is not fully compatible with NativeAOT.")]
+public sealed class PostgresWidgetContext : DbContext
+{
+    public Microsoft.EntityFrameworkCore.DbSet<PostgresWidget> Widgets => Set<PostgresWidget>();
+
+    public PostgresWidgetContext(DbContextOptions<PostgresWidgetContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<PostgresWidget>(e =>
+        {
+            e.HasKey(w => w.Id);
+            e.Property(w => w.Price).HasPrecision(18, 4);
+        });
+    }
+}
+
+public sealed class PostgresWidget
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal? Price { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/tests/QuerySpec.EFCore.Tests/Fixtures/SqlServerFixture.cs
+++ b/tests/QuerySpec.EFCore.Tests/Fixtures/SqlServerFixture.cs
@@ -37,13 +37,13 @@ public sealed class SqlServerFixture : IAsyncLifetime
         using var ctx = new SqlServerWidgetContext(Options);
         await ctx.Database.EnsureCreatedAsync();
         ctx.Widgets.AddRange(
-            new SqlServerWidget { Id = 1, Name = "Alpha",       Quantity = 10, Price = 99.50m, CreatedAt = new DateTime(2024, 1, 15) },
-            new SqlServerWidget { Id = 2, Name = "Beta",        Quantity = 5,  Price = null,   CreatedAt = new DateTime(2024, 6, 1)  },
-            new SqlServerWidget { Id = 3, Name = "alphabet",    Quantity = 25, Price = 49.99m, CreatedAt = new DateTime(2024, 9, 20) },
-            new SqlServerWidget { Id = 4, Name = "Gamma",       Quantity = 0,  Price = 0m,     CreatedAt = new DateTime(2023, 12, 31) },
-            new SqlServerWidget { Id = 5, Name = "50%_off",     Quantity = 3,  Price = 10.00m, CreatedAt = new DateTime(2024, 3, 1)  },
-            new SqlServerWidget { Id = 6, Name = "[Special]",   Quantity = 1,  Price = 5.00m,  CreatedAt = new DateTime(2024, 4, 15) },
-            new SqlServerWidget { Id = 7, Name = "Under_score", Quantity = 2,  Price = 8.00m,  CreatedAt = new DateTime(2024, 5, 10) });
+            new SqlServerWidget { Id = 1, Name = "Alpha", Quantity = 10, Price = 99.50m, CreatedAt = new DateTime(2024, 1, 15) },
+            new SqlServerWidget { Id = 2, Name = "Beta", Quantity = 5, Price = null, CreatedAt = new DateTime(2024, 6, 1) },
+            new SqlServerWidget { Id = 3, Name = "alphabet", Quantity = 25, Price = 49.99m, CreatedAt = new DateTime(2024, 9, 20) },
+            new SqlServerWidget { Id = 4, Name = "Gamma", Quantity = 0, Price = 0m, CreatedAt = new DateTime(2023, 12, 31) },
+            new SqlServerWidget { Id = 5, Name = "50%_off", Quantity = 3, Price = 10.00m, CreatedAt = new DateTime(2024, 3, 1) },
+            new SqlServerWidget { Id = 6, Name = "[Special]", Quantity = 1, Price = 5.00m, CreatedAt = new DateTime(2024, 4, 15) },
+            new SqlServerWidget { Id = 7, Name = "Under_score", Quantity = 2, Price = 8.00m, CreatedAt = new DateTime(2024, 5, 10) });
         await ctx.SaveChangesAsync();
     }
 
@@ -66,6 +66,7 @@ public sealed class SqlServerWidgetContext : DbContext
         modelBuilder.Entity<SqlServerWidget>(e =>
         {
             e.HasKey(w => w.Id);
+            e.Property(w => w.Id).ValueGeneratedNever();
             e.Property(w => w.Price).HasPrecision(18, 4);
         });
     }

--- a/tests/QuerySpec.EFCore.Tests/Fixtures/SqlServerFixture.cs
+++ b/tests/QuerySpec.EFCore.Tests/Fixtures/SqlServerFixture.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.MsSql;
+using Xunit;
+
+namespace QuerySpec.EFCore.Tests.Fixtures;
+
+[CollectionDefinition("SqlServer")]
+public sealed class SqlServerCollection : ICollectionFixture<SqlServerFixture> { }
+
+/// <summary>
+/// Starts a SQL Server 2022 container once per test assembly run and exposes a
+/// <see cref="DbContextOptions{TContext}"/> factory for the Widget entity.  The container
+/// is not restarted between tests; each test creates its own <see cref="DbContext"/> instance
+/// against the same connection string, which provides hermetic reads while keeping container
+/// start overhead to one pay-once cost.
+/// </summary>
+[RequiresUnreferencedCode("Fixture creates EF Core DbContext which requires reflection metadata.")]
+[RequiresDynamicCode("Fixture creates EF Core DbContext which compiles expression trees at runtime.")]
+public sealed class SqlServerFixture : IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
+        .Build();
+
+    public DbContextOptions<SqlServerWidgetContext> Options { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        Options = new DbContextOptionsBuilder<SqlServerWidgetContext>()
+            .UseSqlServer(_container.GetConnectionString())
+            .Options;
+
+        using var ctx = new SqlServerWidgetContext(Options);
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Widgets.AddRange(
+            new SqlServerWidget { Id = 1, Name = "Alpha",       Quantity = 10, Price = 99.50m, CreatedAt = new DateTime(2024, 1, 15) },
+            new SqlServerWidget { Id = 2, Name = "Beta",        Quantity = 5,  Price = null,   CreatedAt = new DateTime(2024, 6, 1)  },
+            new SqlServerWidget { Id = 3, Name = "alphabet",    Quantity = 25, Price = 49.99m, CreatedAt = new DateTime(2024, 9, 20) },
+            new SqlServerWidget { Id = 4, Name = "Gamma",       Quantity = 0,  Price = 0m,     CreatedAt = new DateTime(2023, 12, 31) },
+            new SqlServerWidget { Id = 5, Name = "50%_off",     Quantity = 3,  Price = 10.00m, CreatedAt = new DateTime(2024, 3, 1)  },
+            new SqlServerWidget { Id = 6, Name = "[Special]",   Quantity = 1,  Price = 5.00m,  CreatedAt = new DateTime(2024, 4, 15) },
+            new SqlServerWidget { Id = 7, Name = "Under_score", Quantity = 2,  Price = 8.00m,  CreatedAt = new DateTime(2024, 5, 10) });
+        await ctx.SaveChangesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+}
+
+[RequiresUnreferencedCode("EF Core DbContext is not fully compatible with trimming.")]
+[RequiresDynamicCode("EF Core DbContext is not fully compatible with NativeAOT.")]
+public sealed class SqlServerWidgetContext : DbContext
+{
+    public Microsoft.EntityFrameworkCore.DbSet<SqlServerWidget> Widgets => Set<SqlServerWidget>();
+
+    public SqlServerWidgetContext(DbContextOptions<SqlServerWidgetContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SqlServerWidget>(e =>
+        {
+            e.HasKey(w => w.Id);
+            e.Property(w => w.Price).HasPrecision(18, 4);
+        });
+    }
+}
+
+public sealed class SqlServerWidget
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public decimal? Price { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
+++ b/tests/QuerySpec.EFCore.Tests/QuerySpec.EFCore.Tests.csproj
@@ -29,16 +29,28 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/QuerySpec.EFCore.Tests/TranslatorPostgresTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/TranslatorPostgresTests.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using QuerySpec.Core.Advanced;
+using QuerySpec.EFCore;
+using QuerySpec.EFCore.Tests.Fixtures;
+using Xunit;
+
+namespace QuerySpec.EFCore.Tests;
+
+/// <summary>
+/// Translator tests against a real PostgreSQL 16 provider via Testcontainers (postgres:16-alpine).
+/// Validates that expression trees produced by <see cref="QuerySpecExpressionTranslator"/> are
+/// accepted by the Npgsql dialect and produce correct SQL, including case-insensitive ILIKE
+/// behaviour and DateTime semantics with UTC-typed timestamps.
+/// </summary>
+/// <remarks>
+/// The collection fixture starts the container once per test assembly run; tests share the same
+/// seeded data and each create their own short-lived <see cref="DbContext"/> for isolation.
+/// These tests require Docker on the host.  They run on GitHub-hosted <c>ubuntu-latest</c>
+/// which ships Docker pre-installed.
+/// </remarks>
+[RequiresUnreferencedCode("Test exercises QuerySpecExpressionTranslator, which requires reflection metadata for entity property resolution.")]
+[RequiresDynamicCode("Test exercises QuerySpecExpressionTranslator, which compiles expression trees at runtime.")]
+[Collection("Postgres")]
+public class TranslatorPostgresTests
+{
+    private readonly PostgresFixture _fixture;
+
+    public TranslatorPostgresTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [RequiresUnreferencedCode("EF Core DbContext is not fully compatible with trimming.")]
+    [RequiresDynamicCode("EF Core DbContext is not fully compatible with NativeAOT.")]
+    private List<PostgresWidget> Run(FilterSpec filter)
+    {
+        using var ctx = new PostgresWidgetContext(_fixture.Options);
+        return QuerySpecExpressionTranslator.ApplyFilter(ctx.Widgets.AsQueryable(), filter).ToList();
+    }
+
+    // ── Parity tests mirroring TranslatorSqliteTests ─────────────────────────────────────────────
+
+    /// <summary>String Equal maps to SQL <c>=</c>.</summary>
+    [Fact]
+    public void Equal_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Equal,
+            Value = "Alpha",
+        });
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    /// <summary>
+    /// Case-insensitive Contains.  On PostgreSQL the translator emits <c>ToLower()</c> + LIKE,
+    /// which Npgsql maps to <c>lower(col) LIKE lower('%lph%')</c>.  Both "Alpha" and "alphabet"
+    /// must match.
+    /// </summary>
+    [Fact]
+    public void StringContains_CaseInsensitive_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "lph",
+            CaseSensitive = false,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, w => w.Id == 1);
+        Assert.Contains(result, w => w.Id == 3);
+    }
+
+    /// <summary>Case-insensitive StartsWith maps to a SQL LIKE with trailing wildcard.</summary>
+    [Fact]
+    public void StringStartsWith_CaseInsensitive_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.StartsWith,
+            Value = "alph",
+            CaseSensitive = false,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, w => w.Id == 1);
+        Assert.Contains(result, w => w.Id == 3);
+    }
+
+    /// <summary>Case-insensitive EndsWith maps to a SQL LIKE with leading wildcard.</summary>
+    [Fact]
+    public void StringEndsWith_CaseInsensitive_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.EndsWith,
+            Value = "bet",
+            CaseSensitive = false,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(3, result[0].Id);
+    }
+
+    /// <summary>Numeric GreaterThan produces a real SQL <c>&gt;</c> predicate.</summary>
+    [Fact]
+    public void GreaterThan_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Quantity",
+            Operator = FilterOperator.GreaterThan,
+            Value = 5,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, w => Assert.True(w.Quantity > 5));
+    }
+
+    /// <summary>Nullable decimal Equal uses SQL IS NULL semantics for null rows.</summary>
+    [Fact]
+    public void NullableDecimal_Equal_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.Equal,
+            Value = 49.99m,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(3, result[0].Id);
+    }
+
+    /// <summary>Nullable decimal GreaterThan excludes rows where Price IS NULL.</summary>
+    [Fact]
+    public void NullableDecimal_GreaterThan_Translates_And_ExcludesNull()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.GreaterThan,
+            Value = 1m,
+        });
+
+        Assert.DoesNotContain(result, w => w.Price is null);
+        Assert.Equal(2, result.Count);
+    }
+
+    /// <summary>IN-list maps to SQL <c>= ANY(ARRAY[…])</c> on PostgreSQL.</summary>
+    [Fact]
+    public void In_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Id",
+            Operator = FilterOperator.In,
+            Value = new[] { 1, 3 },
+        });
+
+        Assert.Equal(2, result.Count);
+    }
+
+    /// <summary>Between produces a closed SQL range predicate.</summary>
+    [Fact]
+    public void Between_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.Between,
+            Value = 1m,
+            ValueTo = 60m,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(3, result[0].Id);
+    }
+
+    /// <summary>Nested AND composes two predicates with SQL AND.</summary>
+    [Fact]
+    public void Nested_And_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Quantity",
+            Operator = FilterOperator.GreaterThan,
+            Value = 0,
+            Logic = LogicalOperator.And,
+            Filters = new List<FilterSpec>
+            {
+                new() { Field = "Price", Operator = FilterOperator.GreaterThan, Value = 1m },
+            },
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, w => Assert.True(w.Quantity > 0 && w.Price > 1m));
+    }
+
+    // ── PostgreSQL-specific tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Case-insensitive Equal on PostgreSQL.  PostgreSQL string comparison is case-sensitive by
+    /// default; the translator lowers both sides, so <c>Equal("alpha")</c> must match
+    /// "Alpha" (Id=1).
+    /// </summary>
+    [Fact]
+    public void Equal_CaseInsensitive_LowerBothSides_MatchesCorrectly()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "ALPHA",
+            CaseSensitive = false,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, w => w.Id == 1);
+        Assert.Contains(result, w => w.Id == 3);
+    }
+
+    /// <summary>
+    /// Case-sensitive Contains on PostgreSQL must not match rows that only differ by case.
+    /// "Alpha" contains "lph" case-sensitively; "Beta" and "Gamma" do not.
+    /// </summary>
+    [Fact]
+    public void StringContains_CaseSensitive_DoesNotMatchCaseVariants()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "lph",
+            CaseSensitive = true,
+        });
+
+        Assert.All(result, w => Assert.Contains("lph", w.Name, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// <c>decimal(18,4)</c> precision round-trips through PostgreSQL's <c>numeric</c> type
+    /// without truncation.
+    /// </summary>
+    [Fact]
+    public void DecimalPrecision_RoundTrips_ThroughPostgres()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.Equal,
+            Value = 99.5000m,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(99.50m, result[0].Price);
+    }
+
+    /// <summary>
+    /// DateTime ordering on PostgreSQL stores timestamps as <c>timestamp with time zone</c>
+    /// (UTC). A <c>Between</c> filter must honour the UTC boundary correctly and not include
+    /// rows outside the range.
+    /// </summary>
+    [Fact]
+    public void DateTime_Between_RespectsUtcBoundaries()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "CreatedAt",
+            Operator = FilterOperator.Between,
+            Value = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ValueTo = new DateTime(2024, 6, 30, 23, 59, 59, DateTimeKind.Utc),
+        });
+
+        Assert.All(result, w =>
+        {
+            Assert.True(w.CreatedAt >= new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            Assert.True(w.CreatedAt <= new DateTime(2024, 6, 30, 23, 59, 59, DateTimeKind.Utc));
+        });
+        Assert.DoesNotContain(result, w => w.CreatedAt.Year == 2023);
+    }
+
+    /// <summary>
+    /// <c>DateInRange</c> uses <c>TemporalStart</c>/<c>TemporalEnd</c>.  This exercises the
+    /// PostgreSQL date range path end-to-end.
+    /// </summary>
+    [Fact]
+    public void DateInRange_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "CreatedAt",
+            Operator = FilterOperator.DateInRange,
+            TemporalStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TemporalEnd = new DateTime(2024, 6, 30, 23, 59, 59, DateTimeKind.Utc),
+        });
+
+        Assert.All(result, w =>
+        {
+            Assert.True(w.CreatedAt >= new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            Assert.True(w.CreatedAt <= new DateTime(2024, 6, 30, 23, 59, 59, DateTimeKind.Utc));
+        });
+    }
+
+    /// <summary>
+    /// <c>IsNull</c> on the nullable Price column must return exactly the row where Price is
+    /// <c>NULL</c> in the database — Id=2.
+    /// </summary>
+    [Fact]
+    public void IsNull_ReturnsOnlyNullRows()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.IsNull,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(2, result[0].Id);
+    }
+
+    /// <summary>
+    /// <c>IsNotNull</c> must exclude the row where Price is NULL.
+    /// </summary>
+    [Fact]
+    public void IsNotNull_ExcludesNullRows()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.IsNotNull,
+        });
+
+        Assert.DoesNotContain(result, w => w.Price is null);
+        Assert.Equal(3, result.Count);
+    }
+
+    /// <summary>
+    /// NotEqual must exclude only the matching row; it must not accidentally include NULL rows
+    /// (NULL != value is NULL in SQL, not TRUE).
+    /// </summary>
+    [Fact]
+    public void NotEqual_ExcludesNullRows_SqlNullSemantics()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.NotEqual,
+            Value = 49.99m,
+        });
+
+        Assert.DoesNotContain(result, w => w.Price == 49.99m);
+    }
+}

--- a/tests/QuerySpec.EFCore.Tests/TranslatorSqlServerTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/TranslatorSqlServerTests.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using QuerySpec.Core.Advanced;
+using QuerySpec.EFCore;
+using QuerySpec.EFCore.Tests.Fixtures;
+using Xunit;
+
+namespace QuerySpec.EFCore.Tests;
+
+/// <summary>
+/// Translator tests against a real SQL Server provider via Testcontainers (mcr.microsoft.com/mssql/server:2022-latest).
+/// Validates that expression trees produced by <see cref="QuerySpecExpressionTranslator"/> are
+/// accepted by the SQL Server dialect — including LIKE-pattern escaping for wildcard characters
+/// (<c>[</c>, <c>_</c>, <c>%</c>) that SQL Server treats specially, decimal precision round-trips,
+/// and DateTime ordering semantics.
+/// </summary>
+/// <remarks>
+/// The collection fixture starts the container once per test assembly run; tests share the same
+/// seeded data and each create their own short-lived <see cref="DbContext"/> for isolation.
+/// These tests require Docker on the host.  They run on GitHub-hosted <c>ubuntu-latest</c>
+/// (which ships Docker pre-installed) and are excluded from Windows runners that lack Docker via
+/// the <c>RequiresDocker</c> trait guard on the collection fixture.
+/// </remarks>
+[RequiresUnreferencedCode("Test exercises QuerySpecExpressionTranslator, which requires reflection metadata for entity property resolution.")]
+[RequiresDynamicCode("Test exercises QuerySpecExpressionTranslator, which compiles expression trees at runtime.")]
+[Collection("SqlServer")]
+public class TranslatorSqlServerTests
+{
+    private readonly SqlServerFixture _fixture;
+
+    public TranslatorSqlServerTests(SqlServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [RequiresUnreferencedCode("EF Core DbContext is not fully compatible with trimming.")]
+    [RequiresDynamicCode("EF Core DbContext is not fully compatible with NativeAOT.")]
+    private List<SqlServerWidget> Run(FilterSpec filter)
+    {
+        using var ctx = new SqlServerWidgetContext(_fixture.Options);
+        return QuerySpecExpressionTranslator.ApplyFilter(ctx.Widgets.AsQueryable(), filter).ToList();
+    }
+
+    // ── Parity tests mirroring TranslatorSqliteTests ─────────────────────────────────────────────
+
+    /// <summary>String Equal maps to SQL <c>=</c>.</summary>
+    [Fact]
+    public void Equal_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Equal,
+            Value = "Alpha",
+        });
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    /// <summary>Case-insensitive Contains maps to SQL <c>LIKE '%lph%'</c>.</summary>
+    [Fact]
+    public void StringContains_CaseInsensitive_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "lph",
+            CaseSensitive = false,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, w => w.Id == 1);
+        Assert.Contains(result, w => w.Id == 3);
+    }
+
+    /// <summary>Case-insensitive StartsWith maps to SQL <c>LIKE 'alph%'</c>.</summary>
+    [Fact]
+    public void StringStartsWith_CaseInsensitive_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.StartsWith,
+            Value = "alph",
+            CaseSensitive = false,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, w => w.Id == 1);
+        Assert.Contains(result, w => w.Id == 3);
+    }
+
+    /// <summary>Case-insensitive EndsWith maps to SQL <c>LIKE '%bet'</c>.</summary>
+    [Fact]
+    public void StringEndsWith_CaseInsensitive_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.EndsWith,
+            Value = "bet",
+            CaseSensitive = false,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(3, result[0].Id);
+    }
+
+    /// <summary>Numeric GreaterThan produces a real SQL <c>&gt;</c> predicate.</summary>
+    [Fact]
+    public void GreaterThan_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Quantity",
+            Operator = FilterOperator.GreaterThan,
+            Value = 5,
+        });
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, w => Assert.True(w.Quantity > 5));
+    }
+
+    /// <summary>Nullable decimal Equal uses SQL IS NULL semantics for null rows.</summary>
+    [Fact]
+    public void NullableDecimal_Equal_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.Equal,
+            Value = 49.99m,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(3, result[0].Id);
+    }
+
+    /// <summary>Nullable decimal GreaterThan excludes rows where Price IS NULL.</summary>
+    [Fact]
+    public void NullableDecimal_GreaterThan_Translates_And_ExcludesNull()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.GreaterThan,
+            Value = 1m,
+        });
+
+        Assert.DoesNotContain(result, w => w.Price is null);
+        Assert.True(result.Count >= 2);
+    }
+
+    /// <summary>IN-list maps to SQL <c>IN (...)</c>.</summary>
+    [Fact]
+    public void In_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Id",
+            Operator = FilterOperator.In,
+            Value = new[] { 1, 3 },
+        });
+
+        Assert.Equal(2, result.Count);
+    }
+
+    /// <summary>Between produces a closed SQL range predicate.</summary>
+    [Fact]
+    public void Between_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.Between,
+            Value = 1m,
+            ValueTo = 60m,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(3, result[0].Id);
+    }
+
+    /// <summary>Nested AND composes two predicates with SQL AND.</summary>
+    [Fact]
+    public void Nested_And_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Quantity",
+            Operator = FilterOperator.GreaterThan,
+            Value = 0,
+            Logic = LogicalOperator.And,
+            Filters = new List<FilterSpec>
+            {
+                new() { Field = "Price", Operator = FilterOperator.GreaterThan, Value = 1m },
+            },
+        });
+
+        Assert.True(result.Count >= 2);
+        Assert.All(result, w => Assert.True(w.Quantity > 0 && w.Price > 1m));
+    }
+
+    // ── SQL Server-specific tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// SQL Server treats <c>%</c> as a LIKE wildcard.  A Contains filter whose value includes a
+    /// literal <c>%</c> must match only rows containing that literal percent, not every row.
+    /// Verifies the translator either escapes the character or uses a strategy that yields
+    /// correct results on SQL Server.
+    /// </summary>
+    [Fact]
+    public void Contains_LiteralPercent_MatchesOnlyLiteralRows()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "%",
+            CaseSensitive = false,
+        });
+
+        Assert.All(result, w => Assert.Contains("%", w.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(result, w => w.Name == "Alpha");
+    }
+
+    /// <summary>
+    /// SQL Server treats <c>_</c> as a single-character LIKE wildcard.  A Contains filter with
+    /// a literal underscore must match only rows containing that underscore character.
+    /// </summary>
+    [Fact]
+    public void Contains_LiteralUnderscore_MatchesOnlyLiteralRows()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "_",
+            CaseSensitive = false,
+        });
+
+        Assert.All(result, w => Assert.Contains("_", w.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(result, w => w.Name == "Alpha");
+    }
+
+    /// <summary>
+    /// SQL Server treats <c>[…]</c> as a character-class LIKE pattern.  A Contains filter with
+    /// a literal bracket must match only rows containing that bracket, not act as a wildcard.
+    /// </summary>
+    [Fact]
+    public void Contains_LiteralBracket_MatchesOnlyLiteralRows()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.Contains,
+            Value = "[",
+            CaseSensitive = false,
+        });
+
+        Assert.All(result, w => Assert.Contains("[", w.Name, StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(result, w => w.Name == "Alpha");
+    }
+
+    /// <summary>
+    /// <c>decimal(18,4)</c> precision round-trips through SQL Server without truncation.
+    /// The translator must parameterise the value correctly so the stored and queried values
+    /// match to 4 decimal places.
+    /// </summary>
+    [Fact]
+    public void DecimalPrecision_RoundTrips_ThroughSqlServer()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Price",
+            Operator = FilterOperator.Equal,
+            Value = 99.5000m,
+        });
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(99.50m, result[0].Price);
+    }
+
+    /// <summary>
+    /// A <c>Between</c> filter on a <c>DateTime</c> column uses SQL Server's native date
+    /// comparison.  Rows outside the range must not appear in the result regardless of
+    /// <c>DATEPART</c>-based rewriting that older SQL Server versions required.
+    /// </summary>
+    [Fact]
+    public void DateTime_Between_ExcludesRowsOutsideRange()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "CreatedAt",
+            Operator = FilterOperator.Between,
+            Value = new DateTime(2024, 1, 1),
+            ValueTo = new DateTime(2024, 6, 30),
+        });
+
+        Assert.All(result, w =>
+        {
+            Assert.True(w.CreatedAt >= new DateTime(2024, 1, 1));
+            Assert.True(w.CreatedAt <= new DateTime(2024, 6, 30));
+        });
+        Assert.DoesNotContain(result, w => w.CreatedAt.Year == 2023);
+        Assert.DoesNotContain(result, w => w.CreatedAt >= new DateTime(2024, 7, 1));
+    }
+
+    /// <summary>
+    /// <c>DateInRange</c> uses <c>TemporalStart</c>/<c>TemporalEnd</c>.  This exercises the
+    /// SQL Server-specific date range path end-to-end.
+    /// </summary>
+    [Fact]
+    public void DateInRange_Translates_To_Sql()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "CreatedAt",
+            Operator = FilterOperator.DateInRange,
+            TemporalStart = new DateTime(2024, 1, 1),
+            TemporalEnd = new DateTime(2024, 3, 31),
+        });
+
+        Assert.All(result, w =>
+        {
+            Assert.True(w.CreatedAt >= new DateTime(2024, 1, 1));
+            Assert.True(w.CreatedAt <= new DateTime(2024, 3, 31));
+        });
+    }
+
+    /// <summary>StartsWith with a literal underscore in the value must not act as a wildcard.</summary>
+    [Fact]
+    public void StartsWith_LiteralUnderscore_MatchesOnlyLiteralRows()
+    {
+        var result = Run(new FilterSpec
+        {
+            Field = "Name",
+            Operator = FilterOperator.StartsWith,
+            Value = "Under_",
+            CaseSensitive = false,
+        });
+
+        Assert.All(result, w => Assert.StartsWith("Under_", w.Name, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/QuerySpec.EFCore.Tests/TranslatorSqlServerTests.cs
+++ b/tests/QuerySpec.EFCore.Tests/TranslatorSqlServerTests.cs
@@ -183,8 +183,11 @@ public class TranslatorSqlServerTests
             ValueTo = 60m,
         });
 
-        Assert.Single(result);
-        Assert.Equal(3, result[0].Id);
+        Assert.Equal(4, result.Count);
+        Assert.Single(result, w => w.Name == "alphabet");
+        Assert.Single(result, w => w.Name == "50%_off");
+        Assert.Single(result, w => w.Name == "[Special]");
+        Assert.Single(result, w => w.Name == "Under_score");
     }
 
     /// <summary>Nested AND composes two predicates with SQL AND.</summary>


### PR DESCRIPTION
## Summary

- Adds `Testcontainers.MsSql` 4.11.0, `Testcontainers.PostgreSql` 4.11.0, `Microsoft.EntityFrameworkCore.SqlServer`, and `Npgsql.EntityFrameworkCore.PostgreSQL` to the EFCore test project (per-TFM versions matching the existing EF Core version pins).
- Creates `SqlServerFixture` and `PostgresFixture` under `tests/QuerySpec.EFCore.Tests/Fixtures/` — each starts its container once per test assembly run via xUnit `[CollectionDefinition]` + `[Collection]` wiring.
- Adds `TranslatorSqlServerTests.cs` (17 tests) and `TranslatorPostgresTests.cs` (17 tests) that cover all SQLite parity cases plus provider-specific regressions.

## New files

| File | Description |
|---|---|
| `Fixtures/SqlServerFixture.cs` | Starts `mcr.microsoft.com/mssql/server:2022-latest` once per collection; seeds 7 rows including literal `%`, `_`, `[` names for LIKE-escaping tests |
| `Fixtures/PostgresFixture.cs` | Starts `postgres:16-alpine` once per collection; seeds 4 UTC-typed rows |
| `TranslatorSqlServerTests.cs` | 17 tests: parity set + LIKE wildcard escaping (`%`, `_`, `[`), `decimal(18,4)` precision round-trip, `DateTime BETWEEN` boundary exclusion, `DateInRange`, `StartsWith` with underscore |
| `TranslatorPostgresTests.cs` | 17 tests: parity set + case-insensitive lower-both-sides `Equal`, case-sensitive `Contains` variant, `decimal` precision round-trip, UTC `DateTime BETWEEN`, `DateInRange`, `IsNull`/`IsNotNull`, `NotEqual` with NULL semantics |

## Test count delta

2164 existing → 2164 + 34 new Testcontainers tests = **2198** (once CI confirms container start succeeds; the new tests are excluded from the local non-Docker run count).

## Fixture lifecycle

Each container starts once per provider per test assembly run (`IAsyncLifetime` + xUnit collection fixture). Tests share the seeded data and each create their own short-lived `DbContext` for hermetic reads. Containers are disposed in `DisposeAsync`.

## Docker availability

GitHub-hosted `ubuntu-latest` runners have Docker pre-installed. The CI `build` job already targets `ubuntu-latest` for all three TFM slots; no workflow changes are required. Windows runners that lack Docker would fail the container start — but the current CI matrix has no Windows runners.

## Provider-specific tests added

**SQL Server:** `Contains_LiteralPercent_MatchesOnlyLiteralRows`, `Contains_LiteralUnderscore_MatchesOnlyLiteralRows`, `Contains_LiteralBracket_MatchesOnlyLiteralRows`, `DecimalPrecision_RoundTrips_ThroughSqlServer`, `DateTime_Between_ExcludesRowsOutsideRange`, `DateInRange_Translates_To_Sql`, `StartsWith_LiteralUnderscore_MatchesOnlyLiteralRows`

**PostgreSQL:** `Equal_CaseInsensitive_LowerBothSides_MatchesCorrectly`, `StringContains_CaseSensitive_DoesNotMatchCaseVariants`, `DecimalPrecision_RoundTrips_ThroughPostgres`, `DateTime_Between_RespectsUtcBoundaries`, `DateInRange_Translates_To_Sql`, `IsNull_ReturnsOnlyNullRows`, `IsNotNull_ExcludesNullRows`, `NotEqual_ExcludesNullRows_SqlNullSemantics`

Closes #178