### PR TITLE
fix(release): postbump-baseline halts on NuGet/git failure instead of silent exit 0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -157,7 +157,7 @@ When a PR adds a new public type or member, `EnablePackageValidation` + `EnableS
 ### How it works
 
 1. `npm run release` bumps `package.json`, updates `CHANGELOG.md`, then runs the postbump chain:
-   - `postbump-baseline.mjs` — updates `PackageValidationBaselineVersion` to the last published version.
+   - `postbump-baseline.mjs` — updates `PackageValidationBaselineVersion` to the last published version. **Fails the release** if `git tag` cannot be read or if NuGet's flat-container API is unreachable, so a release can't ship with a stale or unverified baseline. Set `QUERYSPEC_SKIP_BASELINE_NETWORK=true` for offline local runs only — never in CI.
    - `postbump-apicompat.mjs` — runs `dotnet pack` with `ApiCompatGenerateSuppressionFile=true`, validates the new suppressions against the bump type (see rules below), and `git add`s any modified `CompatibilitySuppressions.xml` files so they ride into the standard-version release commit.
 2. The CI release workflow (`release.yml`) re-runs the same regeneration step before `dotnet pack` and diffs the committed files against the freshly regenerated ones. A mismatch fails the gate with a clear message.
 

--- a/scripts/postbump-baseline.mjs
+++ b/scripts/postbump-baseline.mjs
@@ -14,6 +14,11 @@
 //
 // commit-all is enabled in .versionrc.json so the modified Directory.Build.props is
 // included in standard-version's release commit.
+//
+// Failure semantics (fail-closed): network/git failures during a release halt the bump
+// rather than ship a stale baseline. To run offline (e.g. local `npm run release` while
+// disconnected), set QUERYSPEC_SKIP_BASELINE_NETWORK=true to downgrade NuGet failures to
+// a warning. This flag is intentionally NOT honoured in CI — release.yml has no such env.
 
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -49,9 +54,10 @@ try {
     const raw = execSync('git tag -l --sort=-v:refname', { encoding: 'utf8' }).trim();
     tags = raw ? raw.split('\n').filter(Boolean) : [];
 } catch (err) {
-    console.error('postbump-baseline: git tag failed; skipping baseline update.');
+    console.error('postbump-baseline: git tag failed.');
     console.error(err.stderr?.toString() ?? err.message);
-    process.exit(0);
+    console.error('Cannot determine candidate baselines without git history. Aborting release.');
+    process.exit(1);
 }
 
 if (tags.length === 0) {
@@ -73,8 +79,15 @@ try {
     published = new Set(await fetchPublishedVersions());
 } catch (err) {
     console.error(`postbump-baseline: could not query NuGet — ${err.message}`);
-    console.error('Leaving Directory.Build.props unchanged to avoid writing an unverified baseline.');
-    process.exit(0);
+    if (process.env.QUERYSPEC_SKIP_BASELINE_NETWORK === 'true') {
+        console.warn('postbump-baseline: QUERYSPEC_SKIP_BASELINE_NETWORK=true; leaving Directory.Build.props unchanged.');
+        console.warn('This flag must NOT be set in CI — a stale baseline will fail the release pack gate.');
+        process.exit(0);
+    }
+    console.error('Aborting release: cannot verify the baseline points at a published version on NuGet.');
+    console.error('If retrying after a NuGet outage, re-run `npm run release` once the API is reachable.');
+    console.error('For offline local development only, set QUERYSPEC_SKIP_BASELINE_NETWORK=true.');
+    process.exit(1);
 }
 
 const baseline = candidates.find(v => published.has(v));


### PR DESCRIPTION
## Summary

Closes #262.

The postbump-baseline script previously exited `0` on every failure path (git tag missing, NuGet flat-container unreachable, no published candidate). v4.2.0 shipped with `PackageValidationBaselineVersion=4.0.0` because the NuGet API failed silently during the release run, leaving `Directory.Build.props` at the prior baseline. The strict-mode package validation gate then rejected the additive `CacheResult` diff against the wrong baseline, blocking publish.

## Changes

- `git tag` failure now exits 1 (cannot determine candidate baselines).
- NuGet API failure now exits 1 by default. Set `QUERYSPEC_SKIP_BASELINE_NETWORK=true` for offline local development only — explicitly NOT for CI.
- The "no v* tags" and "no published candidate" exits stay at 0; both are legitimate first-release scenarios, not failures.
- `RELEASE.md` documents the new fail-closed semantics and the opt-out flag.

## Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| Happy path (NuGet reachable, v4.1.3 published) | baseline → 4.1.3 | baseline → 4.1.3 (unchanged) |
| NuGet outage during CI release | silent exit 0, stale baseline shipped | exit 1, halts release; operator re-runs |
| NuGet outage during offline local run | silent exit 0 | exit 1 unless `QUERYSPEC_SKIP_BASELINE_NETWORK=true` |
| `git tag` fails | silent exit 0 | exit 1 |
| Brand-new package, no published versions | exit 0 (skip) | exit 0 (skip, unchanged) |
| No v* tags yet | exit 0 (skip) | exit 0 (skip, unchanged) |

## Acceptance criteria

- [x] NuGet API errors halt the release rather than exiting 0 silently.
- [x] Documented opt-out via `QUERYSPEC_SKIP_BASELINE_NETWORK` for local offline runs.
- [x] Local syntax + happy-path verified (script produced `Directory.Build.props PackageValidationBaselineVersion 4.1.3 -> 4.3.0` on a fresh run; reverted before commit).
- [x] RELEASE.md updated with the new failure mode and opt-out flag.
- [x] Suppression-audit grep clean.

## Closes

Closes #262.