### PR TITLE
perf(core): allocation-free Validate on valid-input path

### DIFF
--- a/benchmarks/QuerySpec.Benchmarks/TranslatorBenchmarks.cs
+++ b/benchmarks/QuerySpec.Benchmarks/TranslatorBenchmarks.cs
@@ -184,6 +184,19 @@ public class TranslatorBenchmarks
     public int NullableGreaterThan_Cached()
         => QuerySpecExpressionTranslator.ApplyFilterCached(_nullableSource, _nullableGreaterThan).Count();
 
+    /// <summary>
+    /// Validates a valid <see cref="FilterSpec"/> and builds the predicate expression on the
+    /// uncached path, but does not enumerate a datasource. Isolates the per-call cost of
+    /// <c>Validate()</c> + expression-tree construction without 1 000-row iteration noise.
+    /// This is the primary benchmark for issue #173.
+    /// </summary>
+    [Benchmark]
+    public System.Linq.Expressions.Expression<System.Func<Widget, bool>> UncachedFilter_ValidPath()
+    {
+        QuerySpecExpressionTranslator.ClearPredicateCache();
+        return QuerySpecExpressionTranslator.GetOrBuildCachedPredicate<Widget>(_simpleEqual);
+    }
+
     /// <summary>Simple entity used for translator benchmarks.</summary>
     public sealed class Widget
     {

--- a/src/QuerySpec.Core/Advanced/FilterSpec.cs
+++ b/src/QuerySpec.Core/Advanced/FilterSpec.cs
@@ -66,33 +66,36 @@ public sealed record FilterSpec
     /// <summary>
     /// Validates the filter tree. Recurses into <see cref="Filters"/>.
     /// </summary>
-    /// <returns>An enumeration of error messages; empty when the filter is valid.</returns>
-    public IEnumerable<string> Validate()
+    /// <returns>
+    /// <see cref="Array.Empty{T}"/> when the filter is valid (no allocation);
+    /// otherwise a list of error messages describing what is invalid.
+    /// </returns>
+    public IReadOnlyList<string> Validate()
     {
-        var errors = new List<string>();
-        ValidateInto(errors);
-        return errors;
+        List<string>? errors = null;
+        ValidateInto(ref errors);
+        return errors ?? (IReadOnlyList<string>)Array.Empty<string>();
     }
 
-    private void ValidateInto(List<string> errors)
+    private void ValidateInto(ref List<string>? errors)
     {
         if (string.IsNullOrWhiteSpace(Field))
         {
-            errors.Add("Field is required");
+            (errors ??= new List<string>()).Add("Field is required");
         }
         else if (!FieldNamePattern.IsMatch(Field))
         {
-            errors.Add($"Invalid field name: {Field}");
+            (errors ??= new List<string>()).Add($"Invalid field name: {Field}");
         }
 
         if (TemporalStart.HasValue && TemporalEnd.HasValue && TemporalStart > TemporalEnd)
-            errors.Add("TemporalStart must be before TemporalEnd");
+            (errors ??= new List<string>()).Add("TemporalStart must be before TemporalEnd");
 
         if (GeoLocation.HasValue && GeoRadius.HasValue && GeoRadius <= 0)
-            errors.Add("GeoRadius must be positive");
+            (errors ??= new List<string>()).Add("GeoRadius must be positive");
 
         foreach (var child in Filters)
-            child.ValidateInto(errors);
+            child.ValidateInto(ref errors);
     }
 
     /// <summary>

--- a/src/QuerySpec.Core/PublicAPI.Shipped.txt
+++ b/src/QuerySpec.Core/PublicAPI.Shipped.txt
@@ -95,7 +95,7 @@ QuerySpec.Core.Advanced.FilterSpec.TemporalStart.get -> System.DateTime?
 QuerySpec.Core.Advanced.FilterSpec.TemporalStart.init -> void
 QuerySpec.Core.Advanced.FilterSpec.UseRegex.get -> bool
 QuerySpec.Core.Advanced.FilterSpec.UseRegex.init -> void
-QuerySpec.Core.Advanced.FilterSpec.Validate() -> System.Collections.Generic.IEnumerable<string!>!
+QuerySpec.Core.Advanced.FilterSpec.Validate() -> System.Collections.Generic.IReadOnlyList<string!>!
 QuerySpec.Core.Advanced.FilterSpec.Value.get -> object?
 QuerySpec.Core.Advanced.FilterSpec.Value.init -> void
 QuerySpec.Core.Advanced.FilterSpec.ValueTo.get -> object?

--- a/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
+++ b/src/QuerySpec.EFCore/QuerySpecExpressionTranslator.cs
@@ -123,7 +123,7 @@ public static class QuerySpecExpressionTranslator
         var buildEnabled = QuerySpecMetrics.FilterBuildDuration.Enabled;
         var sw = buildEnabled ? Stopwatch.StartNew() : null;
 
-        var errors = filter.Validate().ToList();
+        var errors = filter.Validate();
         if (errors.Count > 0)
             throw new ArgumentException($"Invalid filter: {string.Join(", ", errors)}");
 
@@ -212,7 +212,7 @@ public static class QuerySpecExpressionTranslator
         var buildEnabled = QuerySpecMetrics.FilterBuildDuration.Enabled;
         var sw = buildEnabled ? Stopwatch.StartNew() : null;
 
-        var errors = filter.Validate().ToList();
+        var errors = filter.Validate();
         if (errors.Count > 0)
             throw new ArgumentException($"Invalid filter: {string.Join(", ", errors)}");
 

--- a/tests/QuerySpec.Core.Tests/Advanced/FilterSpecTests.cs
+++ b/tests/QuerySpec.Core.Tests/Advanced/FilterSpecTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using QuerySpec.Core.Advanced;
 using Xunit;
@@ -246,5 +247,49 @@ public class FilterSpecTests
         private readonly string _label;
         public NonFormattable(string label) => _label = label;
         public override string ToString() => _label;
+    }
+
+    [Fact]
+    public void Validate_ValidInput_ReturnsEmptyArraySingleton()
+    {
+        var spec = new FilterSpec { Field = "Status", Operator = FilterOperator.Equal, Value = "Active" };
+        var result = spec.Validate();
+        Assert.IsType<string[]>(result);
+        Assert.Same(Array.Empty<string>(), result);
+    }
+
+    [Fact]
+    public void Validate_ReturnsIReadOnlyList()
+    {
+        var spec = new FilterSpec { Field = "Status", Operator = FilterOperator.Equal, Value = "Active" };
+        IReadOnlyList<string> result = spec.Validate();
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Validate_ErrorPath_MessagesUnchanged()
+    {
+        var spec = new FilterSpec
+        {
+            Field = "1bad",
+            TemporalStart = new DateTime(2026, 12, 1, 0, 0, 0, DateTimeKind.Utc),
+            TemporalEnd = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            GeoLocation = new GeoCoordinate(10, 20),
+            GeoRadius = 0m,
+        };
+        var errors = spec.Validate();
+        Assert.Equal(3, errors.Count);
+        Assert.Contains("Invalid field name: 1bad", errors);
+        Assert.Contains("TemporalStart must be before TemporalEnd", errors);
+        Assert.Contains("GeoRadius must be positive", errors);
+    }
+
+    [Fact]
+    public void Validate_ValidInput_RepeatCallsReturnSameInstance()
+    {
+        var spec = new FilterSpec { Field = "Name", Operator = FilterOperator.Equal, Value = "x" };
+        var r1 = spec.Validate();
+        var r2 = spec.Validate();
+        Assert.Same(r1, r2);
     }
 }

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
@@ -91,7 +91,7 @@
         public long ComputeStableHash() { }
         public bool Equals(QuerySpec.Core.Advanced.FilterSpec? other) { }
         public override int GetHashCode() { }
-        public System.Collections.Generic.IEnumerable<string> Validate() { }
+        public System.Collections.Generic.IReadOnlyList<string> Validate() { }
     }
     public readonly struct GeoCoordinate : System.IEquatable<QuerySpec.Core.Advanced.GeoCoordinate>
     {


### PR DESCRIPTION
## Summary

- \`FilterSpec.Validate()\` now returns \`IReadOnlyList<string>\` and returns \`Array.Empty<string>()\` on the valid-input path, eliminating one \`List<string>\` allocation per call.
- \`ValidateInto\` takes \`ref List<string>?\` and only allocates when the first validation rule fires.
- Both translator call sites previously called \`filter.Validate().ToList()\`, allocating twice (one \`List<string>\` inside \`Validate()\`, one more from \`.ToList()\`). After this change \`Validate()\` returns \`IReadOnlyList<string>\` directly and the translator calls \`.Count > 0\`, eliminating both superfluous allocations.
- \`UncachedFilter_ValidPath\` benchmark added to isolate the cache-miss validation path.
- Four new tests cover: valid path returns singleton \`Array.Empty<string>()\`, return type is \`IReadOnlyList<string>\`, error messages unchanged, repeat calls return same instance.

**Benchmark (net10.0, Windows 11 i3-1215U — 2 launch 5 warmup 15 iter):**

| Benchmark | Mean | Allocated | Gen0 |
|---|---|---|---|
| UncachedFilter_ValidPath — Before (develop) | 4.745 µs | 1.23 KB | 0.0610 |
| UncachedFilter_ValidPath — After | 4.548 µs | 1.16 KB | 0.0458 |
| Delta | -4.2% | **-73 B/op (-5.9%)** | **-25%** |

The -73 B/op eliminates: `List<string>` from inside `Validate()` + the second `List<string>` from the callers' `.ToList()` call (two allocations replaced with a zero-alloc `Array.Empty<string>()` singleton on the valid path). Gen0 collections drop 25%, meaning GC pauses are less frequent on this path.

`PublicAPI.Shipped.txt` updated: `IEnumerable<string>` → `IReadOnlyList<string>`. This is a narrowing of the return type (more specific), which is source-compatible for all callers that iterate or call `.Count` on the result.

Fixes #173

## Test plan

- [x] `dotnet build -c Release` — 0 errors (Core + EFCore)
- [x] Core tests: 764/764 passed on net8/9/10
- [x] EFCore translator tests: 23/23 passed on net8/9/10
- [x] `UncachedFilter_ValidPath` benchmark before/after confirmed
- [ ] CI build + test matrix