### PR TITLE
fix(ci): no-suppression gate misses #pragma additions due to regex bug

### DIFF
--- a/eng/no-suppression-check.sh
+++ b/eng/no-suppression-check.sh
@@ -37,11 +37,12 @@ else
   fi
 fi
 
-pattern='^\+[^+].*(<NoWarn>|<WarningsNotAsErrors>|<TreatWarningsAsErrors>false|\[UnconditionalSuppressMessage|\[SuppressMessage|#pragma warning disable|continue-on-error: true)'
-
-added="$(git diff --unified=0 "$range" \
-  -- '*.cs' '*.csproj' '*.props' '*.targets' '*.yml' '*.yaml' \
-  | grep -E "$pattern" || true)"
+added="$(git diff --unified=0 \
+    "$range" -- '*.cs' '*.csproj' '*.props' '*.targets' '*.yml' '*.yaml' \
+  | grep -vE '^\+\+\+' \
+  | grep -E '^\+' \
+  | grep -E '<NoWarn>|<WarningsNotAsErrors>|<TreatWarningsAsErrors>false|UnconditionalSuppressMessage|\[SuppressMessage|#pragma warning disable|continue-on-error: true' \
+  || true)"
 
 if [[ -n "$added" ]]; then
   echo "::error::This PR introduces forbidden warning-suppression patterns:" >&2


### PR DESCRIPTION
## Summary

The no-suppression gate introduced in PR #254 has a false-negative: adding `#pragma warning disable CS0618` to a `.cs` file exits 0 (clean) instead of 1 (violation).

**Root cause — two compounding issues in the original single-grep approach:**

1. The pattern `^\+[^+].*(<alternation>)` consumed the first non-`+` character (here `#`) into `[^+]`, leaving `pragma warning disable CS0618` as the remaining string. The alternation requires `#pragma warning disable` to start with `#`, but `#` was already consumed — no match, exit 0.

2. In the pipeline fix, `grep -v '^\+\+\+'` uses BRE by default. GNU grep's BRE treats `\+` as "one or more `+`" characters, so `^\+\+\+` matched *any* line starting with one or more `+` — stripping the very `+#pragma...` added lines we wanted to keep. Fix: `grep -vE '^\+\+\+'` (ERE, where `\+` is a literal `+`).

**Fix:** replace the single-grep with a three-stage pipeline using `-E` throughout:

```bash
git diff --unified=0 "$range" -- '*.cs' '*.csproj' '*.props' '*.targets' '*.yml' '*.yaml' \
  | grep -vE '^\+\+\+'  # exclude diff file-header lines
  | grep -E '^\+'        # keep only added lines
  | grep -E '<NoWarn>|...|#pragma warning disable|...'  # match patterns anywhere in line
```

## Verification

All 7 false-negative test cases exit 1 after the fix:

| Pattern | Before fix | After fix |
|---------|-----------|-----------|
| `#pragma warning disable CS0618` | exit 0 (BUG) | exit 1 |
| `<NoWarn>$(NoWarn);CS1591</NoWarn>` | exit 0 (BUG) | exit 1 |
| `[SuppressMessage("...")]` | exit 0 (BUG) | exit 1 |
| `[UnconditionalSuppressMessage(...)]` | exit 0 (BUG) | exit 1 |
| `continue-on-error: true` | exit 0 (BUG) | exit 1 |
| `<TreatWarningsAsErrors>false` | exit 0 (BUG) | exit 1 |
| `<WarningsNotAsErrors>CS0618` | exit 0 (BUG) | exit 1 |

No-false-positive on own PR diff: `bash eng/no-suppression-check.sh origin/develop` → exit 0.

The pre-existing `#pragma warning disable QSPEC0011` in develop (PR #256 carve-out) is in the base — the gate compares only additions, so it is not flagged.