### PR TITLE
fix(release): test SourceLink against .snupkg when symbols are external

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,10 +263,20 @@ jobs:
         dotnet tool install -g sourcelink
         export PATH="$PATH:$HOME/.dotnet/tools"
         failed=0
-        for pkg in ./artifacts/*.nupkg; do
-          echo "::group::SourceLink test $(basename "$pkg")"
-          if ! sourcelink test "$pkg"; then
-            echo "::error::SourceLink test failed for $(basename "$pkg")"
+        for nupkg in ./artifacts/*.nupkg; do
+          base="${nupkg%.nupkg}"
+          snupkg="${base}.snupkg"
+          pkg_name="$(basename "$nupkg")"
+          if [[ -f "$snupkg" ]]; then
+            target="$snupkg"
+            target_name="$(basename "$snupkg")"
+          else
+            target="$nupkg"
+            target_name="$pkg_name"
+          fi
+          echo "::group::SourceLink test $target_name"
+          if ! sourcelink test "$target"; then
+            echo "::error::SourceLink test failed for $target_name"
             failed=$((failed + 1))
           fi
           echo "::endgroup::"


### PR DESCRIPTION
## Summary

The `Test SourceLink mappings` step in `release.yml` iterated over `./artifacts/*.nupkg` and ran `sourcelink test` against each `.nupkg`. For `QuerySpec.Analyzers` this works because it uses `<DebugType>embedded</DebugType>` — the PDB is embedded in the DLL inside the nupkg. For the three symbol-bearing packages (Core, EFCore, DependencyInjection) this fails with `unable to read debug info` because their PDBs live in separate `.snupkg` files — the Microsoft-recommended `IncludeSymbols=true` + `SymbolPackageFormat=snupkg` pattern.

## Location

- `.github/workflows/release.yml` — `Test SourceLink mappings` step

## Evidence

Running `sourcelink test QuerySpec.Core.*.nupkg` locally produces:
```
unable to read debug info: QuerySpec.Core.0.0.0-local.nupkg
5 files did not pass in QuerySpec.Core.0.0.0-local.nupkg
```
Running against the `.snupkg` exits cleanly (PDBs present, SourceLink metadata valid).

## Proposed remediation

For each `.nupkg`, check whether a `.snupkg` with the same base name exists. If yes, run `sourcelink test` against the `.snupkg` (which holds the PDBs). If no, fall back to the `.nupkg` (analyzer-style embedded-debug packages). Both paths are valid SourceLink targets; the correct one depends on how the package was produced.

## Risk and verification

The change is a routing fix inside the bash loop — no build properties, no MSBuild changes. The gate still fails hard (`exit 1`) if any target fails. The Analyzers fallback path (no `.snupkg` → test `.nupkg`) is tested locally and passes. The Core/EFCore/DI `.snupkg` path will be validated by the next release CI run where `ContinuousIntegrationBuild=true` embeds real GitHub source URLs into the PDBs.

## Acceptance criteria

- [ ] `sourcelink test` step in `release.yml` targets `.snupkg` for Core, EFCore, DependencyInjection
- [ ] `sourcelink test` step falls back to `.nupkg` for Analyzers (no `.snupkg` produced)
- [ ] Release workflow completes the `Test SourceLink mappings` step without error on the v4.1.2 tag