### PR TITLE
Document additive CacheResult surface in CompatibilitySuppressions.xml for v4.2.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
     <EnablePackageValidation Condition="'$(IsPackable)' != 'false' and '$(Version)' != '0.0.0-local'">true</EnablePackageValidation>
     <EnableStrictModeForBaselineValidation Condition="'$(IsPackable)' != 'false' and '$(Version)' != '0.0.0-local'">true</EnableStrictModeForBaselineValidation>
     <ApiCompatPermitUnnecessarySuppressions Condition="'$(IsPackable)' != 'false' and '$(Version)' != '0.0.0-local'">false</ApiCompatPermitUnnecessarySuppressions>
-    <PackageValidationBaselineVersion Condition="'$(IsPackable)' != 'false' and '$(Version)' != '0.0.0-local'">4.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(IsPackable)' != 'false' and '$(Version)' != '0.0.0-local'">4.1.3</PackageValidationBaselineVersion>
 
     <Authors>Abongile Boja</Authors>
     <PackageProjectUrl>https://github.com/AbongileBoja/QuerySpec</PackageProjectUrl>

--- a/src/QuerySpec.Core/CompatibilitySuppressions.xml
+++ b/src/QuerySpec.Core/CompatibilitySuppressions.xml
@@ -2,6 +2,27 @@
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:QuerySpec.Core.Caching.CacheResult</Target>
+    <Left>lib/net10.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net10.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:QuerySpec.Core.Caching.CacheResult</Target>
+    <Left>lib/net8.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net8.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:QuerySpec.Core.Caching.CacheResult</Target>
+    <Left>lib/net9.0/QuerySpec.Core.dll</Left>
+    <Right>lib/net9.0/QuerySpec.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:QuerySpec.Core.Caching.CacheKeyGenerator.GenerateKey(System.String,System.Object[])</Target>
     <Left>lib/net8.0/QuerySpec.Core.dll</Left>


### PR DESCRIPTION
## Summary

The v4.2.0 release attempt failed at the package-validation strict-mode gate with `error CP0001: Type 'QuerySpec.Core.Caching.CacheResult' exists on lib/net{8,9,10}.0/QuerySpec.Core.dll but not on [Baseline]`. The non-generic `CacheResult` companion type (CA1000 sentinel for `CacheResult<T>`) was added in Bundle B / PR #258 and is genuinely additive — a SemVer-minor change — but `EnableStrictModeForBaselineValidation=true` rejects any baseline diff without an explicit per-DLL entry in `CompatibilitySuppressions.xml`. This is the Microsoft first-party pattern (dotnet/runtime, dotnet/efcore): document accepted additive diffs in the suppression file rather than disabling strict mode.

## Changes

- `src/QuerySpec.Core/CompatibilitySuppressions.xml`: regenerated via `dotnet pack -p:ApiCompatGenerateSuppressionFile=true`. Three new `CP0001` entries (one per TFM) cover `T:QuerySpec.Core.Caching.CacheResult`, each carrying `<IsBaselineSuppression>true</IsBaselineSuppression>` so they scope to the baseline comparison only. The pre-existing inter-TFM `CP0002` entry for `CacheKeyGenerator.GenerateKey` is unchanged.
- `Directory.Build.props`: `PackageValidationBaselineVersion` 4.0.0 -> 4.1.3. v4.1.3 is the most recently published release on NuGet, matching the dotnet/runtime convention of bumping the baseline after every published release.
- `src/QuerySpec.EFCore/CompatibilitySuppressions.xml`, `src/QuerySpec.DependencyInjection/CompatibilitySuppressions.xml`: regenerate to empty `<Suppressions />`. Neither assembly added public surface this cycle.
- Strict mode stays on. `EnableStrictModeForBaselineValidation=true` and `ApiCompatPermitUnnecessarySuppressions=false` are unchanged.

## Suppression audit

| Diagnostic | Count | Direction | SemVer impact |
|---|---|---|---|
| CP0001 (type added) | 3 | baseline (per-TFM) | additive — minor-safe |
| CP0002 (signature change) | 1 | inter-TFM only (pre-existing) | not a baseline diff |
| CP0006 / CP0008 / CP0009 (breaking) | 0 | — | none |

No member-removal, signature-narrowing, or sealed/static metadata flips entered the file. The only baseline-direction suppression added is the new `CacheResult` type.

## Verification

```
dotnet pack QuerySpec.sln -c Release -p:Version=4.2.1
# EXIT=0, all four packages produced, zero CP00xx / PKVxxx errors.

bash eng/no-suppression-check.sh origin/develop
# EXIT=0 — clean (CompatibilitySuppressions.xml is API-compat tracking, not warning suppression; the gate's allowlist covers .cs/.csproj/.props/.targets/.yml only).

grep -E "CP000[6-9]" src/QuerySpec.*/CompatibilitySuppressions.xml
# no matches
```

## Test plan

- [ ] CI build/test green across net8/9/10
- [ ] CI package-validation step is now clean (this is the gate that failed v4.2.0)
- [ ] no-suppression-check exits 0
- [ ] Reviewer confirms suppression file contains only CP0001/CP0002 entries

## Follow-up (separate issue)

`scripts/postbump-baseline.mjs` exits 0 silently when the NuGet flat-container API errors or times out, leaving `Directory.Build.props` with the previous (potentially-unpublished) baseline. v4.2.0 shipped with `PackageValidationBaselineVersion=4.0.0` despite v4.1.3 being on NuGet at release time, which is the most likely explanation for that drift. The right fix is to either (a) treat NuGet-API failure as fatal in CI/release context, or (b) keep the existing fail-safe but emit a warning that release-engineer / guardrail can detect. Out of scope for this PR (one-PR-in-flight rule); will file separately.