### PR TITLE
fix(release): walk back postbump baseline through unpublished tags

### DIFF
--- a/scripts/postbump-baseline.mjs
+++ b/scripts/postbump-baseline.mjs
@@ -3,33 +3,91 @@
 // PackageValidationBaselineVersion aligned with the previous published release.
 //
 // Lifecycle: standard-version runs this AFTER bumping package.json to the new version
-// but BEFORE creating the release commit and tag. At this point `git describe --tags
-// --abbrev=0 --match=v*` returns the most recent EXISTING tag, which is the previous
-// release on nuget.org — exactly what the next build should validate against.
+// but BEFORE creating the release commit and tag. At this point the most recent v* git
+// tag is the previous release. However that tag may correspond to a release that failed
+// before reaching NuGet (e.g. a CI gate failure). Writing an unpublished version as the
+// baseline causes PackageValidation to fail with NU1102 on the very next release attempt.
+//
+// This script resolves the issue by querying the NuGet v3 flat-container index for each
+// candidate tag (newest first) and stopping at the first one that is actually published.
+// If no candidate is published (brand-new package) it exits 0 without modifying the file.
 //
 // commit-all is enabled in .versionrc.json so the modified Directory.Build.props is
 // included in standard-version's release commit.
 
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { request } from 'node:https';
 
 const PROPS = 'Directory.Build.props';
 const RE = /(<PackageValidationBaselineVersion[^>]*>)([^<]+)(<\/PackageValidationBaselineVersion>)/;
+const NUGET_INDEX = 'https://api.nuget.org/v3-flatcontainer/queryspec.core/index.json';
 
-let prevTag;
+function fetchPublishedVersions() {
+    return new Promise((resolve, reject) => {
+        const req = request(NUGET_INDEX, (res) => {
+            let body = '';
+            res.on('data', (chunk) => body += chunk);
+            res.on('end', () => {
+                if (res.statusCode !== 200) {
+                    return reject(new Error(`NuGet API returned HTTP ${res.statusCode}`));
+                }
+                try {
+                    resolve(JSON.parse(body).versions);
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        });
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+let tags;
 try {
-    prevTag = execSync('git describe --tags --abbrev=0 --match=v*', { encoding: 'utf8' }).trim();
+    const raw = execSync('git tag -l --sort=-v:refname', { encoding: 'utf8' }).trim();
+    tags = raw ? raw.split('\n').filter(Boolean) : [];
 } catch (err) {
-    console.error('postbump-baseline: no prior v* tag found; skipping baseline update.');
+    console.error('postbump-baseline: git tag failed; skipping baseline update.');
     console.error(err.stderr?.toString() ?? err.message);
     process.exit(0);
 }
 
-if (!/^v\d+\.\d+\.\d+/.test(prevTag)) {
-    console.error(`postbump-baseline: unexpected tag format '${prevTag}'; skipping baseline update.`);
+if (tags.length === 0) {
+    console.log('postbump-baseline: no v* tags found; skipping baseline update.');
     process.exit(0);
 }
-const prevVersion = prevTag.slice(1);
+
+const candidates = tags
+    .filter(t => /^v\d+\.\d+\.\d+/.test(t))
+    .map(t => t.slice(1));
+
+if (candidates.length === 0) {
+    console.log('postbump-baseline: no v* tags with semver format found; skipping baseline update.');
+    process.exit(0);
+}
+
+let published;
+try {
+    published = new Set(await fetchPublishedVersions());
+} catch (err) {
+    console.error(`postbump-baseline: could not query NuGet — ${err.message}`);
+    console.error('Leaving Directory.Build.props unchanged to avoid writing an unverified baseline.');
+    process.exit(0);
+}
+
+const baseline = candidates.find(v => published.has(v));
+
+if (!baseline) {
+    console.log('postbump-baseline: no published version found among candidate tags; leaving Directory.Build.props unchanged.');
+    process.exit(0);
+}
+
+if (candidates[0] !== baseline) {
+    const skipped = candidates.slice(0, candidates.indexOf(baseline));
+    console.log(`postbump-baseline: ${skipped.map(v => 'v' + v).join(', ')} not published on NuGet.org; falling back to v${baseline}`);
+}
 
 const content = readFileSync(PROPS, 'utf8');
 const m = content.match(RE);
@@ -39,11 +97,11 @@ if (!m) {
 }
 
 const oldBaseline = m[2];
-if (oldBaseline === prevVersion) {
-    console.log(`postbump-baseline: baseline already ${prevVersion}, no change.`);
+if (oldBaseline === baseline) {
+    console.log(`postbump-baseline: baseline already ${baseline}, no change.`);
     process.exit(0);
 }
 
-const updated = content.replace(RE, `$1${prevVersion}$3`);
+const updated = content.replace(RE, `$1${baseline}$3`);
 writeFileSync(PROPS, updated);
-console.log(`postbump-baseline: ${PROPS} PackageValidationBaselineVersion ${oldBaseline} -> ${prevVersion}`);
+console.log(`postbump-baseline: ${PROPS} PackageValidationBaselineVersion ${oldBaseline} -> ${baseline}`);


### PR DESCRIPTION
## Summary

- `scripts/postbump-baseline.mjs` previously resolved the PackageValidation baseline using `git describe --tags`, which returns the most recent local tag regardless of whether that version was ever published to NuGet.
- When a release fails after tagging but before the NuGet push completes (or is not reached at all), the next `npm run release` writes that unpublished version as `PackageValidationBaselineVersion`, causing `NU1102` on the subsequent release attempt.
- This PR fixes the hook by querying the NuGet v3 flat-container index for `QuerySpec.Core` and walking backward through candidate tags until it finds a version that is confirmed published. If no candidate is published (first-ever release), the hook exits 0 without modifying `Directory.Build.props`.

## Changes

- `scripts/postbump-baseline.mjs`: replace single `git describe` call with an ordered `git tag -l` enumeration + async NuGet API check; add clear fallback logging identifying which tags were skipped and why.
- Also fixes Windows-shell compatibility: `git tag -l 'v*' --sort=-v:refname` used single-quote glob that is not expanded by Windows `cmd.exe`; replaced with `git tag -l --sort=-v:refname` and JS-side `v*` regex filtering.

## Verification

Local run with tags `v4.1.1` (unpublished), `v4.1.0` (unpublished), `v4.0.0` (published):

```
postbump-baseline: v4.1.1, v4.1.0 not published on NuGet.org; falling back to v4.0.0
postbump-baseline: baseline already 4.0.0, no change.
```

Suppression audit (`NoWarn`, `SuppressMessage`, `pragma warning disable`, etc.) returned empty — no suppressions added.

## Risk and verification

The NuGet API call is non-destructive and fails safe: if the request fails (network error or non-200 status) the hook exits 0 without modifying the file, leaving the existing baseline in place. The release would then proceed with the previous baseline value, which is the same behavior as before this change.

## Acceptance criteria

- [ ] Script queries NuGet.org and skips unpublished candidate tags
- [ ] Clear log line identifies each skipped tag and the chosen fallback
- [ ] NuGet API failure exits 0 (safe skip, no file modification)
- [ ] No published tag found exits 0 (safe skip)
- [ ] Works on both Unix and Windows shells (no single-quote glob)
- [ ] CI passes (no new suppressions, no new warnings)

Fixes #251