### PR TITLE
feat(ci): add no-suppression CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,9 +765,58 @@ jobs:
         path: ./evidence
         retention-days: 30
 
+  no-suppression:
+    name: No warning suppressions
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
+      with:
+        egress-policy: audit
+        disable-sudo: true
+        disable-file-monitoring: false
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 0
+    - name: Record start time
+      run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+    - name: Fetch base branch
+      run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+    - name: Check for new suppressions
+      id: check
+      run: bash eng/no-suppression-check.sh origin/${{ github.event.pull_request.base.ref }}
+
+    - name: Emit no-suppression evidence
+      if: always()
+      shell: bash
+      env:
+        STARTED_AT: ${{ env.STARTED_AT }}
+      run: |
+        set -euo pipefail
+        chmod +x eng/emit-evidence.sh
+        verdict=pass
+        violations=0
+        if [[ "${{ steps.check.outcome }}" != "success" ]]; then
+          verdict=fail
+          violations=1
+        fi
+        summary=$(jq -n --argjson v "$violations" '{violations:$v}')
+        eng/emit-evidence.sh --gate no-suppression --verdict "$verdict" \
+          --summary-json "$summary" --output-dir ./evidence
+    - name: Upload no-suppression evidence
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: evidence-no-suppression
+        path: ./evidence
+        retention-days: 30
+
   aggregate-evidence:
     name: Aggregate evidence index
-    needs: [build, format, codeql, vulnerability-scan, commitlint, reproducibility]
+    needs: [build, format, codeql, vulnerability-scan, commitlint, reproducibility, no-suppression]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,43 @@ Both a `feat:` (or `fix:`) commit for the API change and the baseline update bel
 
 Both gates must pass for CI to be green.
 
+## No warning suppression
+
+Every compiler and analyzer warning in QuerySpec is a signal. Suppressing that signal is never the right default — it hides bugs, confuses future contributors, and creates noise in code scanning tools.
+
+### The rule
+
+Do not introduce any of the following in a PR:
+
+- `<NoWarn>` in `.csproj` or `.props` files
+- `<WarningsNotAsErrors>` in `.csproj` or `.props` files
+- `<TreatWarningsAsErrors>false</TreatWarningsAsErrors>` (downgrading the repo-wide true)
+- `[UnconditionalSuppressMessage(...)]` attribute
+- `[SuppressMessage(...)]` attribute
+- `#pragma warning disable <code>`
+- `continue-on-error: true` in a workflow step
+
+CI enforces this on every PR via `eng/no-suppression-check.sh`. The check is diff-based: it compares the PR head against the merge-base with the target branch, so pre-existing suppressions in `develop` are not retriggered.
+
+### Why this matters
+
+Signal preservation keeps the analyzer baseline honest. A suppressed CA1062 today becomes a NullReferenceException in production six months later. Suppressions also confuse supply-chain scanners (CodeQL, Dependabot) that rely on the analyzer results being unfiltered.
+
+### How to fix a warning instead of suppressing it
+
+For the most common cases:
+
+- **CA1062 (validate public params):** replace `if (x == null) throw ...` with `ArgumentNullException.ThrowIfNull(x);`.
+- **MA0004 / CA2007 (ConfigureAwait):** add `.ConfigureAwait(false)` to every `await` in library code.
+- **CA1822 (can be static):** add `static` to the member, or extract to a helper if the member is on a public interface.
+- **RS0026/RS0027 (optional params on overloads):** declare an explicit overload rather than `= default` on an overloaded parameter.
+
+When the fix requires a refactor that is out of scope for the current PR, open a tracked issue describing the warning, link it from the PR description, and land the fix in a subsequent PR. The warning will remain active in CI and continue to show in logs — which is intentional.
+
+### The escape hatch
+
+If a warning genuinely cannot be fixed without a breaking change slated for a future major version, document the carve-out in a GitHub issue before merging. The issue must explain: the warning code and why it fires, why the fix requires a breaking change, and the target version for the fix. This is the only path that allows a suppression past CI — and it requires human review of the issue before the PR can merge.
+
 ## Coverage ratchet
 
 CI enforces minimum line and branch coverage on every push and PR. Thresholds are defined in `.github/workflows/ci.yml`:

--- a/eng/emit-evidence.sh
+++ b/eng/emit-evidence.sh
@@ -58,7 +58,7 @@ for v in GATE VERDICT OUTPUT_DIR; do
 done
 
 case "$GATE" in
-  build|test|format|codeql|vulnerability-scan|commitlint|reproducibility|dependency-review|pack|package-validation|strong-name-verify|benchmark-smoke) ;;
+  build|test|format|codeql|vulnerability-scan|commitlint|reproducibility|dependency-review|pack|package-validation|strong-name-verify|benchmark-smoke|no-suppression) ;;
   *) echo "invalid --gate: $GATE" >&2; exit 2 ;;
 esac
 case "$VERDICT" in

--- a/eng/no-suppression-check.sh
+++ b/eng/no-suppression-check.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# no-suppression-check.sh — diff-based check that a PR introduces no new warning suppressions.
+#
+# Compares PR head against the merge-base with the target branch. Pre-existing
+# suppressions in the base are not flagged; only additions in the PR are checked.
+#
+# Usage:
+#   eng/no-suppression-check.sh [base-ref]
+#
+#   base-ref  Git ref to diff against. Defaults to origin/develop.
+#             On CI, pass origin/${{ github.event.pull_request.base.ref }}.
+#
+# Forbidden patterns (matched on '+' lines of the unified diff):
+#   <NoWarn>                        — silences specific diagnostics in MSBuild
+#   <WarningsNotAsErrors>           — demotes specific warnings from error treatment
+#   <TreatWarningsAsErrors>false    — downgrades the global treat-as-errors flag
+#   [UnconditionalSuppressMessage   — unconditional suppression attribute
+#   [SuppressMessage                — conditional suppression attribute
+#   #pragma warning disable         — in-source warning suppression
+#   continue-on-error: true         — silences failure in GitHub Actions workflow steps
+#
+# Exit codes: 0 clean, 1 forbidden patterns found, 2 no base ref available (non-fatal on push).
+
+set -euo pipefail
+
+base_ref="${1:-origin/develop}"
+
+if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  range="${base_ref}...HEAD"
+else
+  echo "no-suppression check: base ref '${base_ref}' not found; falling back to HEAD~1..HEAD" >&2
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    range="HEAD~1..HEAD"
+  else
+    echo "no-suppression check: only one commit in history; nothing to diff. Skipping." >&2
+    exit 0
+  fi
+fi
+
+pattern='^\+[^+].*(<NoWarn>|<WarningsNotAsErrors>|<TreatWarningsAsErrors>false|\[UnconditionalSuppressMessage|\[SuppressMessage|#pragma warning disable|continue-on-error: true)'
+
+added="$(git diff --unified=0 "$range" \
+  -- '*.cs' '*.csproj' '*.props' '*.targets' '*.yml' '*.yaml' \
+  | grep -E "$pattern" || true)"
+
+if [[ -n "$added" ]]; then
+  echo "::error::This PR introduces forbidden warning-suppression patterns:" >&2
+  echo "$added" >&2
+  echo "" >&2
+  echo "Per the project's no-suppression rule, fix the warning at its root cause." >&2
+  echo "If a warning genuinely cannot be fixed without a breaking refactor," >&2
+  echo "document the carve-out in an issue before merging. See CONTRIBUTING.md." >&2
+  exit 1
+fi
+
+echo "no-suppression check: clean (no new <NoWarn>, SuppressMessage, pragma, WarningsNotAsErrors, or continue-on-error)."


### PR DESCRIPTION
## Summary

- Adds `eng/no-suppression-check.sh`: a diff-based script that fails if a PR introduces any of the seven forbidden suppression patterns (`<NoWarn>`, `<WarningsNotAsErrors>`, `<TreatWarningsAsErrors>false`, `[UnconditionalSuppressMessage]`, `[SuppressMessage]`, `#pragma warning disable`, `continue-on-error: true`).
- Adds a new `no-suppression` CI job in `.github/workflows/ci.yml` that runs the script on every `pull_request` event. The job appears as its own check in the PR check rollup.
- Extends the `aggregate-evidence` job's `needs:` to include `no-suppression`, so the overall CI gate fails when this one does.
- Adds `no-suppression` to the gate allowlist in `eng/emit-evidence.sh`.
- Extends `CONTRIBUTING.md` with a "No warning suppression" section explaining the rule, the rationale, common fixes, and the documented escape hatch.

## How the check works

The script uses file-extension filtering (`*.cs`, `*.csproj`, `*.props`, `*.targets`, `*.yml`, `*.yaml`) so documentation and shell scripts that _mention_ suppression patterns do not trigger false positives. Only diffs against actual production/config/workflow files are scanned.

On `pull_request` events CI resolves the merge-base against `origin/<base.ref>`. On `push` events the `no-suppression` job is skipped (the `if: github.event_name == 'pull_request'` guard), so the aggregate job is unaffected.

## Test plan

- [x] Gate-fires test: committed a `.csproj` with `<NoWarn>TEST123</NoWarn>` on a temp branch, ran `bash eng/no-suppression-check.sh origin/develop` — exit 1 with violation listed.
- [x] No-false-positive test: ran `bash eng/no-suppression-check.sh origin/develop` on this PR branch — exit 0.
- [x] Suppression-audit grep on PR diff: matches are exclusively from `CONTRIBUTING.md` bullet/backtick lines and `no-suppression-check.sh` comment and pattern-variable lines — no actual suppressions in `.cs`, `.csproj`, `.props`, `.yml`, or `.yaml` files.