### PR TITLE
perf(security): use HMACSHA256.HashData static + cache tenant keys

### DIFF
--- a/benchmarks/QuerySpec.Benchmarks/DataMaskingBenchmarks.cs
+++ b/benchmarks/QuerySpec.Benchmarks/DataMaskingBenchmarks.cs
@@ -1,0 +1,42 @@
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using QuerySpec.Core.Security;
+
+namespace QuerySpec.Benchmarks;
+
+[Config(typeof(BenchConfig))]
+public class DataMaskingBenchmarks
+{
+    private DataMaskingEngine _engine = null!;
+    private DataMaskingEngine _engineNoTenant = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+
+        _engine = new DataMaskingEngine(key);
+        _engine.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+
+        _engineNoTenant = new DataMaskingEngine(key);
+        _engineNoTenant.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+    }
+
+    [Benchmark]
+    public string Mask_HashStrategy_10kRows()
+    {
+        var result = string.Empty;
+        for (var i = 0; i < 10_000; i++)
+            result = _engineNoTenant.Mask("Ssn", "123-45-6789");
+        return result;
+    }
+
+    [Benchmark]
+    public string Mask_HashStrategy_PerTenant_10kRequests()
+    {
+        var result = string.Empty;
+        for (var i = 0; i < 10_000; i++)
+            result = _engine.Mask("Ssn", "123-45-6789", tenantId: $"tenant-{i % 100}");
+        return result;
+    }
+}

--- a/src/QuerySpec.Core/Security/DataMaskingEngine.cs
+++ b/src/QuerySpec.Core/Security/DataMaskingEngine.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
@@ -33,7 +35,9 @@ namespace QuerySpec.Core.Security;
 /// </remarks>
 public sealed class DataMaskingEngine
 {
-    private const int HashOutputBytes = 32;
+    private const int HashOutputBytes = HMACSHA256.HashSizeInBytes;
+    private const int MaxTenantKeyCacheSize = 1024;
+    private const int StackAllocThresholdBytes = 256;
 
     private const DynamicallyAccessedMemberTypes ClassifierMembers =
         DynamicallyAccessedMemberTypes.PublicProperties
@@ -41,10 +45,13 @@ public sealed class DataMaskingEngine
         | DynamicallyAccessedMemberTypes.PublicFields
         | DynamicallyAccessedMemberTypes.NonPublicFields;
 
-    private readonly Dictionary<string, MaskingStrategy> _fieldMasks = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, Regex> _piiPatterns = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, MaskingStrategy> _fieldMasksBuilder = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Regex> _piiPatternsBuilder = new(StringComparer.Ordinal);
+    private FrozenDictionary<string, MaskingStrategy> _fieldMasks = FrozenDictionary<string, MaskingStrategy>.Empty;
+    private FrozenDictionary<string, Regex> _piiPatterns = FrozenDictionary<string, Regex>.Empty;
     private readonly byte[]? _hashKey;
     private readonly IPiiClassifier? _classifier;
+    private readonly ConcurrentDictionary<string, byte[]>? _tenantKeyCache;
 
     /// <summary>
     /// Initializes a new instance of <see cref="DataMaskingEngine"/> without a hash key.
@@ -86,15 +93,17 @@ public sealed class DataMaskingEngine
 
         _hashKey = hashKey is null ? null : (byte[])hashKey.Clone();
         _classifier = classifier;
+        _tenantKeyCache = hashKey is null ? null : new ConcurrentDictionary<string, byte[]>(StringComparer.Ordinal);
         InitializeDefaultPiiPatterns();
     }
 
     private void InitializeDefaultPiiPatterns()
     {
-        _piiPatterns["Email"] = new Regex(@"^[^\@]+@[^\@]+$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
-        _piiPatterns["SSN"] = new Regex(@"^\d{3}-\d{2}-\d{4}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
-        _piiPatterns["Phone"] = new Regex(@"^\+?1?\d{9,15}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
-        _piiPatterns["CreditCard"] = new Regex(@"^\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatternsBuilder["Email"] = new Regex(@"^[^\@]+@[^\@]+$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatternsBuilder["SSN"] = new Regex(@"^\d{3}-\d{2}-\d{4}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatternsBuilder["Phone"] = new Regex(@"^\+?1?\d{9,15}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatternsBuilder["CreditCard"] = new Regex(@"^\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+        _piiPatterns = _piiPatternsBuilder.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -117,7 +126,8 @@ public sealed class DataMaskingEngine
                 "Pass a per-application secret (>= 16 bytes) to the DataMaskingEngine(byte[]) constructor.");
         }
 
-        _fieldMasks[fieldName] = strategy;
+        _fieldMasksBuilder[fieldName] = strategy;
+        _fieldMasks = _fieldMasksBuilder.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -215,21 +225,55 @@ public sealed class DataMaskingEngine
 
         var key = string.IsNullOrEmpty(tenantId)
             ? _hashKey
-            : DeriveTenantKey(_hashKey, tenantId);
+            : GetOrDeriveTenantKey(tenantId);
 
         Span<byte> hash = stackalloc byte[HashOutputBytes];
-        using var hmac = new HMACSHA256(key);
-        var written = hmac.TryComputeHash(Encoding.UTF8.GetBytes(value), hash, out var bytesWritten);
-        if (!written || bytesWritten != HashOutputBytes)
-            throw new CryptographicException("Unexpected HMAC output length.");
+
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        if (byteCount <= StackAllocThresholdBytes)
+        {
+            Span<byte> valueBytes = stackalloc byte[byteCount];
+            Encoding.UTF8.GetBytes(value, valueBytes);
+            HMACSHA256.HashData(key, valueBytes, hash);
+        }
+        else
+        {
+            var valueBytes = Encoding.UTF8.GetBytes(value);
+            HMACSHA256.HashData(key, valueBytes, hash);
+        }
 
         return Convert.ToBase64String(hash);
     }
 
+    private byte[] GetOrDeriveTenantKey(string tenantId)
+    {
+        if (_tenantKeyCache!.TryGetValue(tenantId, out var cached))
+            return cached;
+
+        var derived = DeriveTenantKey(_hashKey!, tenantId);
+
+        if (_tenantKeyCache.Count >= MaxTenantKeyCacheSize)
+            _tenantKeyCache.Clear();
+
+        return _tenantKeyCache.GetOrAdd(tenantId, derived);
+    }
+
     private static byte[] DeriveTenantKey(byte[] rootKey, string tenantId)
     {
-        using var hmac = new HMACSHA256(rootKey);
-        return hmac.ComputeHash(Encoding.UTF8.GetBytes(tenantId));
+        Span<byte> derived = stackalloc byte[HashOutputBytes];
+        var byteCount = Encoding.UTF8.GetByteCount(tenantId);
+        if (byteCount <= StackAllocThresholdBytes)
+        {
+            Span<byte> tenantBytes = stackalloc byte[byteCount];
+            Encoding.UTF8.GetBytes(tenantId, tenantBytes);
+            HMACSHA256.HashData(rootKey, tenantBytes, derived);
+        }
+        else
+        {
+            var tenantBytes = Encoding.UTF8.GetBytes(tenantId);
+            HMACSHA256.HashData(rootKey, tenantBytes, derived);
+        }
+        return derived.ToArray();
     }
 
     /// <summary>

--- a/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineHashDataTests.cs
+++ b/tests/QuerySpec.Core.Tests/Security/DataMaskingEngineHashDataTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+using QuerySpec.Core.Security;
+
+namespace QuerySpec.Core.Tests.Security;
+
+public class DataMaskingEngineHashDataTests
+{
+    private static byte[] FixedKey() => new byte[32]
+    {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
+    };
+
+    [Fact]
+    public void MaskHash_KnownFixture_MatchesReferenceOutput()
+    {
+        var key = FixedKey();
+        var expected = ComputeExpectedHmac(key, "123-45-6789");
+
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+
+        var actual = engine.Mask("Ssn", "123-45-6789");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MaskHash_KnownFixture_WithTenant_MatchesReferenceOutput()
+    {
+        var key = FixedKey();
+        var tenantKey = ComputeExpectedHmacBytes(key, "tenant-A");
+        var expected = ComputeExpectedHmac(tenantKey, "123-45-6789");
+
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+
+        var actual = engine.Mask("Ssn", "123-45-6789", tenantId: "tenant-A");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MaskHash_LongValue_OverStackAllocThreshold_ProducesCorrectOutput()
+    {
+        var key = FixedKey();
+        var longValue = new string('x', 300);
+        var expected = ComputeExpectedHmac(key, longValue);
+
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("Field", MaskingStrategy.HashMask);
+
+        var actual = engine.Mask("Field", longValue);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TenantCache_MultipleDistinctTenants_ProducesDeterministicResults()
+    {
+        var key = FixedKey();
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+
+        var tenants = new[] { "alpha", "beta", "gamma", "delta", "epsilon" };
+        var firstPass = new string[tenants.Length];
+        var secondPass = new string[tenants.Length];
+
+        for (var i = 0; i < tenants.Length; i++)
+            firstPass[i] = engine.Mask("Ssn", "123-45-6789", tenantId: tenants[i]);
+
+        for (var i = 0; i < tenants.Length; i++)
+            secondPass[i] = engine.Mask("Ssn", "123-45-6789", tenantId: tenants[i]);
+
+        Assert.Equal(firstPass, secondPass);
+
+        for (var i = 0; i < tenants.Length; i++)
+            for (var j = i + 1; j < tenants.Length; j++)
+                Assert.NotEqual(firstPass[i], firstPass[j]);
+    }
+
+    [Fact]
+    public void TenantCache_HundredDistinctTenants_AllResultsDeterministic()
+    {
+        var key = FixedKey();
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+
+        const int count = 100;
+        var results = new string[count];
+
+        for (var i = 0; i < count; i++)
+            results[i] = engine.Mask("Ssn", "123-45-6789", tenantId: $"tenant-{i}");
+
+        for (var i = 0; i < count; i++)
+        {
+            var repeated = engine.Mask("Ssn", "123-45-6789", tenantId: $"tenant-{i}");
+            Assert.Equal(results[i], repeated);
+        }
+    }
+
+    [Fact]
+    public void TenantCache_EvictionPath_ContinuesToProduceCorrectResults()
+    {
+        var key = FixedKey();
+        var engine = new DataMaskingEngine(key);
+        engine.RegisterFieldMask("Ssn", MaskingStrategy.HashMask);
+
+        const int tenantCount = 1025;
+        var firstResult = engine.Mask("Ssn", "123-45-6789", tenantId: "tenant-0");
+
+        for (var i = 1; i < tenantCount; i++)
+            engine.Mask("Ssn", "123-45-6789", tenantId: $"tenant-{i}");
+
+        var afterEviction = engine.Mask("Ssn", "123-45-6789", tenantId: "tenant-0");
+        Assert.Equal(firstResult, afterEviction);
+    }
+
+    private static string ComputeExpectedHmac(byte[] key, string value)
+        => Convert.ToBase64String(ComputeExpectedHmacBytes(key, value));
+
+    private static byte[] ComputeExpectedHmacBytes(byte[] key, string value)
+    {
+        var data = Encoding.UTF8.GetBytes(value);
+        var result = new byte[HMACSHA256.HashSizeInBytes];
+        HMACSHA256.HashData(key, data, result);
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces `new HMACSHA256(key)` + `ComputeHash` / `TryComputeHash` in `MaskHash` and `DeriveTenantKey` with the static `HMACSHA256.HashData(key, data, destination)` API, eliminating one heap-allocated HMAC instance per call.
- Caches derived tenant keys in a `ConcurrentDictionary<string, byte[]>` bounded to 1024 entries. On cap, the dictionary is cleared and the next miss re-derives. Workloads with ≤1024 active tenants see a permanent cache hit after the first call per tenant.
- Short field values (≤256 UTF-8 bytes, which covers all real PII field values) encode via `stackalloc Span<byte>` instead of `byte[]`.
- `_fieldMasks` and `_piiPatterns` converted to `FrozenDictionary` for faster read-dominated lookup after setup.

## Benchmark results

.NET 10.0.7, Windows 11, i3-1215U, Release, LaunchCount=2, WarmupCount=5, IterationCount=15:

| Method | Before Mean | After Mean | Delta | Before Alloc | After Alloc | Delta |
|---|---|---|---|---|---|---|
| `Mask_HashStrategy_10kRows` | 29.86 ms | 17.44 ms | **-41.6%** | 4.50 MB | 1.07 MB | **-76%** |
| `Mask_HashStrategy_PerTenant_10kRequests` | 66.82 ms | 20.28 ms | **-69.7%** | 9.38 MB | 1.45 MB | **-85%** |

Per-call allocation reduction: ~347 B/call (no-tenant path), ~793 B/call (per-tenant path).

## Test plan

- [ ] Existing `DataMaskingEngineTests` (25 tests) — output bytes unchanged, all pass
- [ ] Existing `DataMaskingEngineCoverageTests` (5 tests) — internal branch coverage, all pass
- [ ] New `DataMaskingEngineHashDataTests` (6 tests) — known-fixture regression guard, tenant-cache determinism, cache-eviction continuity, long-value (>256B) code path
- [ ] Full suite: 753 tests pass on net8.0, net9.0, net10.0
- [ ] `bash eng/no-suppression-check.sh origin/develop` exits 0
- [ ] `dotnet build -c Release -p:ContinuousIntegrationBuild=true` exits 0

## API surface

No public API change. `_fieldMasks`, `_piiPatterns`, `MaskHash`, `DeriveTenantKey`, and `GetOrDeriveTenantKey` are all private. No CP000x codes expected.

Fixes #174