### PR TITLE
fix(release): extract PDBs from snupkg before running sourcelink test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,24 +263,40 @@ jobs:
         dotnet tool install -g sourcelink
         export PATH="$PATH:$HOME/.dotnet/tools"
         failed=0
+        work="$(mktemp -d)"
         for nupkg in ./artifacts/*.nupkg; do
           base="${nupkg%.nupkg}"
           snupkg="${base}.snupkg"
           pkg_name="$(basename "$nupkg")"
+          echo "::group::SourceLink test $pkg_name"
           if [[ -f "$snupkg" ]]; then
-            target="$snupkg"
-            target_name="$(basename "$snupkg")"
+            pkg_work="$work/$(basename "$base")"
+            mkdir -p "$pkg_work"
+            unzip -q -o "$snupkg" -d "$pkg_work"
+            pdb_failed=0
+            pdb_count=0
+            while IFS= read -r -d '' pdb; do
+              pdb_count=$((pdb_count + 1))
+              if ! sourcelink test "$pdb"; then
+                echo "::error::SourceLink test failed for $(basename "$pdb") (in $pkg_name)"
+                pdb_failed=$((pdb_failed + 1))
+              fi
+            done < <(find "$pkg_work" -name '*.pdb' -print0)
+            if [[ $pdb_count -eq 0 ]]; then
+              echo "::error::No PDB files found inside $(basename "$snupkg")"
+              failed=$((failed + 1))
+            elif [[ $pdb_failed -ne 0 ]]; then
+              failed=$((failed + 1))
+            fi
           else
-            target="$nupkg"
-            target_name="$pkg_name"
-          fi
-          echo "::group::SourceLink test $target_name"
-          if ! sourcelink test "$target"; then
-            echo "::error::SourceLink test failed for $target_name"
-            failed=$((failed + 1))
+            if ! sourcelink test "$nupkg"; then
+              echo "::error::SourceLink test failed for $pkg_name"
+              failed=$((failed + 1))
+            fi
           fi
           echo "::endgroup::"
         done
+        rm -rf "$work"
         if [[ "$failed" -ne 0 ]]; then
           exit 1
         fi


### PR DESCRIPTION
## Summary

`sourcelink test` accepts a PDB, DLL, or nupkg (with embedded PDBs) as its argument. It does not accept a `.snupkg` file. The previous step passed `.snupkg` archives directly, which caused the tool to fail silently in some environments and fail with an error on CI where `ContinuousIntegrationBuild=true` injects real SourceLink URLs into PDBs.

The fix extracts PDBs from each `.snupkg` into a temporary directory and runs `sourcelink test` against each PDB individually. For packages without a companion `.snupkg` (i.e. `QuerySpec.Analyzers`, which uses embedded debug), the `.nupkg` is tested directly as before.

## What changes

- `.github/workflows/release.yml` — `Test SourceLink mappings` step only.
- For each `.nupkg` that has a companion `.snupkg`: unzip the snupkg to a temp dir, find all `.pdb` files, run `sourcelink test <pdb>` on each. A missing snupkg with zero PDBs is an explicit error.
- For `.nupkg` with no companion `.snupkg` (Analyzers): test the nupkg directly, unchanged from before.
- Temp directory is cleaned up unconditionally at the end.

## Local verification (ContinuousIntegrationBuild=true)

Pack command:
```
dotnet pack QuerySpec.sln -c Release -p:Version=4.1.3-test \
  -p:ContinuousIntegrationBuild=true -p:RepositoryCommit=$(git rev-parse HEAD) \
  -p:SignAssembly=false -p:TreatWarningsAsErrors=false -o /tmp/srctest
```

New step output (all 11 lines real, not silent):
```
::group::SourceLink test QuerySpec.Analyzers.4.1.3-test.nupkg
sourcelink test passed: analyzers/dotnet/cs/QuerySpec.Analyzers.CodeFixes.dll
sourcelink test passed: analyzers/dotnet/cs/QuerySpec.Analyzers.dll
::endgroup::
::group::SourceLink test QuerySpec.Core.4.1.3-test.nupkg
sourcelink test passed: .../lib/net10.0/QuerySpec.Core.pdb
sourcelink test passed: .../lib/net8.0/QuerySpec.Core.pdb
sourcelink test passed: .../lib/net9.0/QuerySpec.Core.pdb
::endgroup::
::group::SourceLink test QuerySpec.DependencyInjection.4.1.3-test.nupkg
sourcelink test passed: .../lib/net10.0/QuerySpec.DependencyInjection.pdb
sourcelink test passed: .../lib/net8.0/QuerySpec.DependencyInjection.pdb
sourcelink test passed: .../lib/net9.0/QuerySpec.DependencyInjection.pdb
::endgroup::
::group::SourceLink test QuerySpec.EFCore.4.1.3-test.nupkg
sourcelink test passed: .../lib/net10.0/QuerySpec.EFCore.pdb
sourcelink test passed: .../lib/net8.0/QuerySpec.EFCore.pdb
sourcelink test passed: .../lib/net9.0/QuerySpec.EFCore.pdb
::endgroup::
All packages passed SourceLink mapping verification.
```

SourceLink URL confirmed present in PDBs via `sourcelink print-json`:
```
{"documents":{"/_/*":"https://raw.githubusercontent.com/AbongileBoja/QuerySpec/21a9660d2bb1abb11cac0ff682144b5d61917f43/*"}}
```

Suppression audit (must be empty):
```
git diff origin/develop...HEAD --unified=0 | grep -E '^\+.*(NoWarn|UnconditionalSuppressMessage|...)'
# no output
```