### PR TITLE
feat(auditing)!: flip IComplianceExporter abstract to GenerateGdprExportAsync (v5.0)

### DIFF
--- a/docs/deprecations/QSPEC0011.md
+++ b/docs/deprecations/QSPEC0011.md
@@ -30,11 +30,19 @@ public class MyExporter : IComplianceExporter
 }
 ```
 
-Implementations that override the new-name overload satisfy the interface contract. The old-name member remains abstract on the interface in the v4.x line, so existing implementations continue to compile; consumers see a warning that points at this document.
+Implementations that override the new-name overload satisfy the interface contract.
 
-## v5.0 plan
+In v4.x, the old-name member was abstract on the interface; existing implementations continued to compile and consumers saw a warning that pointed at this document.
 
-In v5.0, `GenerateGdprExportAsync(..., CancellationToken)` will become the abstract interface member and the obsolete acronym-form members will be demoted to default-interface-method bridges. See the v5.0 tracker for migration details: [#255](https://github.com/AbongileBoja/QuerySpec/issues/255).
+## v5.0 binary break
+
+As of v5.0, `GenerateGdprExportAsync(..., CancellationToken)` is the abstract interface member. The obsolete acronym-form members (`GenerateGDPRExportAsync` no-CT and CT) are now default-interface-methods that delegate forward to the new-name abstract.
+
+Implications for v4.x consumers upgrading to v5.0:
+
+- Customer code that implements `IComplianceExporter` by overriding only `GenerateGDPRExportAsync` no longer satisfies the interface contract. Such implementations must override `GenerateGdprExportAsync(..., CancellationToken)` instead.
+- Recompilation against the v5.0 reference assembly will surface this as a missing-implementation error on the abstract `GenerateGdprExportAsync(..., CancellationToken)` member.
+- v4.x-built binaries that implemented only the acronym-form member will throw `TypeLoadException` when loaded against the v5.0 interface, because the abstract slot is now `GenerateGdprExportAsync`.
 
 ## Suppression
 

--- a/docs/deprecations/QSPEC0012.md
+++ b/docs/deprecations/QSPEC0012.md
@@ -24,9 +24,9 @@ await exporter.GenerateGdprExportAsync(userId, tenantId, stream, cancellationTok
 
 The old-name CancellationToken overload is a default-interface-method that delegates forward to the new-name CancellationToken overload, so callers and implementers can move at their own pace.
 
-## v5.0 plan
+## v5.0 status
 
-In v5.0, `GenerateGdprExportAsync(..., CancellationToken)` becomes the abstract member; this obsolete overload becomes a default-interface-method bridge. See [#255](https://github.com/AbongileBoja/QuerySpec/issues/255).
+As of v5.0, `GenerateGdprExportAsync(..., CancellationToken)` is the abstract interface member. This obsolete overload is a default-interface-method bridge that forwards to the new-name abstract — its runtime behaviour is unchanged. The bridge is retained for source compatibility with v4.x callers; it remains marked obsolete and will be removed in a future major release. See [QSPEC0011](QSPEC0011.md) for the v5.0 binary-break implications.
 
 ## Suppression
 

--- a/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
+++ b/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
@@ -61,7 +61,8 @@ public interface IComplianceExporter
         UrlFormat = "https://github.com/AbongileBoja/QuerySpec/blob/main/docs/deprecations/{0}.md")]
     [RequiresUnreferencedCode(GdprExportRequiresUnreferencedCodeMessage)]
     [RequiresDynamicCode(GdprExportRequiresDynamicCodeMessage)]
-    Task GenerateGDPRExportAsync(string userId, string tenantId, Stream outputStream);
+    Task GenerateGDPRExportAsync(string userId, string tenantId, Stream outputStream)
+        => GenerateGdprExportAsync(userId, tenantId, outputStream, CancellationToken.None);
     /// <summary>
     /// Generates a GDPR export for a user with cancellation support. Original spelling retained
     /// for source compatibility with 2.x consumers; prefer
@@ -96,14 +97,7 @@ public interface IComplianceExporter
     /// <param name="cancellationToken">Token observed during the serialisation pass.</param>
     [RequiresUnreferencedCode(GdprExportRequiresUnreferencedCodeMessage)]
     [RequiresDynamicCode(GdprExportRequiresDynamicCodeMessage)]
-    Task GenerateGdprExportAsync(string userId, string tenantId, Stream outputStream, CancellationToken cancellationToken = default)
-        // v5.0: this pragma is the only remaining warning suppression in shipping code.
-        // It bridges the new-name DIM to the obsolete abstract member; removing it
-        // requires flipping which interface member is abstract, which is a binary break.
-        // Tracked by issue #255 for v5.0.
-#pragma warning disable QSPEC0011
-        => GenerateGDPRExportAsync(userId, tenantId, outputStream);
-#pragma warning restore QSPEC0011
+    Task GenerateGdprExportAsync(string userId, string tenantId, Stream outputStream, CancellationToken cancellationToken = default);
 
     internal const string GdprExportRequiresUnreferencedCodeMessage =
         "GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation over AuditLogEntry. Under trimming, members of AuditLogEntry or its referenced types may be removed and emit incomplete JSON. Use a JsonSerializerContext-based exporter for trimmed scenarios.";


### PR DESCRIPTION
## Summary

Closes #255. In v5.0, `GenerateGdprExportAsync(string, string, Stream, CancellationToken)` becomes the abstract interface member on `IComplianceExporter`. The acronym-form members and the new-name no-CT overload become default-interface-methods that delegate forward to the new abstract. This removes the last remaining `#pragma warning disable` in shipping QuerySpec code.

## Why

In v4.x the abstract member was `GenerateGDPRExportAsync` (acronym), and the new-name DIM had to bridge into it via a CS0618 / QSPEC0011 pragma block — the only remaining warning suppression in shipping code. Issue #255 tracked the v5.0 flip: making the new-name CT overload abstract, demoting the acronym overloads to DIMs, and removing the pragma. v5.0 is the SemVer-major bump where binary breaks are permitted.

## Changes

- `src/QuerySpec.Core/Auditing/ComplianceExporter.cs`
  - `IComplianceExporter.GenerateGdprExportAsync(..., CancellationToken)` is now abstract (no DIM body).
  - `IComplianceExporter.GenerateGdprExportAsync(string, string, Stream)` is a DIM that calls the new-name CT abstract with `CancellationToken.None`.
  - `IComplianceExporter.GenerateGDPRExportAsync(string, string, Stream)` is a DIM that calls the new-name no-CT DIM (forward delegation, no obsolete bridge).
  - `IComplianceExporter.GenerateGDPRExportAsync(..., CancellationToken)` is a DIM that calls the new-name CT abstract.
  - `#pragma warning disable QSPEC0011` / `restore QSPEC0011` block removed.
  - `ComplianceExporter` concrete class is unchanged: it overrides the new-name CT (the abstract) plus retains the other three overloads as source-compat shadows that all forward to the new-name CT body.
- `docs/deprecations/QSPEC0011.md` updated to document the v5.0 binary break and migration path.
- `docs/deprecations/QSPEC0012.md` updated to note that the acronym CT overload is now a DIM bridge in v5.0.

## Verification

- `dotnet build QuerySpec.sln -c Release -p:TreatWarningsAsErrors=true` — 0 errors, only pre-existing MA00xx warnings (unrelated).
- `dotnet test tests/QuerySpec.Core.Tests --filter "FullyQualifiedName~ComplianceExporter|FullyQualifiedName~MutationKiller"` — 194/194 pass on net8/9/10.
- `dotnet test tests/QuerySpec.PublicApi.Tests` — 4/4 pass; `PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt` is unchanged (signatures unchanged, only abstract-vs-DIM metadata flipped).
- `bash eng/no-suppression-check.sh` — clean (no new pragmas; one pragma block deleted).
- `git diff` shows three files changed: `+16 / -14`.

## SemVer verdict

**major** — abstract interface member changed (CP0006 / CP0008 against the v4.x baseline). The PR is gated for v5.0 per issue #255.

## Risk and rollback

- v4.x binaries that implement `IComplianceExporter` only via `GenerateGDPRExportAsync(...)` (the v4.x abstract) will fail to satisfy the v5.0 interface contract: source compile error on missing implementation; runtime `TypeLoadException` if loaded as a v4.x DLL against the v5.0 reference assembly. This is the documented v5.0 migration cost, called out in QSPEC0011.md.
- The release engineer should regenerate `src/QuerySpec.Core/CompatibilitySuppressions.xml` and add CP0006/CP0008 entries against the v4.1.3 baseline at v5.0 release time, then bump `PackageValidationBaselineVersion` to the most recent shipped v4.x.
- Strict-mode package validation does not run on this PR's CI because `Version=0.0.0-local` short-circuits `EnablePackageValidation`. The break will surface during the v5.0 release pack.

## Acceptance criteria

- [x] `GenerateGdprExportAsync(..., CT)` is the abstract interface member.
- [x] Both `GenerateGDPRExportAsync` overloads are DIMs delegating forward.
- [x] No `#pragma warning disable CS0618` (or QSPEC0011) remains in `ComplianceExporter.cs`.
- [x] Migration documented in `docs/deprecations/QSPEC0011.md` with a v5.0 section.
- [x] PublicApi approval baseline (`PublicAPI.Shipped.txt`, `PublicApiApprovalTests.*.verified.txt`) verified unchanged — interface signatures did not change, only abstract-vs-DIM metadata.

## Test plan

- [ ] CI green on net8.0/net9.0/net10.0 build, test, and PublicApi approval jobs.
- [ ] `eng/no-suppression-check.sh` reports clean.
- [ ] Reviewer confirms the forward-delegation chain has no recursion: old-no-CT -> new-no-CT -> new-CT (abstract); old-CT -> new-CT (abstract).