### PR TITLE
Resolve RS0026/RS0027 optional-parameter API violations for v5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>$(WarningsAsErrors);CS1573;CS1572;CS1574;CS1734</WarningsAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);RS0026;RS0027</WarningsNotAsErrors>
 
     <IsTrimmable Condition="'$(IsPackable)' != 'false' and !$(TargetFramework.StartsWith('netstandard'))">true</IsTrimmable>
     <IsAotCompatible Condition="'$(IsPackable)' != 'false' and !$(TargetFramework.StartsWith('netstandard'))">true</IsAotCompatible>

--- a/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
+++ b/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
@@ -131,7 +131,7 @@ public class ComplianceExporter : IComplianceExporter
     /// <returns>Audit entries belonging to <paramref name="userId"/> within <paramref name="tenantId"/>.</returns>
     public async Task<IEnumerable<AuditLogEntry>> GetUserDataAsync(string userId, string tenantId)
     {
-        var audits = await _auditReader.GetAuditsByUserAsync(userId).ConfigureAwait(false);
+        var audits = await _auditReader.GetAuditsByUserAsync(userId, since: null).ConfigureAwait(false);
         return audits.Where(a => a.TenantId == tenantId);
     }
 

--- a/src/QuerySpec.Core/Auditing/IAuditLogger.cs
+++ b/src/QuerySpec.Core/Auditing/IAuditLogger.cs
@@ -68,27 +68,37 @@ public interface IAuditReader
     Task<IEnumerable<AuditLogEntry>> GetAuditsByRequestAsync(string requestId, CancellationToken cancellationToken)
         => GetAuditsByRequestAsync(requestId);
 
-    /// <summary>Gets all audits for a specific user, optionally filtered by date.</summary>
+    /// <summary>Gets all audits for a specific user.</summary>
     /// <param name="userId">User identifier.</param>
-    /// <param name="since">Optional inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="userId"/>.</returns>
-    Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since = null);
-    /// <summary>Gets all audits for a specific user, optionally filtered by date, with cancellation support.</summary>
+    Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId);
+    /// <summary>Gets all audits for a specific user filtered by date.</summary>
     /// <param name="userId">User identifier.</param>
-    /// <param name="since">Optional inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <returns>A materialised snapshot of audit entries for <paramref name="userId"/>.</returns>
+    Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since)
+        => GetAuditsByUserAsync(userId);
+    /// <summary>Gets all audits for a specific user filtered by date, with cancellation support.</summary>
+    /// <param name="userId">User identifier.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
     /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="userId"/>.</returns>
     Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since, CancellationToken cancellationToken)
         => GetAuditsByUserAsync(userId, since);
 
-    /// <summary>Gets all audits for a specific tenant, optionally filtered by date.</summary>
+    /// <summary>Gets all audits for a specific tenant.</summary>
     /// <param name="tenantId">Tenant identifier.</param>
-    /// <param name="since">Optional inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="tenantId"/>.</returns>
-    Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since = null);
-    /// <summary>Gets all audits for a specific tenant, optionally filtered by date, with cancellation support.</summary>
+    Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId);
+    /// <summary>Gets all audits for a specific tenant filtered by date.</summary>
     /// <param name="tenantId">Tenant identifier.</param>
-    /// <param name="since">Optional inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <returns>A materialised snapshot of audit entries for <paramref name="tenantId"/>.</returns>
+    Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since)
+        => GetAuditsByTenantAsync(tenantId);
+    /// <summary>Gets all audits for a specific tenant filtered by date, with cancellation support.</summary>
+    /// <param name="tenantId">Tenant identifier.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
     /// <param name="cancellationToken">Token observed by implementations that perform I/O.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="tenantId"/>.</returns>
     Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since, CancellationToken cancellationToken)

--- a/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
+++ b/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
@@ -133,14 +133,23 @@ public class InMemoryAuditLogger : IAuditLogger, IDisposable
     }
 
     /// <summary>
-    /// Gets all audits for a specific user, optionally filtered by date. Returns a materialised
-    /// snapshot taken under the read lock so subsequent enumeration is safe even while writers
-    /// are appending.
+    /// Gets all audits for a specific user. Returns a materialised snapshot taken under the read
+    /// lock so subsequent enumeration is safe even while writers are appending.
     /// </summary>
     /// <param name="userId">User identifier.</param>
-    /// <param name="since">Optional inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="userId"/>.</returns>
-    public Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since = null)
+    public Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId)
+        => GetAuditsByUserAsync(userId, since: null);
+
+    /// <summary>
+    /// Gets all audits for a specific user filtered by date. Returns a materialised snapshot
+    /// taken under the read lock so subsequent enumeration is safe even while writers are
+    /// appending.
+    /// </summary>
+    /// <param name="userId">User identifier.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <returns>A materialised snapshot of audit entries for <paramref name="userId"/>.</returns>
+    public Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since)
     {
         _lockSlim.EnterReadLock();
         try
@@ -157,14 +166,23 @@ public class InMemoryAuditLogger : IAuditLogger, IDisposable
     }
 
     /// <summary>
-    /// Gets all audits for a specific tenant, optionally filtered by date. Returns a materialised
-    /// snapshot taken under the read lock so subsequent enumeration is safe even while writers
-    /// are appending.
+    /// Gets all audits for a specific tenant. Returns a materialised snapshot taken under the
+    /// read lock so subsequent enumeration is safe even while writers are appending.
     /// </summary>
     /// <param name="tenantId">Tenant identifier.</param>
-    /// <param name="since">Optional inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="tenantId"/>.</returns>
-    public Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since = null)
+    public Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId)
+        => GetAuditsByTenantAsync(tenantId, since: null);
+
+    /// <summary>
+    /// Gets all audits for a specific tenant filtered by date. Returns a materialised snapshot
+    /// taken under the read lock so subsequent enumeration is safe even while writers are
+    /// appending.
+    /// </summary>
+    /// <param name="tenantId">Tenant identifier.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <returns>A materialised snapshot of audit entries for <paramref name="tenantId"/>.</returns>
+    public Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since)
     {
         _lockSlim.EnterReadLock();
         try

--- a/src/QuerySpec.Core/PublicAPI.Unshipped.txt
+++ b/src/QuerySpec.Core/PublicAPI.Unshipped.txt
@@ -5,3 +5,24 @@ static QuerySpec.Core.Caching.CacheResult.Miss<T>() -> QuerySpec.Core.Caching.Ca
 QuerySpec.Core.Caching.CacheStats.CacheStats(string! cacheName) -> void
 QuerySpec.Core.Diagnostics.QuerySpecMetrics
 const QuerySpec.Core.Diagnostics.QuerySpecMetrics.MeterName = "QuerySpec" -> string!
+*REMOVED*QuerySpec.Core.Auditing.IAuditReader.GetAuditsByTenantAsync(string! tenantId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+*REMOVED*QuerySpec.Core.Auditing.IAuditReader.GetAuditsByUserAsync(string! userId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+*REMOVED*QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByTenantAsync(string! tenantId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+*REMOVED*QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByUserAsync(string! userId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+*REMOVED*QuerySpec.Core.Resilience.CircuitBreaker.ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! operation) -> System.Threading.Tasks.Task<T>!
+*REMOVED*QuerySpec.Core.Resilience.CircuitBreaker.ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! operation, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T>!
+*REMOVED*QuerySpec.Core.Security.DataMaskingEngine.Mask(System.Type? declaringType, string! fieldName, object? value, string? tenantId = null) -> string!
+*REMOVED*QuerySpec.Core.Security.DataMaskingEngine.Mask(string! fieldName, object? value, string? tenantId = null) -> string!
+QuerySpec.Core.Auditing.IAuditReader.GetAuditsByTenantAsync(string! tenantId) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.IAuditReader.GetAuditsByTenantAsync(string! tenantId, System.DateTime? since) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.IAuditReader.GetAuditsByUserAsync(string! userId) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.IAuditReader.GetAuditsByUserAsync(string! userId, System.DateTime? since) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByTenantAsync(string! tenantId) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByTenantAsync(string! tenantId, System.DateTime? since) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByUserAsync(string! userId) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByUserAsync(string! userId, System.DateTime? since) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
+QuerySpec.Core.Resilience.CircuitBreaker.ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
+QuerySpec.Core.Security.DataMaskingEngine.Mask(System.Type? declaringType, string! fieldName, object? value) -> string!
+QuerySpec.Core.Security.DataMaskingEngine.Mask(System.Type? declaringType, string! fieldName, object? value, string? tenantId) -> string!
+QuerySpec.Core.Security.DataMaskingEngine.Mask(string! fieldName, object? value) -> string!
+QuerySpec.Core.Security.DataMaskingEngine.Mask(string! fieldName, object? value, string? tenantId) -> string!

--- a/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
+++ b/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
@@ -57,28 +57,16 @@ public class CircuitBreaker
     }
 
     /// <summary>
-    /// Executes operation with circuit breaker protection. Equivalent to
-    /// <see cref="ExecuteAsync{T}(Func{Task{T}}, CancellationToken)"/> with <see cref="CancellationToken.None"/>.
-    /// </summary>
-    /// <typeparam name="T">Result type the operation produces.</typeparam>
-    /// <param name="operation">The operation to execute. Must not be null.</param>
-    /// <returns>The operation's result on success.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="operation"/> is null.</exception>
-    /// <exception cref="CircuitBreakerOpenException">Thrown when the circuit is currently open.</exception>
-    public Task<T> ExecuteAsync<T>(Func<Task<T>> operation)
-        => ExecuteAsync(operation, CancellationToken.None);
-
-    /// <summary>
     /// Executes operation with circuit breaker protection and cancellation support.
     /// </summary>
     /// <typeparam name="T">Result type the operation produces.</typeparam>
     /// <param name="operation">The operation to execute. Must not be null.</param>
-    /// <param name="cancellationToken">Token observed before circuit-state evaluation and before invoking <paramref name="operation"/>.</param>
+    /// <param name="cancellationToken">Token observed before circuit-state evaluation and before invoking <paramref name="operation"/>. Defaults to <see cref="CancellationToken.None"/>.</param>
     /// <returns>The operation's result on success.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="operation"/> is null.</exception>
     /// <exception cref="CircuitBreakerOpenException">Thrown when the circuit is currently open.</exception>
     /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is signalled.</exception>
-    public async Task<T> ExecuteAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken)
+    public async Task<T> ExecuteAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(operation);
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/QuerySpec.Core/Security/DataMaskingEngine.cs
+++ b/src/QuerySpec.Core/Security/DataMaskingEngine.cs
@@ -139,12 +139,26 @@ public sealed class DataMaskingEngine
     /// </summary>
     /// <param name="fieldName">Field name registered via <see cref="RegisterFieldMask"/>.</param>
     /// <param name="value">Value to mask. Null produces the literal string <c>"null"</c>.</param>
+    /// <returns>The masked value, or the original string representation if no strategy is registered.</returns>
+    public string Mask(string fieldName, object? value)
+        => MaskCore(fieldName, value, tenantId: null, classifierCategory: PiiCategory.None);
+
+    /// <summary>
+    /// Masks a field value using the strategy registered for <paramref name="fieldName"/>, scoped
+    /// to a tenant. The same value masks differently across tenants when
+    /// <see cref="MaskingStrategy.HashMask"/> is in use. Returns the original string when no
+    /// strategy is registered — this overload has no type context and so cannot consult the
+    /// configured classifier. Prefer <see cref="Mask(System.Type?, string, object?, string?)"/>
+    /// when calling from a code path that knows the entity type.
+    /// </summary>
+    /// <param name="fieldName">Field name registered via <see cref="RegisterFieldMask"/>.</param>
+    /// <param name="value">Value to mask. Null produces the literal string <c>"null"</c>.</param>
     /// <param name="tenantId">
-    /// Optional tenant scope. When supplied, <see cref="MaskingStrategy.HashMask"/> derives a
-    /// tenant-specific key so the same value masks differently across tenants.
+    /// Tenant scope. When non-empty, <see cref="MaskingStrategy.HashMask"/> derives a
+    /// tenant-specific key. Pass <c>null</c> for a tenant-agnostic mask.
     /// </param>
     /// <returns>The masked value, or the original string representation if no strategy is registered.</returns>
-    public string Mask(string fieldName, object? value, string? tenantId = null)
+    public string Mask(string fieldName, object? value, string? tenantId)
         => MaskCore(fieldName, value, tenantId, classifierCategory: PiiCategory.None);
 
     /// <summary>
@@ -158,7 +172,30 @@ public sealed class DataMaskingEngine
     /// <param name="declaringType">The type that owns <paramref name="fieldName"/>. Used to consult the classifier.</param>
     /// <param name="fieldName">Field name. Explicit registrations take precedence over classifier defaults.</param>
     /// <param name="value">Value to mask. Null produces the literal string <c>"null"</c>.</param>
-    /// <param name="tenantId">Optional tenant scope for <see cref="MaskingStrategy.HashMask"/>.</param>
+    /// <returns>
+    /// The masked value. When no field mask is registered and the classifier returns
+    /// <see cref="PiiCategory.None"/>, the original string representation is returned.
+    /// </returns>
+    public string Mask(
+        [DynamicallyAccessedMembers(ClassifierMembers)] Type? declaringType,
+        string fieldName,
+        object? value)
+        => MaskCore(fieldName, value, tenantId: null, Classify(declaringType, fieldName));
+
+    /// <summary>
+    /// Masks a field value with full classifier consultation, scoped to a tenant. The same value
+    /// masks differently across tenants when <see cref="MaskingStrategy.HashMask"/> is in use.
+    /// When no explicit field mask is registered, the configured <see cref="IPiiClassifier"/> is
+    /// consulted via <paramref name="declaringType"/> and a category-default strategy is applied
+    /// for any non-<see cref="PiiCategory.None"/> result.
+    /// </summary>
+    /// <param name="declaringType">The type that owns <paramref name="fieldName"/>. Used to consult the classifier.</param>
+    /// <param name="fieldName">Field name. Explicit registrations take precedence over classifier defaults.</param>
+    /// <param name="value">Value to mask. Null produces the literal string <c>"null"</c>.</param>
+    /// <param name="tenantId">
+    /// Tenant scope. When non-empty, <see cref="MaskingStrategy.HashMask"/> derives a
+    /// tenant-specific key. Pass <c>null</c> for a tenant-agnostic mask.
+    /// </param>
     /// <returns>
     /// The masked value. When no field mask is registered and the classifier returns
     /// <see cref="PiiCategory.None"/>, the original string representation is returned.
@@ -167,7 +204,7 @@ public sealed class DataMaskingEngine
         [DynamicallyAccessedMembers(ClassifierMembers)] Type? declaringType,
         string fieldName,
         object? value,
-        string? tenantId = null)
+        string? tenantId)
         => MaskCore(fieldName, value, tenantId, Classify(declaringType, fieldName));
 
     private string MaskCore(string fieldName, object? value, string? tenantId, PiiCategory classifierCategory)

--- a/tests/QuerySpec.Core.Tests/DependencyInjection/QuerySpecBuilderTests.cs
+++ b/tests/QuerySpec.Core.Tests/DependencyInjection/QuerySpecBuilderTests.cs
@@ -148,8 +148,8 @@ public class QuerySpecBuilderTests
         public System.Threading.Tasks.Task LogChangeAsync(FieldChange change) => System.Threading.Tasks.Task.CompletedTask;
         public System.Threading.Tasks.Task<AuditLogEntry?> GetAuditAsync(string id) => System.Threading.Tasks.Task.FromResult<AuditLogEntry?>(null);
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByRequestAsync(string requestId) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
-        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since = null) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
-        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since = null) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to) => System.Threading.Tasks.Task.FromResult(System.Linq.Enumerable.Empty<AuditLogEntry>());
         public System.Threading.Tasks.Task PurgeOldLogsAsync(System.TimeSpan olderThan) => System.Threading.Tasks.Task.CompletedTask;
     }

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
@@ -224,9 +224,11 @@ namespace QuerySpec.Core.Auditing
         System.Threading.Tasks.Task<QuerySpec.Core.Auditing.AuditLogEntry?> GetAuditAsync(string id, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to, System.Threading.CancellationToken cancellationToken);
@@ -276,8 +278,10 @@ namespace QuerySpec.Core.Auditing
         protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.Task<QuerySpec.Core.Auditing.AuditLogEntry?> GetAuditAsync(string id) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId) { }
-        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since = default) { }
-        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since = default) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, System.DateTime? since) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByUserAsync(string userId, System.DateTime? since) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetComplianceReportAsync(System.DateTime from, System.DateTime to) { }
         public System.Threading.Tasks.Task LogChangeAsync(QuerySpec.Core.Auditing.FieldChange change) { }
         public System.Threading.Tasks.Task LogQueryAsync(QuerySpec.Core.Auditing.AuditLogEntry entry) { }
@@ -551,8 +555,7 @@ namespace QuerySpec.Core.Resilience
         public System.TimeSpan HalfOpenTestInterval { get; set; }
         public System.TimeSpan OpenTimeout { get; set; }
         public QuerySpec.Core.Resilience.CircuitState State { get; }
-        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation) { }
-        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, System.Threading.CancellationToken cancellationToken = default) { }
         public void Reset() { }
     }
     public class CircuitBreakerOpenException : System.Exception
@@ -662,8 +665,10 @@ namespace QuerySpec.Core.Security
             "te fields with [Pii(...)] and use IsPii(Type, string) backed by IPiiClassifier i" +
             "nstead. Promoted to a build error in 2.0.1; scheduled for removal in 3.0.0.", true)]
         public bool IsPii(string fieldName, object? value) { }
-        public string Mask(string fieldName, object? value, string? tenantId = null) { }
-        public string Mask([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName, object? value, string? tenantId = null) { }
+        public string Mask(string fieldName, object? value) { }
+        public string Mask([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName, object? value) { }
+        public string Mask(string fieldName, object? value, string? tenantId) { }
+        public string Mask([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] System.Type? declaringType, string fieldName, object? value, string? tenantId) { }
         public void RegisterFieldMask(string fieldName, QuerySpec.Core.Security.MaskingStrategy strategy) { }
     }
     public class DynamicContext


### PR DESCRIPTION
## Summary

Refactors four public overload sets flagged by RS0026/RS0027 so the analyzer rules can be enforced as errors. These are SemVer-major API changes gated on the v5.0 release window per #192.

- `DataMaskingEngine.Mask`: replaced the two overloads with optional `tenantId = null` defaults by four explicit overloads — `Mask(fieldName, value)`, `Mask(fieldName, value, tenantId)`, `Mask(declaringType, fieldName, value)`, `Mask(declaringType, fieldName, value, tenantId)`.
- `CircuitBreaker.ExecuteAsync<T>`: collapsed `(operation)` and `(operation, ct)` into a single canonical `ExecuteAsync<T>(operation, cancellationToken = default)`.
- `IAuditReader` and `InMemoryAuditLogger`: replaced the optional-`since` overloads of `GetAuditsByUserAsync` and `GetAuditsByTenantAsync` with explicit `(id)` and `(id, since)` overloads. The existing `(id, since, ct)` overload becomes the most-optional variant.

`<WarningsNotAsErrors>$(WarningsNotAsErrors);RS0026;RS0027</WarningsNotAsErrors>` is removed from `Directory.Build.props`. `PublicAPI.Unshipped.txt` records the removed and added members; the public-API approval baseline is regenerated. `ComplianceExporter.GetUserDataAsync` now calls `GetAuditsByUserAsync(userId, since: null)` explicitly to preserve the mock contract used by `ComplianceExporterTests`.

## Verification

- `dotnet build -c Release` is clean across `net8.0`, `net9.0`, `net10.0`.
- `dotnet test` for `QuerySpec.Core.Tests` (760/760), `QuerySpec.PublicApi.Tests` (4/4), and `QuerySpec.Analyzers.Tests` (45/45) all pass. The 35 EFCore Testcontainers failures observed locally are Docker environment, not code regressions, and pre-exist this change.
- `grep -rn 'RS0026\|RS0027' Directory.Build.props` returns no matches.

## Breaking changes (acceptance criteria)

- [x] All four affected overload sets redesigned to satisfy RS0026/RS0027
- [x] `<WarningsNotAsErrors>` exemption for RS0026 and RS0027 removed from `Directory.Build.props`
- [x] `dotnet build -warnaserror` passes with zero RS0026/RS0027 diagnostics
- [x] PublicAPI.Unshipped.txt and the API approval baseline reflect the new surface
- [ ] CHANGELOG entry — auto-generated by `standard-version` from the `BREAKING CHANGE:` footer in this commit

Migration notes for downstream:
- `engine.Mask("Email", value)` continues to compile (one of the new overloads).
- `engine.Mask("Email", value, tenantId: "t1")` continues to compile (named or positional).
- `breaker.ExecuteAsync(op)` continues to compile (CT defaults to `None`).
- `reader.GetAuditsByUserAsync("u1")` and `reader.GetAuditsByUserAsync("u1", since)` are the only no-CT calls; consumers that called `GetAuditsByUserAsync("u1", since: null)` or `GetAuditsByTenantAsync("t1", since: null)` continue to compile against the `(id, since)` overload.

Fixes #192