### PR TITLE
fix(release): generate SBOM for QuerySpec.Analyzers package

### DIFF
--- a/src/QuerySpec.Analyzers/QuerySpec.Analyzers.csproj
+++ b/src/QuerySpec.Analyzers/QuerySpec.Analyzers.csproj
@@ -26,7 +26,6 @@
     <EnablePackageValidation>false</EnablePackageValidation>
     <EnableStrictModeForBaselineValidation>false</EnableStrictModeForBaselineValidation>
     <PackageValidationBaselineVersion></PackageValidationBaselineVersion>
-    <GenerateSBOM>false</GenerateSBOM>
     <IncludeSymbols>false</IncludeSymbols>
     <SymbolPackageFormat></SymbolPackageFormat>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Removes `<GenerateSBOM>false</GenerateSBOM>` from `QuerySpec.Analyzers.csproj`. This flag was introduced in commit `c9032a8` (PR #153) because `Microsoft.Sbom.Targets` 3.x could not generate an SBOM for `IncludeBuildOutput=false` analyzer-shape packs. `Microsoft.Sbom.Targets` was bumped to 4.1.5 in PR #227; the limitation no longer exists. Removing the override restores the uniform `Directory.Build.props`-driven SBOM generation for all packable projects.

The v4.1.0 release gate correctly blocked publish because `QuerySpec.Analyzers.4.1.0.nupkg` was missing `_manifest/spdx_2.2/manifest.spdx.json`. This is the engineering fix; v4.1.1 will be the published release.

## Verification

Local pack with the fix applied:
```
$ unzip -l /tmp/sbom-verify/QuerySpec.Analyzers.0.0.0-local.nupkg | grep manifest
    31423  _manifest/spdx_2.2/manifest.spdx.json
       64  _manifest/spdx_2.2/manifest.spdx.json.sha256
```

## Diff

One-line deletion from `src/QuerySpec.Analyzers/QuerySpec.Analyzers.csproj`:
```diff
-    <GenerateSBOM>false</GenerateSBOM>
```

## Test plan

- [ ] CI passes all required checks on this PR
- [ ] v4.1.1 release run: `Verify SBOM in packages` step passes for all 4 nupkgs including `QuerySpec.Analyzers`
- [ ] Closes #248