### PR TITLE
fix(ci): pre-pull Testcontainers images with exponential-backoff retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,31 @@ jobs:
         echo "warnings=${warnings}" >> "$GITHUB_OUTPUT"
         echo "errors=${errors}" >> "$GITHUB_OUTPUT"
 
+    - name: Pre-pull Testcontainers images (retry on transient registry errors)
+      run: |
+        set -euo pipefail
+        images=(
+          "mcr.microsoft.com/mssql/server:2022-latest"
+          "postgres:16-alpine"
+        )
+        for image in "${images[@]}"; do
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$image"; then
+              echo "Pulled $image on attempt $attempt"
+              break
+            fi
+            if [[ "$attempt" -eq 5 ]]; then
+              echo "::error::Failed to pull $image after 5 attempts"
+              exit 1
+            fi
+            backoff=$((attempt * 10))
+            echo "::warning::Pull attempt $attempt for $image failed; retrying in ${backoff}s"
+            sleep "$backoff"
+          done
+        done
+
     - name: Test with coverage
       id: test
-      # `dotnet test QuerySpec.sln` runs all test projects across all target frameworks
-      # in parallel. `LogFileName=` would point all runners at the same trx file and
-      # the resulting overwrite race makes one of the runners exit non-zero on roughly
-      # one matrix slot per run (despite every test passing). `LogFilePrefix=` gives
-      # each test run a unique trx filename and removes the race.
       run: |
         set -euo pipefail
         dotnet test QuerySpec.sln \


### PR DESCRIPTION
Pre-pulls the SQL Server (`mcr.microsoft.com/mssql/server:2022-latest`) and Postgres (`postgres:16-alpine`) images once before the test step, with up to 5 attempts and 10/20/30/40s exponential backoff.

## Why

MCR intermittently rate-limits or transiently blocks the SQL Server image pull from GitHub-hosted runners. Symptoms (verbatim from CI logs across PRs #258, #264, #265):

`Docker.DotNet.DockerApiException : pull access denied for mcr.microsoft.com/mssql/server, ... The request is blocked.`

Without retry, every Testcontainers test that calls `StartAsync()` hits MCR independently. The first failure aborts the test run before the cache warms, cascading into ~17 failed SQL Server tests. Each occurrence required a manual `gh run rerun --failed`.

Pulling once up-front with retry isolates the flake to a single retry loop. The actual test run hits a warm local cache and never round-trips MCR.

## Behaviour

- Happy path (MCR healthy): both pulls succeed on attempt 1, ~5-30s overhead.
- Transient flake: retries until success, max 100s wasted on retries before giving up.
- Genuine MCR outage > 2min: pre-pull fails loudly with a clear error. Tests cannot run against unavailable infra; noisy failure beats 17 confusing test failures.