### PR TITLE
feat(ci): flip ci.yml harden-runner to egress-policy block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,22 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.github.com:443
+          api.nuget.org:443
+          auth.docker.io:443
+          builds.dotnet.microsoft.com:443
+          codeload.github.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          mcr.microsoft.com:443
+          objects.githubusercontent.com:443
+          production.cloudflare.docker.com:443
+          registry-1.docker.io:443
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -346,9 +359,16 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -401,9 +421,19 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.github.com:443
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          codeload.github.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          objects.githubusercontent.com:443
+          uploads.github.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -508,9 +538,13 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.github.com:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -551,9 +585,16 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -624,9 +665,14 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          github.com:443
+          nodejs.org:443
+          objects.githubusercontent.com:443
+          registry.npmjs.org:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
@@ -687,9 +733,16 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -807,9 +860,12 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
@@ -855,9 +911,16 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -936,9 +999,16 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.nuget.org:443
+          builds.dotnet.microsoft.com:443
+          dotnetbuilds.azureedge.net:443
+          dotnetcli.azureedge.net:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Record start time
       run: echo "STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
@@ -1058,9 +1128,13 @@ jobs:
     - name: Harden runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40  # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
         disable-sudo: true
         disable-file-monitoring: false
+        allowed-endpoints: >
+          api.github.com:443
+          github.com:443
+          objects.githubusercontent.com:443
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Download all per-gate evidence


### PR DESCRIPTION
## Summary

Phase 2 of #164's harden-runner rollout, scoped to `ci.yml` only per the phased plan documented in #216. Curates a per-job allowlist for each of the 11 jobs in `ci.yml` and flips `egress-policy` from `audit` to `block`. `mutation.yml` and `release.yml` remain in audit mode and ratchet in subsequent PRs once a full week of green CI runs has confirmed the `ci.yml` allowlist.

Refs #216 (issue stays open until all three workflows are in block mode).

## Per-job allowlists

Endpoints are scoped narrowly per the principle of least authority — narrower per job is better than one shared list. Common endpoints (`github.com`, `objects.githubusercontent.com`) appear everywhere; everything else is gated by what the job actually does.

| Job | Endpoints |
|---|---|
| `build` | github + api.nuget.org + dotnet SDK CDNs + mcr.microsoft.com + Docker Hub (auth.docker.io, registry-1.docker.io, production.cloudflare.docker.com) for Testcontainers postgres/mssql pulls |
| `format` | github + api.nuget.org + dotnet SDK CDNs |
| `codeql` | github + api.nuget.org + dotnet SDK CDNs + `codeload.github.com` (CodeQL bundle) + `uploads.github.com` (SARIF) + `api.github.com` (alert count read) |
| `dependency-review` | github + `api.github.com` only |
| `vulnerability-scan` | github + api.nuget.org + dotnet SDK CDNs |
| `commitlint` | github + `nodejs.org` (setup-node) + `registry.npmjs.org` |
| `reproducibility` | github + api.nuget.org + dotnet SDK CDNs |
| `no-suppression` | github only |
| `sample-build` | github + api.nuget.org + dotnet SDK CDNs |
| `trim-smoke` | github + api.nuget.org + dotnet SDK CDNs |
| `aggregate-evidence` | github + `api.github.com` (artifact download) |

## Risk and verification

The single failure mode is over-pruning the allowlist: a missing endpoint causes the job to fail at the first egress attempt to that host. Mitigation is the phased rollout itself — `ci.yml` runs on every push and PR so any miss surfaces in the first run, and the fix is one allowlist line.

After this PR merges, the harden-runner job summary on each subsequent CI run should report zero blocked egress events on healthy runs. Any blocked event indicates either an incomplete allowlist or an action reaching out to an unexpected endpoint, both of which warrant investigation before adding to the list.

## Scope (out of scope)

- `mutation.yml` — flips next, after one week of green `ci.yml` runs.
- `release.yml` — flips last; failure there blocks shipping, so it ratchets only after both other workflows are stable.
- Issue #216 stays open until all three workflows are in block mode.

## Test plan

- [ ] Push triggers full CI matrix; every job's harden-runner summary shows zero blocked events
- [ ] Pull-request triggers `dependency-review` and `no-suppression` (PR-only jobs); both pass with the allowlists above
- [ ] No CI step fails with a `Disallowed endpoint` error from harden-runner