### PR TITLE
feat(release): auto-regenerate ApiCompat suppression file in postbump + verify in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,59 @@ jobs:
         path: ./TestResults
         retention-days: 14
 
+    - name: Verify ApiCompat suppression files are up to date
+      run: |
+        set -euo pipefail
+        version="${{ steps.version.outputs.version }}"
+
+        snap_dir="$(mktemp -d)"
+        for project in QuerySpec.Core QuerySpec.EFCore QuerySpec.DependencyInjection; do
+          src="src/${project}/CompatibilitySuppressions.xml"
+          if [[ -f "$src" ]]; then
+            cp "$src" "${snap_dir}/${project}.xml"
+          else
+            touch "${snap_dir}/${project}.xml"
+          fi
+        done
+
+        dotnet pack QuerySpec.sln \
+          --configuration Release \
+          -p:Version="${version}" \
+          -p:ApiCompatGenerateSuppressionFile=true \
+          -p:ApiCompatGenerateSuppressionFileForChangedAssemblies=true \
+          --output /tmp/apicompat-verify \
+          --nologo \
+          > /tmp/apicompat-pack.log 2>&1 || {
+          echo "::error::dotnet pack failed during ApiCompat suppression verification."
+          cat /tmp/apicompat-pack.log
+          exit 1
+        }
+
+        fail=0
+        for project in QuerySpec.Core QuerySpec.EFCore QuerySpec.DependencyInjection; do
+          committed="${snap_dir}/${project}.xml"
+          regenerated="src/${project}/CompatibilitySuppressions.xml"
+
+          if [[ -f "$committed" && -f "$regenerated" ]]; then
+            if ! diff -q "$committed" "$regenerated" > /dev/null 2>&1; then
+              echo "::error::CompatibilitySuppressions.xml is stale for ${project}. Run 'npm run release' locally to regenerate, commit the updated file, then re-tag."
+              echo "--- committed"
+              echo "+++ regenerated"
+              diff -u "$committed" "$regenerated" | head -60 || true
+              fail=1
+            fi
+          elif [[ -f "$regenerated" && ! -s "$committed" ]]; then
+            echo "::error::CompatibilitySuppressions.xml exists for ${project} after regeneration but was absent in the committed tree. Run 'npm run release' locally, commit the generated file, then re-tag."
+            fail=1
+          fi
+          if [[ -s "$committed" ]]; then
+            cp "$committed" "src/${project}/CompatibilitySuppressions.xml"
+          fi
+        done
+
+        if [[ "$fail" == "1" ]]; then exit 1; fi
+        echo "All CompatibilitySuppressions.xml files match the regenerated state."
+
     - name: Pack
       run: |
         set -euo pipefail

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -3,7 +3,7 @@
   "tag-prefix": "v",
   "commit-all": true,
   "scripts": {
-    "postbump": "node scripts/postbump-baseline.mjs"
+    "postbump": "node scripts/postbump-baseline.mjs && node scripts/postbump-apicompat.mjs"
   },
   "types": [
     { "type": "feat",     "section": "Features" },

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -148,6 +148,49 @@ this repository at a specific commit, with no intermediate tampering. Verificati
 requires no third-party services and no offline trust roots — GitHub publishes the
 Sigstore transparency log and the attestation alongside the release.
 
+## Public API additions and CompatibilitySuppressions.xml
+
+When a PR adds a new public type or member, `EnablePackageValidation` + `EnableStrictModeForBaselineValidation` will reject the package unless the addition is explicitly recorded in the project's `CompatibilitySuppressions.xml`.
+
+**Don't hand-edit these files.** The postbump hook regenerates them automatically.
+
+### How it works
+
+1. `npm run release` bumps `package.json`, updates `CHANGELOG.md`, then runs the postbump chain:
+   - `postbump-baseline.mjs` — updates `PackageValidationBaselineVersion` to the last published version.
+   - `postbump-apicompat.mjs` — runs `dotnet pack` with `ApiCompatGenerateSuppressionFile=true`, validates the new suppressions against the bump type (see rules below), and `git add`s any modified `CompatibilitySuppressions.xml` files so they ride into the standard-version release commit.
+2. The CI release workflow (`release.yml`) re-runs the same regeneration step before `dotnet pack` and diffs the committed files against the freshly regenerated ones. A mismatch fails the gate with a clear message.
+
+### Suppression rules by bump type
+
+| Bump type | Allowed baseline suppressions | Blocked |
+|---|---|---|
+| **patch** or **minor** | CP0001 (type added), CP0007 (member added) | CP0002/CP0006/CP0008/CP0009/CP0011/CP0031 (removals or changes) |
+| **major** | All codes allowed | nothing blocked |
+
+Inter-TFM suppressions (entries without `IsBaselineSuppression=true`) are always allowed regardless of bump type — they reflect platform-level API differences, not a baseline regression.
+
+### What happens when a breaking change is detected on a minor/patch bump
+
+The postbump script aborts immediately with:
+
+```
+postbump-apicompat: ABORT — breaking-change suppressions detected for a non-major bump.
+```
+
+It lists the affected diagnostics and tells you to either revert the breaking change or bump as major. The release commit is never created.
+
+### What happens if you forget to run `npm run release` and push a stale file
+
+The CI gate catches it and blocks the pack step:
+
+```
+::error::CompatibilitySuppressions.xml is stale for QuerySpec.Core.
+Run 'npm run release' locally to regenerate, commit the updated file, then re-tag.
+```
+
+Re-run `npm run release` locally, push the new commit, delete the old tag, re-tag, and re-push.
+
 ## Unlisting a broken release
 
 If a published version contains something harmful, don't delete — **unlist** it.

--- a/scripts/postbump-apicompat.mjs
+++ b/scripts/postbump-apicompat.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+// Standard-version postbump hook: auto-regenerate CompatibilitySuppressions.xml
+// and validate that only SemVer-legal suppressions appear for the bump type.
+//
+// Lifecycle: standard-version runs this AFTER bumping package.json to the new version
+// but BEFORE creating the release commit and tag. At this point:
+//   - package.json already has the NEW version
+//   - The most recent v* git tag is the PREVIOUS release
+//
+// What this script does:
+//   1. Determines bump type (patch/minor/major) by comparing old (tag) and new versions.
+//   2. Runs `dotnet pack` with ApiCompatGenerateSuppressionFile=true to regenerate
+//      CompatibilitySuppressions.xml for each packable src project.
+//   3. Validates the suppression contents per SemVer rules:
+//      - PATCH/MINOR: only CP0001 (type added), CP0007 (member added) with
+//        IsBaselineSuppression=true, or inter-TFM diffs (no IsBaselineSuppression).
+//        Breaking codes (CP0002/CP0006/CP0008/CP0009/CP0011/CP0031) with
+//        IsBaselineSuppression=true abort the release.
+//      - MAJOR: all suppression types are allowed (intentional breaking changes).
+//   4. git adds the modified files so standard-version's commit includes them.
+//   5. Prints a clear summary of what was regenerated.
+//
+// commit-all is enabled in .versionrc.json so the git-added files ride into the
+// standard-version release commit.
+
+import { execSync, spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+const BREAKING_CODES = new Set(['CP0002', 'CP0006', 'CP0008', 'CP0009', 'CP0011', 'CP0031']);
+const ADDITIVE_CODES = new Set(['CP0001', 'CP0007']);
+
+const PACKABLE_PROJECTS = [
+    'src/QuerySpec.Core/QuerySpec.Core.csproj',
+    'src/QuerySpec.EFCore/QuerySpec.EFCore.csproj',
+    'src/QuerySpec.DependencyInjection/QuerySpec.DependencyInjection.csproj',
+];
+
+const SUPPRESSION_FILES = [
+    'src/QuerySpec.Core/CompatibilitySuppressions.xml',
+    'src/QuerySpec.EFCore/CompatibilitySuppressions.xml',
+    'src/QuerySpec.DependencyInjection/CompatibilitySuppressions.xml',
+];
+
+function parseSemVer(v) {
+    const m = v.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!m) return null;
+    return { major: +m[1], minor: +m[2], patch: +m[3] };
+}
+
+function bumpType(oldVer, newVer) {
+    const o = parseSemVer(oldVer);
+    const n = parseSemVer(newVer);
+    if (!o || !n) return 'unknown';
+    if (n.major > o.major) return 'major';
+    if (n.minor > o.minor) return 'minor';
+    return 'patch';
+}
+
+function getNewVersion() {
+    try {
+        const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+        return pkg.version;
+    } catch {
+        return null;
+    }
+}
+
+function getOldVersion() {
+    try {
+        const raw = execSync('git tag -l --sort=-v:refname', { encoding: 'utf8' }).trim();
+        const tags = raw ? raw.split('\n').filter(Boolean) : [];
+        const semverTags = tags.filter(t => /^v\d+\.\d+\.\d+/.test(t));
+        if (semverTags.length === 0) return null;
+        return semverTags[0].slice(1);
+    } catch {
+        return null;
+    }
+}
+
+function runPack(version) {
+    console.log(`postbump-apicompat: running dotnet pack to regenerate suppressions for v${version}...`);
+    const args = [
+        'pack', 'QuerySpec.sln',
+        '--configuration', 'Release',
+        `-p:Version=${version}`,
+        '-p:ApiCompatGenerateSuppressionFile=true',
+        '-p:ApiCompatGenerateSuppressionFileForChangedAssemblies=true',
+        '--output', '/tmp/apicompat-regen',
+        '--nologo',
+    ];
+    const result = spawnSync('dotnet', args, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    if (result.status !== 0) {
+        console.error('postbump-apicompat: dotnet pack failed. Output:');
+        console.error(result.stdout || '');
+        console.error(result.stderr || '');
+        process.exit(1);
+    }
+}
+
+function parseSuppressions(xmlContent) {
+    const entries = [];
+    const suppressionRe = /<Suppression>([\s\S]*?)<\/Suppression>/g;
+    let match;
+    while ((match = suppressionRe.exec(xmlContent)) !== null) {
+        const block = match[1];
+        const diagId = (block.match(/<DiagnosticId>([^<]+)<\/DiagnosticId>/) || [])[1] || '';
+        const target = (block.match(/<Target>([^<]+)<\/Target>/) || [])[1] || '';
+        const left = (block.match(/<Left>([^<]+)<\/Left>/) || [])[1] || '';
+        const right = (block.match(/<Right>([^<]+)<\/Right>/) || [])[1] || '';
+        const isBaseline = /<IsBaselineSuppression>true<\/IsBaselineSuppression>/.test(block);
+        entries.push({ diagId, target, left, right, isBaseline });
+    }
+    return entries;
+}
+
+function validateSuppressions(filePath, entries, bump, version) {
+    if (bump === 'major') {
+        return { valid: true, additive: [], breaking: entries.filter(e => BREAKING_CODES.has(e.diagId) && e.isBaseline) };
+    }
+
+    const violations = [];
+    for (const entry of entries) {
+        if (!entry.isBaseline) continue;
+        if (BREAKING_CODES.has(entry.diagId)) {
+            violations.push(entry);
+        }
+    }
+
+    if (violations.length > 0) {
+        console.error('');
+        console.error('postbump-apicompat: ABORT — breaking-change suppressions detected for a non-major bump.');
+        console.error(`  Version bump type: ${bump} (${version})`);
+        console.error(`  File: ${filePath}`);
+        console.error('');
+        console.error('  Breaking entries (IsBaselineSuppression=true with breaking diagnostic code):');
+        for (const v of violations) {
+            console.error(`    ${v.diagId}  ${v.target}`);
+            console.error(`      left:  ${v.left}`);
+            console.error(`      right: ${v.right}`);
+        }
+        console.error('');
+        console.error('  These diagnostics indicate you removed or changed public API surface that');
+        console.error('  existing consumers depend on. Options:');
+        console.error('    1. Revert the breaking change and keep the minor/patch version.');
+        console.error(`    2. Cut a major release instead of a ${bump} bump.`);
+        console.error('       Run: npm run release -- --release-as major');
+        console.error('');
+        return { valid: false, additive: [], breaking: violations };
+    }
+
+    const additive = entries.filter(e => e.isBaseline && (ADDITIVE_CODES.has(e.diagId)));
+    return { valid: true, additive, breaking: [] };
+}
+
+function gitAdd(files) {
+    const existing = files.filter(f => existsSync(f));
+    if (existing.length === 0) return;
+    try {
+        execSync(`git add ${existing.map(f => `"${f}"`).join(' ')}`, { stdio: 'inherit' });
+    } catch (err) {
+        console.error(`postbump-apicompat: git add failed: ${err.message}`);
+        process.exit(1);
+    }
+}
+
+const newVersion = getNewVersion();
+if (!newVersion) {
+    console.error('postbump-apicompat: could not read version from package.json; skipping.');
+    process.exit(0);
+}
+
+const oldVersion = getOldVersion();
+if (!oldVersion) {
+    console.log('postbump-apicompat: no previous v* tag found; skipping ApiCompat suppression regeneration.');
+    process.exit(0);
+}
+
+const bump = bumpType(oldVersion, newVersion);
+console.log(`postbump-apicompat: bump type is ${bump} (${oldVersion} -> ${newVersion})`);
+
+runPack(newVersion);
+
+let totalAdditive = 0;
+let totalBreaking = 0;
+let anyInvalid = false;
+const summary = [];
+
+for (const suppFile of SUPPRESSION_FILES) {
+    if (!existsSync(suppFile)) {
+        summary.push(`  ${suppFile}: file not found (skipped)`);
+        continue;
+    }
+
+    const xml = readFileSync(suppFile, 'utf8');
+    const entries = parseSuppressions(xml);
+    const result = validateSuppressions(suppFile, entries, bump, newVersion);
+
+    if (!result.valid) {
+        anyInvalid = true;
+        continue;
+    }
+
+    totalAdditive += result.additive.length;
+    totalBreaking += result.breaking.length;
+
+    const interTfm = entries.filter(e => !e.isBaseline);
+    const parts = [];
+    if (result.additive.length > 0) parts.push(`${result.additive.length} additive (CP0001/CP0007)`);
+    if (result.breaking.length > 0) parts.push(`${result.breaking.length} breaking`);
+    if (interTfm.length > 0) parts.push(`${interTfm.length} inter-TFM`);
+    const desc = parts.length > 0 ? parts.join(', ') : 'empty';
+    summary.push(`  ${suppFile}: ${desc}`);
+}
+
+if (anyInvalid) {
+    process.exit(1);
+}
+
+gitAdd(SUPPRESSION_FILES);
+
+console.log('');
+console.log(`postbump-apicompat: regenerated CompatibilitySuppressions.xml (${bump} bump, v${newVersion})`);
+for (const line of summary) {
+    console.log(line);
+}
+if (bump === 'major' && totalBreaking > 0) {
+    console.log('');
+    console.log(`  Major bump: ${totalBreaking} breaking suppression(s) recorded above. Review before pushing.`);
+}
+console.log('');


### PR DESCRIPTION
## Summary

- Adds `scripts/postbump-apicompat.mjs`: a standard-version postbump hook that regenerates `CompatibilitySuppressions.xml` for all three packable projects, validates that only additive suppressions (CP0001/CP0007 with `IsBaselineSuppression=true`) appear on minor/patch bumps, aborts the release with a clear message if any breaking codes (CP0002/CP0006/CP0008/CP0009/CP0011/CP0031) are detected, and `git add`s the updated files so they ride into the release commit.
- Chains the new script in `.versionrc.json` postbump after `postbump-baseline.mjs`.
- Adds a "Verify ApiCompat suppression files are up to date" CI gate in `release.yml` immediately before the `dotnet pack` step: snapshots the committed XML state, regenerates via `dotnet pack -p:ApiCompatGenerateSuppressionFile=true`, diffs committed vs regenerated, fails with a clear error if stale, then restores the committed state so the subsequent pack step runs from clean source.
- Documents the workflow in `RELEASE.md` under "Public API additions and CompatibilitySuppressions.xml".

## Motivation

v4.2.0 was tagged but failed at `dotnet pack` because PR #258 added `QuerySpec.Core.Caching.CacheResult` without regenerating the suppression file. PR #261 manually committed the file to unblock v4.2.1. This automation prevents that failure pattern from recurring.

## Test plan

- [ ] `dotnet build QuerySpec.sln -c Release` — clean (0 errors)
- [ ] `node scripts/postbump-apicompat.mjs` (success case) — exits 0, reports "3 additive (CP0001/CP0007), 1 inter-TFM" for Core, empty for EFCore and DI
- [ ] Breaking-change detection — injecting a synthetic CP0002 with `IsBaselineSuppression=true` into the parser exits 1 with abort message (tested inline)
- [ ] Inter-TFM CP0002 without `IsBaselineSuppression` — not flagged (tested inline)
- [ ] `bash eng/no-suppression-check.sh origin/develop` — exit 0
- [ ] CI checks pass on this branch