### PR TITLE
feat(core)!: seal 15 public concrete classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to QuerySpec are documented here. Generated from Conventiona
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### BREAKING CHANGES
+
+* **core:** seal 15 public concrete classes — `AesEncryptionProvider`, `AesGcmEncryptionProvider`, `BulkheadPolicy`, `CircuitBreaker`, `ComplianceExporter`, `CustomOperatorRegistry`, `DistributedCacheProvider`, `InMemoryAuditLogger`, `MetricsCollector`, `MultiLevelCache`, `N1DetectionEngine`, `RateLimiter`, `ResiliencePolicy`, `RetryPolicy`, `RowLevelSecurityEngine`. Any consumer that subclasses these types will fail to compile. The `protected virtual Dispose(bool)` hook on `BulkheadPolicy` and `InMemoryAuditLogger` is removed; both use a direct `Dispose()` now. ([#159](https://github.com/AbongileBoja/QuerySpec/issues/159))
+
 ## [4.3.0](https://github.com/AbongileBoja/QuerySpec/compare/v4.2.0...v4.3.0) (2026-04-29)
 
 

--- a/src/QuerySpec.Core/Advanced/CustomOperatorRegistry.cs
+++ b/src/QuerySpec.Core/Advanced/CustomOperatorRegistry.cs
@@ -26,7 +26,7 @@ public interface ICustomOperator
 /// <summary>
 /// Manages custom operators for extensibility.
 /// </summary>
-public class CustomOperatorRegistry
+public sealed class CustomOperatorRegistry
 {
     private readonly ConcurrentDictionary<string, ICustomOperator> _operators = new();
 

--- a/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
+++ b/src/QuerySpec.Core/Auditing/ComplianceExporter.cs
@@ -108,7 +108,7 @@ public interface IComplianceExporter
 /// <summary>
 /// Handles compliance exports (GDPR, HIPAA, etc.) injected as a service.
 /// </summary>
-public class ComplianceExporter : IComplianceExporter
+public sealed class ComplianceExporter : IComplianceExporter
 {
     private static readonly JsonSerializerOptions IndentedOptions = new() { WriteIndented = true };
     private readonly IAuditReader _auditReader;

--- a/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
+++ b/src/QuerySpec.Core/Auditing/InMemoryAuditLogger.cs
@@ -12,7 +12,7 @@ namespace QuerySpec.Core.Auditing;
 /// <see cref="IDisposable"/> so the kernel-backed lock is released when the DI container
 /// disposes the singleton (or when callers <c>using</c> the type directly).
 /// </summary>
-public class InMemoryAuditLogger : IAuditLogger, IDisposable
+public sealed class InMemoryAuditLogger : IAuditLogger, IDisposable
 {
     private readonly List<AuditLogEntry> _logs = new();
     private readonly ReaderWriterLockSlim _lockSlim = new();
@@ -39,20 +39,10 @@ public class InMemoryAuditLogger : IAuditLogger, IDisposable
     /// </summary>
     public void Dispose()
     {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>Dispose pattern hook for subclasses.</summary>
-    /// <param name="disposing"><c>true</c> when called from <see cref="Dispose()"/>, <c>false</c> from a finalizer.</param>
-    protected virtual void Dispose(bool disposing)
-    {
         if (_disposed) return;
-        if (disposing)
-        {
-            _lockSlim.Dispose();
-        }
+        _lockSlim.Dispose();
         _disposed = true;
+        GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/src/QuerySpec.Core/Caching/DistributedCacheProvider.cs
+++ b/src/QuerySpec.Core/Caching/DistributedCacheProvider.cs
@@ -17,7 +17,7 @@ namespace QuerySpec.Core.Caching;
 /// a cache outage does not take down the caller. Deserialization exceptions indicate a
 /// poison entry: the entry is evicted so the next read will miss and repopulate.
 /// </remarks>
-public class DistributedCacheProvider : ICacheProvider, ICacheStore
+public sealed class DistributedCacheProvider : ICacheProvider, ICacheStore
 {
     private readonly IDistributedCache _cache;
     private readonly ILogger<DistributedCacheProvider> _logger;

--- a/src/QuerySpec.Core/Caching/MultiLevelCache.cs
+++ b/src/QuerySpec.Core/Caching/MultiLevelCache.cs
@@ -9,7 +9,7 @@ namespace QuerySpec.Core.Caching;
 /// Multi-level cache with memory (L1) + distributed (L2) tier.
 /// Provides best of both worlds: speed and scalability.
 /// </summary>
-public class MultiLevelCache : ICacheProvider, ICacheStore
+public sealed class MultiLevelCache : ICacheProvider, ICacheStore
 {
     private readonly MemoryCacheProvider _l1;
     private readonly DistributedCacheProvider _l2;

--- a/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
+++ b/src/QuerySpec.Core/Monitoring/N1DetectionEngine.cs
@@ -21,7 +21,7 @@ namespace QuerySpec.Core.Monitoring;
 /// <para>Execution times are retained as rolling aggregates (count, sum, max) rather than a
 /// list, so each entry has O(1) memory regardless of call count.</para>
 /// </remarks>
-public class N1DetectionEngine
+public sealed class N1DetectionEngine
 {
     /// <summary>Maximum number of unique call-stack patterns retained at any time.</summary>
     public const int MaxTrackedPatterns = 1024;

--- a/src/QuerySpec.Core/Monitoring/QueryMetrics.cs
+++ b/src/QuerySpec.Core/Monitoring/QueryMetrics.cs
@@ -69,7 +69,7 @@ public class QueryMetricsReport
 /// (FIFO eviction at <see cref="DefaultMaxRetainedQueries"/>) so long-running hosts cannot
 /// leak memory through the metrics pipeline.
 /// </summary>
-public class MetricsCollector
+public sealed class MetricsCollector
 {
     /// <summary>
     /// Default maximum number of <see cref="QueryMetrics"/> entries retained before FIFO

--- a/src/QuerySpec.Core/PublicAPI.Shipped.txt
+++ b/src/QuerySpec.Core/PublicAPI.Shipped.txt
@@ -682,6 +682,4 @@ static QuerySpec.Core.Security.RowLevelSecurityEngine.EscapeSqlLiteral(string? v
 static QuerySpec.Core.Security.RowLevelSecurityEngine.ValidateIdentifier(string! identifier) -> string!
 static readonly QuerySpec.Core.Security.RLSFilter.AllowAll -> QuerySpec.Core.Security.RLSFilter!
 static readonly QuerySpec.Core.Security.RLSFilter.DenyAll -> QuerySpec.Core.Security.RLSFilter!
-virtual QuerySpec.Core.Auditing.InMemoryAuditLogger.Dispose(bool disposing) -> void
-virtual QuerySpec.Core.Resilience.BulkheadPolicy.Dispose(bool disposing) -> void
 ~override QuerySpec.Core.Advanced.GeoCoordinate.Equals(object obj) -> bool

--- a/src/QuerySpec.Core/PublicAPI.Unshipped.txt
+++ b/src/QuerySpec.Core/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ static QuerySpec.Core.Caching.CacheResult.Miss<T>() -> QuerySpec.Core.Caching.Ca
 QuerySpec.Core.Caching.CacheStats.CacheStats(string! cacheName) -> void
 QuerySpec.Core.Diagnostics.QuerySpecMetrics
 const QuerySpec.Core.Diagnostics.QuerySpecMetrics.MeterName = "QuerySpec" -> string!
+*REMOVED*QuerySpec.Core.Auditing.InMemoryAuditLogger.Dispose(bool disposing) -> void
+*REMOVED*QuerySpec.Core.Resilience.BulkheadPolicy.Dispose(bool disposing) -> void
 *REMOVED*QuerySpec.Core.Auditing.IAuditReader.GetAuditsByTenantAsync(string! tenantId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
 *REMOVED*QuerySpec.Core.Auditing.IAuditReader.GetAuditsByUserAsync(string! userId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!
 *REMOVED*QuerySpec.Core.Auditing.InMemoryAuditLogger.GetAuditsByTenantAsync(string! tenantId, System.DateTime? since = null) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry!>!>!

--- a/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
+++ b/src/QuerySpec.Core/Resilience/BulkheadPolicy.cs
@@ -9,7 +9,7 @@ namespace QuerySpec.Core.Resilience;
 /// <see cref="IDisposable"/> because the backing <see cref="SemaphoreSlim"/> owns a
 /// kernel-allocated wait handle that must be released on teardown.
 /// </summary>
-public class BulkheadPolicy : IDisposable
+public sealed class BulkheadPolicy : IDisposable
 {
     private readonly SemaphoreSlim _semaphore;
     private bool _disposed;
@@ -68,20 +68,10 @@ public class BulkheadPolicy : IDisposable
     /// <summary>Releases the backing <see cref="SemaphoreSlim"/>. Idempotent.</summary>
     public void Dispose()
     {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>Dispose pattern hook for subclasses.</summary>
-    /// <param name="disposing"><c>true</c> when called from <see cref="Dispose()"/>, <c>false</c> from a finalizer.</param>
-    protected virtual void Dispose(bool disposing)
-    {
         if (_disposed) return;
-        if (disposing)
-        {
-            _semaphore.Dispose();
-        }
+        _semaphore.Dispose();
         _disposed = true;
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
+++ b/src/QuerySpec.Core/Resilience/CircuitBreaker.cs
@@ -8,7 +8,7 @@ namespace QuerySpec.Core.Resilience;
 /// Circuit breaker pattern implementation.
 /// Prevents cascading failures with state machine: Closed -> Open -> HalfOpen -> Closed.
 /// </summary>
-public class CircuitBreaker
+public sealed class CircuitBreaker
 {
     private CircuitState _state = CircuitState.Closed;
     private DateTimeOffset _lastFailureTime = DateTimeOffset.MinValue;

--- a/src/QuerySpec.Core/Resilience/RateLimiter.cs
+++ b/src/QuerySpec.Core/Resilience/RateLimiter.cs
@@ -17,7 +17,7 @@ namespace QuerySpec.Core.Resilience;
 /// shape — callers are already being throttled on that key — so the managed lock is the right
 /// primitive.
 /// </remarks>
-public class RateLimiter
+public sealed class RateLimiter
 {
     private sealed class Bucket
     {

--- a/src/QuerySpec.Core/Resilience/ResiliencePolicy.cs
+++ b/src/QuerySpec.Core/Resilience/ResiliencePolicy.cs
@@ -7,7 +7,7 @@ namespace QuerySpec.Core.Resilience;
 /// <summary>
 /// Resilience policy combinator for chaining multiple resilience patterns.
 /// </summary>
-public class ResiliencePolicy
+public sealed class ResiliencePolicy
 {
     /// <summary>Circuit breaker policy.</summary>
     public CircuitBreaker? CircuitBreaker { get; set; }

--- a/src/QuerySpec.Core/Resilience/RetryPolicy.cs
+++ b/src/QuerySpec.Core/Resilience/RetryPolicy.cs
@@ -7,7 +7,7 @@ namespace QuerySpec.Core.Resilience;
 /// <summary>
 /// Retry policy with exponential backoff for transient failures.
 /// </summary>
-public class RetryPolicy
+public sealed class RetryPolicy
 {
     /// <summary>Maximum number of retry attempts.</summary>
     public int MaxRetries { get; set; } = 3;

--- a/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesEncryptionProvider.cs
@@ -19,7 +19,7 @@ namespace QuerySpec.Core.Security;
 /// <see cref="AesGcmEncryptionProvider"/> for any new ciphertext.
 /// </remarks>
 [Obsolete("CBC without authentication is malleable. Use AesGcmEncryptionProvider for new ciphertexts; this class remains only to decrypt legacy data.")]
-public class AesEncryptionProvider : IEncryptionProvider
+public sealed class AesEncryptionProvider : IEncryptionProvider
 {
     private readonly byte[] _key;
 

--- a/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
+++ b/src/QuerySpec.Core/Security/AesGcmEncryptionProvider.cs
@@ -25,7 +25,7 @@ namespace QuerySpec.Core.Security;
 /// <see cref="CryptographicException"/>, not corrupt plaintext.
 /// </para>
 /// </remarks>
-public class AesGcmEncryptionProvider : IAuthenticatedEncryptionProvider, IEncryptionProvider
+public sealed class AesGcmEncryptionProvider : IAuthenticatedEncryptionProvider, IEncryptionProvider
 {
     private const int NonceSize = 12;
     private const int TagSize = 16;

--- a/src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs
+++ b/src/QuerySpec.Core/Security/RowLevelSecurityEngine.cs
@@ -59,7 +59,7 @@ public enum RLSDefaultBehavior
 /// genuinely public.
 /// </para>
 /// </remarks>
-public class RowLevelSecurityEngine
+public sealed class RowLevelSecurityEngine
 {
     private static readonly Regex IdentifierPattern = new(
         @"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?$",

--- a/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
+++ b/tests/QuerySpec.PublicApi.Tests/ApprovedApi/PublicApiApprovalTests.Core_PublicApi_HasNotChanged.verified.txt
@@ -22,7 +22,7 @@
         public QuerySpec.Core.Advanced.AggregationOperator Operator { get; set; }
         public int? Percentile { get; set; }
     }
-    public class CustomOperatorRegistry
+    public sealed class CustomOperatorRegistry
     {
         public CustomOperatorRegistry() { }
         public QuerySpec.Core.Advanced.ICustomOperator? Get(string name) { }
@@ -163,7 +163,7 @@ namespace QuerySpec.Core.Auditing
         public bool VerifyIntegrity(string? expectedPreviousHash) { }
         public static int VerifyChain(System.Collections.Generic.IReadOnlyList<QuerySpec.Core.Auditing.AuditLogEntry> entries) { }
     }
-    public class ComplianceExporter : QuerySpec.Core.Auditing.IComplianceExporter
+    public sealed class ComplianceExporter : QuerySpec.Core.Auditing.IComplianceExporter
     {
         public ComplianceExporter(QuerySpec.Core.Auditing.IAuditReader auditReader) { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("GenerateGdprExportAsync uses System.Text.Json reflection-based serialisation, whi" +
@@ -269,13 +269,12 @@ namespace QuerySpec.Core.Auditing
         System.Threading.Tasks.Task<bool> UserHasAccessedFieldAsync(string userId, string fieldName, System.DateTime since);
         System.Threading.Tasks.Task<bool> UserHasAccessedFieldAsync(string userId, string fieldName, System.DateTime since, System.Threading.CancellationToken cancellationToken);
     }
-    public class InMemoryAuditLogger : QuerySpec.Core.Auditing.IAuditLogger, QuerySpec.Core.Auditing.IAuditMaintenance, QuerySpec.Core.Auditing.IAuditReader, QuerySpec.Core.Auditing.IAuditWriter, System.IDisposable
+    public sealed class InMemoryAuditLogger : QuerySpec.Core.Auditing.IAuditLogger, QuerySpec.Core.Auditing.IAuditMaintenance, QuerySpec.Core.Auditing.IAuditReader, QuerySpec.Core.Auditing.IAuditWriter, System.IDisposable
     {
         public InMemoryAuditLogger() { }
         public InMemoryAuditLogger(System.TimeProvider timeProvider) { }
         public int Count { get; }
         public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.Task<QuerySpec.Core.Auditing.AuditLogEntry?> GetAuditAsync(string id) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByRequestAsync(string requestId) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<QuerySpec.Core.Auditing.AuditLogEntry>> GetAuditsByTenantAsync(string tenantId) { }
@@ -349,7 +348,7 @@ namespace QuerySpec.Core.Caching
         public QuerySpec.Core.Caching.CacheStats Snapshot() { }
         public override string ToString() { }
     }
-    public class DistributedCacheProvider : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore
+    public sealed class DistributedCacheProvider : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore
     {
         public DistributedCacheProvider(Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Microsoft.Extensions.Logging.ILogger<QuerySpec.Core.Caching.DistributedCacheProvider>? logger = null) { }
         public System.Threading.Tasks.ValueTask<bool> ExistsAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
@@ -420,7 +419,7 @@ namespace QuerySpec.Core.Caching
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"Cache store reads and writes deserialise/serialise T. Distributed implementations (DistributedCacheProvider, MultiLevelCache) use System.Text.Json reflection-based serialisation, which may emit incomplete payloads under trimming when members of T are removed. In-process implementations (MemoryCacheProvider) are trim-safe; suppress the warning at the call site only when you can prove the underlying provider does not serialise.")]
         public System.Threading.Tasks.ValueTask<QuerySpec.Core.Caching.CacheResult<T>> TryGetAsync<T>(string key, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public class MultiLevelCache : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore
+    public sealed class MultiLevelCache : QuerySpec.Core.Caching.ICacheProvider, QuerySpec.Core.Caching.ICacheStore
     {
         public MultiLevelCache(QuerySpec.Core.Caching.MemoryCacheProvider l1, QuerySpec.Core.Caching.DistributedCacheProvider l2) { }
         public System.Threading.Tasks.ValueTask<bool> ExistsAsync(string key, System.Threading.CancellationToken cancellationToken = default) { }
@@ -464,7 +463,7 @@ namespace QuerySpec.Core.Monitoring
         System.Threading.Tasks.Task<QuerySpec.Core.Monitoring.HealthStatus> CheckDatabaseAsync();
         System.Threading.Tasks.Task<QuerySpec.Core.Monitoring.HealthStatus> CheckSecurityAsync();
     }
-    public class MetricsCollector
+    public sealed class MetricsCollector
     {
         public const int DefaultMaxRetainedQueries = 10000;
         public MetricsCollector() { }
@@ -473,7 +472,7 @@ namespace QuerySpec.Core.Monitoring
         public QuerySpec.Core.Monitoring.QueryMetricsReport GetReport(System.TimeSpan? period = default) { }
         public void Record(QuerySpec.Core.Monitoring.QueryMetrics metrics) { }
     }
-    public class N1DetectionEngine
+    public sealed class N1DetectionEngine
     {
         public const int MaxTrackedPatterns = 1024;
         public N1DetectionEngine() { }
@@ -539,16 +538,15 @@ namespace QuerySpec.Core.Resilience
         public BulkheadException(string message) { }
         public BulkheadException(string message, System.Exception innerException) { }
     }
-    public class BulkheadPolicy : System.IDisposable
+    public sealed class BulkheadPolicy : System.IDisposable
     {
         public BulkheadPolicy(int maxConcurrentRequests) { }
         public int MaxConcurrentRequests { get; }
         public void Dispose() { }
-        protected virtual void Dispose(bool disposing) { }
         public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation) { }
         public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, System.Threading.CancellationToken cancellationToken) { }
     }
-    public class CircuitBreaker
+    public sealed class CircuitBreaker
     {
         public CircuitBreaker(System.TimeProvider? timeProvider = null) { }
         public int FailureThreshold { get; set; }
@@ -581,7 +579,7 @@ namespace QuerySpec.Core.Resilience
         public RateLimitedException(string message) { }
         public RateLimitedException(string message, System.Exception innerException) { }
     }
-    public class RateLimiter
+    public sealed class RateLimiter
     {
         public RateLimiter(System.TimeProvider? timeProvider = null) { }
         public int BurstSize { get; set; }
@@ -589,7 +587,7 @@ namespace QuerySpec.Core.Resilience
         public System.TimeSpan? GetRetryAfter(string key, int tokensRequired = 1) { }
         public bool TryAcquire(string key, int tokensRequired = 1) { }
     }
-    public class ResiliencePolicy
+    public sealed class ResiliencePolicy
     {
         public ResiliencePolicy() { }
         public QuerySpec.Core.Resilience.BulkheadPolicy? Bulkhead { get; set; }
@@ -599,7 +597,7 @@ namespace QuerySpec.Core.Resilience
         public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, string key = "default") { }
         public System.Threading.Tasks.Task<T> ExecuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, string key, System.Threading.CancellationToken cancellationToken) { }
     }
-    public class RetryPolicy
+    public sealed class RetryPolicy
     {
         public RetryPolicy() { }
         public double BackoffMultiplier { get; set; }
@@ -615,14 +613,14 @@ namespace QuerySpec.Core.Security
 {
     [System.Obsolete("CBC without authentication is malleable. Use AesGcmEncryptionProvider for new cip" +
         "hertexts; this class remains only to decrypt legacy data.")]
-    public class AesEncryptionProvider : QuerySpec.Core.Security.IEncryptionProvider
+    public sealed class AesEncryptionProvider : QuerySpec.Core.Security.IEncryptionProvider
     {
         public AesEncryptionProvider(string keyBase64) { }
         public string Decrypt(string ciphertext) { }
         public string Encrypt(string plaintext) { }
         public static string GenerateKey() { }
     }
-    public class AesGcmEncryptionProvider : QuerySpec.Core.Security.IAuthenticatedEncryptionProvider, QuerySpec.Core.Security.IEncryptionProvider
+    public sealed class AesGcmEncryptionProvider : QuerySpec.Core.Security.IAuthenticatedEncryptionProvider, QuerySpec.Core.Security.IEncryptionProvider
     {
         public AesGcmEncryptionProvider(byte[] key) { }
         public AesGcmEncryptionProvider(string keyBase64) { }
@@ -786,7 +784,7 @@ namespace QuerySpec.Core.Security
         public string ResourceType { get; set; }
         public QuerySpec.Core.Security.RLSPolicy SetPredicate<T>(System.Func<QuerySpec.Core.Security.RLSContext, System.Linq.Expressions.Expression<System.Func<T, bool>>> factory) { }
     }
-    public class RowLevelSecurityEngine
+    public sealed class RowLevelSecurityEngine
     {
         public RowLevelSecurityEngine(QuerySpec.Core.Security.RLSDefaultBehavior defaultBehavior = 0) { }
         public QuerySpec.Core.Security.RLSFilter GenerateFilter(string resourceType, QuerySpec.Core.Security.RLSContext context) { }


### PR DESCRIPTION
## Summary

- Adds `sealed` to 15 public concrete classes in `QuerySpec.Core` that had no documented inheritance contract, no known subclasses (verified via repo-wide grep), and no protected virtual extension points outside the dispose pattern.
- Collapses the `protected virtual Dispose(bool)` indirection on `BulkheadPolicy` and `InMemoryAuditLogger` into a direct `Dispose()` with an `_disposed` guard, matching the sealed-class dispose idiom.
- Updates `PublicAPI.Unshipped.txt` with `*REMOVED*` entries for the two removed `Dispose(bool disposing)` overloads.
- Updates the Verify public-API snapshot to reflect `sealed` on all 15 types and the removal of the two `protected virtual void Dispose(bool)` lines.

Sealed types: `AesEncryptionProvider`, `AesGcmEncryptionProvider`, `BulkheadPolicy`, `CircuitBreaker`, `ComplianceExporter`, `CustomOperatorRegistry`, `DistributedCacheProvider`, `InMemoryAuditLogger`, `MetricsCollector`, `MultiLevelCache`, `N1DetectionEngine`, `RateLimiter`, `ResiliencePolicy`, `RetryPolicy`, `RowLevelSecurityEngine`.

## Breaking changes

Any consumer that subclasses one of the 15 types will receive CS0509 at compile time. The `protected virtual Dispose(bool)` hook on `BulkheadPolicy` and `InMemoryAuditLogger` is removed; callers that overrode it must switch to composing a new `IDisposable` wrapper instead.

This is intentional and constitutes the v5.0 SemVer-major API change described in issue #159.

## Test plan

- [ ] CI: Build net8/net9/net10 passes — no CS0509 in the repo itself (no subclasses exist)
- [ ] CI: `dotnet format` passes — no style regressions
- [ ] CI: PublicAPI analyzer passes — `Unshipped.txt` REMOVED entries satisfy RS0017 for the two removed protected members
- [ ] CI: Verify snapshot test (`PublicApiApprovalTests.Core_PublicApi_HasNotChanged`) passes — snapshot updated in sync with sealed modifiers
- [ ] CI: All existing dispose-pattern tests pass — idempotency and post-dispose ObjectDisposedException contracts unchanged
- [ ] CI: CodeQL passes — sealing reduces attack surface, no new patterns introduced

Fixes #159