### PR TITLE
fix(auditing): IAuditReader DIM applies since filter instead of dropping it

### DIFF
--- a/src/QuerySpec.Core/Auditing/IAuditLogger.cs
+++ b/src/QuerySpec.Core/Auditing/IAuditLogger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -74,10 +75,18 @@ public interface IAuditReader
     Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId);
     /// <summary>Gets all audits for a specific user filtered by date.</summary>
     /// <param name="userId">User identifier.</param>
-    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>; pass <c>null</c> to skip filtering.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="userId"/>.</returns>
-    Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since)
-        => GetAuditsByUserAsync(userId);
+    /// <remarks>
+    /// The default implementation calls <see cref="GetAuditsByUserAsync(string)"/> and post-filters by
+    /// <paramref name="since"/>. Implementations that can push the predicate to the storage layer should
+    /// override this overload for efficiency.
+    /// </remarks>
+    async Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId, DateTime? since)
+    {
+        var all = await GetAuditsByUserAsync(userId).ConfigureAwait(false);
+        return since.HasValue ? all.Where(e => e.Timestamp >= since.Value) : all;
+    }
     /// <summary>Gets all audits for a specific user filtered by date, with cancellation support.</summary>
     /// <param name="userId">User identifier.</param>
     /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
@@ -92,10 +101,18 @@ public interface IAuditReader
     Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId);
     /// <summary>Gets all audits for a specific tenant filtered by date.</summary>
     /// <param name="tenantId">Tenant identifier.</param>
-    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>
+    /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>; pass <c>null</c> to skip filtering.</param>
     /// <returns>A materialised snapshot of audit entries for <paramref name="tenantId"/>.</returns>
-    Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since)
-        => GetAuditsByTenantAsync(tenantId);
+    /// <remarks>
+    /// The default implementation calls <see cref="GetAuditsByTenantAsync(string)"/> and post-filters by
+    /// <paramref name="since"/>. Implementations that can push the predicate to the storage layer should
+    /// override this overload for efficiency.
+    /// </remarks>
+    async Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId, DateTime? since)
+    {
+        var all = await GetAuditsByTenantAsync(tenantId).ConfigureAwait(false);
+        return since.HasValue ? all.Where(e => e.Timestamp >= since.Value) : all;
+    }
     /// <summary>Gets all audits for a specific tenant filtered by date, with cancellation support.</summary>
     /// <param name="tenantId">Tenant identifier.</param>
     /// <param name="since">Inclusive lower bound on <see cref="AuditLogEntry.Timestamp"/>.</param>

--- a/tests/QuerySpec.Core.Tests/Auditing/IAuditReaderDefaultImplementationTests.cs
+++ b/tests/QuerySpec.Core.Tests/Auditing/IAuditReaderDefaultImplementationTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using QuerySpec.Core.Auditing;
+using Xunit;
+
+namespace QuerySpec.Core.Tests.Auditing;
+
+/// <summary>
+/// Verifies that <see cref="IAuditReader"/> default implementations honour the documented contract
+/// when an implementer overrides only the simplest overload — in particular, that the
+/// <c>since</c> date filter is applied by the DIM rather than silently dropped.
+/// </summary>
+public class IAuditReaderDefaultImplementationTests
+{
+    [Fact]
+    public async Task GetAuditsByUserAsync_WithSince_DimAppliesDateFilter()
+    {
+        IAuditReader reader = new MinimalReader(new[]
+        {
+            Entry("u1", new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            Entry("u1", new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)),
+            Entry("u1", new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc)),
+        });
+
+        var since = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var result = (await reader.GetAuditsByUserAsync("u1", since)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, e => Assert.True(e.Timestamp >= since));
+    }
+
+    [Fact]
+    public async Task GetAuditsByUserAsync_WithNullSince_DimReturnsAllEntries()
+    {
+        IAuditReader reader = new MinimalReader(new[]
+        {
+            Entry("u1", new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            Entry("u1", new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc)),
+        });
+
+        var result = (await reader.GetAuditsByUserAsync("u1", since: null)).ToList();
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAuditsByTenantAsync_WithSince_DimAppliesDateFilter()
+    {
+        IAuditReader reader = new MinimalReader(new[]
+        {
+            EntryTenant("t1", new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            EntryTenant("t1", new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)),
+            EntryTenant("t1", new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc)),
+        });
+
+        var since = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var result = (await reader.GetAuditsByTenantAsync("t1", since)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, e => Assert.True(e.Timestamp >= since));
+    }
+
+    [Fact]
+    public async Task GetAuditsByTenantAsync_WithNullSince_DimReturnsAllEntries()
+    {
+        IAuditReader reader = new MinimalReader(new[]
+        {
+            EntryTenant("t1", new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            EntryTenant("t1", new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc)),
+        });
+
+        var result = (await reader.GetAuditsByTenantAsync("t1", since: null)).ToList();
+
+        Assert.Equal(2, result.Count);
+    }
+
+    private static AuditLogEntry Entry(string userId, DateTime timestamp)
+        => new() { UserId = userId, TenantId = "t", Operation = "Query", Timestamp = timestamp };
+
+    private static AuditLogEntry EntryTenant(string tenantId, DateTime timestamp)
+        => new() { UserId = "u", TenantId = tenantId, Operation = "Query", Timestamp = timestamp };
+
+    private sealed class MinimalReader : IAuditReader
+    {
+        private readonly IReadOnlyList<AuditLogEntry> _entries;
+
+        public MinimalReader(IEnumerable<AuditLogEntry> entries)
+        {
+            _entries = entries.ToList();
+        }
+
+        public Task<AuditLogEntry?> GetAuditAsync(string id)
+            => Task.FromResult(_entries.FirstOrDefault(e => e.Id == id));
+
+        public Task<IEnumerable<AuditLogEntry>> GetAuditsByRequestAsync(string requestId)
+            => Task.FromResult<IEnumerable<AuditLogEntry>>(_entries.Where(e => e.RequestId == requestId).ToList());
+
+        public Task<IEnumerable<AuditLogEntry>> GetAuditsByUserAsync(string userId)
+            => Task.FromResult<IEnumerable<AuditLogEntry>>(_entries.Where(e => e.UserId == userId).ToList());
+
+        public Task<IEnumerable<AuditLogEntry>> GetAuditsByTenantAsync(string tenantId)
+            => Task.FromResult<IEnumerable<AuditLogEntry>>(_entries.Where(e => e.TenantId == tenantId).ToList());
+
+        public Task<IEnumerable<AuditLogEntry>> GetComplianceReportAsync(DateTime from, DateTime to)
+            => Task.FromResult<IEnumerable<AuditLogEntry>>(
+                _entries.Where(e => e.Timestamp >= from && e.Timestamp <= to).ToList());
+    }
+}


### PR DESCRIPTION
## Summary

The default implementations of `IAuditReader.GetAuditsByUserAsync(string, DateTime?)` and `GetAuditsByTenantAsync(string, DateTime?)` previously delegated straight to the no-`since` overload, silently returning unfiltered results for any implementer that overrode only the simplest member.

The DIM now post-filters by `Timestamp >= since` (when `since` is non-null) so the documented contract holds for legacy and new implementers alike. Implementers that can push the predicate to the storage layer should still override this overload for efficiency; the DIM is correctness-first, not performance-first.

Fixes #275

## Changes
- `src/QuerySpec.Core/Auditing/IAuditLogger.cs` — DIM bodies for the two `(string, DateTime?)` overloads now `await` the no-`since` overload and apply `Where(e => e.Timestamp >= since.Value)` when `since.HasValue`.
- `tests/QuerySpec.Core.Tests/Auditing/IAuditReaderDefaultImplementationTests.cs` — 4 tests exercising the DIM path against a minimal `IAuditReader` implementation that overrides only the no-`since` members.

## Verification
- 768/768 Core tests pass on net10.
- 4/4 PublicApi snapshot tests pass.
- No public API surface change (DIM body change only).
- No analyzer suppressions.