### PR TITLE
chore(ci): ignore benchmarks/baseline-run/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ dlldata.c
 
 # Benchmark Results
 BenchmarkDotNet.Artifacts/
+benchmarks/baseline-run/
 
 # .NET Core
 project.lock.json


### PR DESCRIPTION
## Summary

Adds `benchmarks/baseline-run/` to `.gitignore` so local BenchmarkDotNet output doesn't appear as untracked in `git status`. The `.gitleaks.toml` allowlist remains as defence-in-depth.

Fixes #228

## Verification
- `git status` no longer surfaces `benchmarks/baseline-run/` after a local benchmark run.